### PR TITLE
fix(core): Clean up resources after failed initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Fix initialization tracking for some cases of array textures, 3d textures, and depth/stencil textures with divergent usage in a render pass. By @andyleiserson in [#10002](https://github.com/gfx-rs/wgpu/pull/10002) and [#10060](https://github.com/gfx-rs/wgpu/pull/10060).
 - Fixed a deadlock between `Queue::compact_blas` and `Queue::submit`, which acquired `Device::command_indices` and `Queue::pending_writes` in opposite orders. By @mstampfli in [#10118](https://github.com/gfx-rs/wgpu/pull/10118).
 - Fixed some cases of passing object labels to platform APIs despite `InstanceFlags::DISCARD_HAL_LABELS` being set. By @andyleiserson in [#10121](https://github.com/gfx-rs/wgpu/pull/10121) and [#10123](https://github.com/gfx-rs/wgpu/pull/10123).
+- Clean up resources properly when `Device::new` fails, to avoid a leak or panic. By @andyleiserson in [#10160](https://github.com/gfx-rs/wgpu/pull/10160).
 
 #### naga
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,6 +4807,7 @@ dependencies = [
  "raw-window-handle",
  "ron",
  "rustc-hash 1.1.0",
+ "scopeguard",
  "serde",
  "smallvec",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,7 @@ ron = "0.12"
 # see discussion here (including with some other alternatives): https://github.com/gfx-rs/wgpu/issues/6999
 # (using default-features = false to support no-std build, avoiding any extra features that may require std::collections)
 rustc-hash = { version = "1.1", default-features = false }
+scopeguard = { version = "1.2", default-features = false }
 serde_json = "1.0.143"
 serde = { version = "1.0.225", default-features = false }
 shell-words = "1"

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -204,6 +204,7 @@ profiling = { workspace = true, default-features = false }
 raw-window-handle.workspace = true
 ron = { workspace = true, optional = true }
 rustc-hash.workspace = true
+scopeguard.workspace = true
 serde = { workspace = true, features = ["derive"], default-features = false, optional = true }
 smallvec.workspace = true
 thiserror.workspace = true

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -14,6 +14,7 @@ use hal::ShouldBeNonZeroExt;
 
 use arrayvec::ArrayVec;
 use bitflags::Flags;
+use scopeguard::{guard, ScopeGuard};
 use smallvec::SmallVec;
 use wgpu_sync::atomic::{AtomicBool, Ordering};
 use wgpu_sync::OnceCell;
@@ -220,22 +221,6 @@ impl DeferredBufferMapPendingClosures {
     }
 }
 
-/// Resources associated with a device.
-///
-/// This struct exists so that resources can be cleaned up properly on error returns
-/// from [`Device::new`].
-///
-/// [`Device::timestamp_normalizer`] is late-initialized after [`Device::new`], so it is not
-/// included here.
-struct DeviceResources<'a> {
-    raw: &'a dyn hal::DynDevice,
-    zero_buffer: Option<Box<dyn hal::DynBuffer>>,
-    empty_bgl: Option<Box<dyn hal::DynBindGroupLayout>>,
-    default_external_texture_params_buffer: Option<Box<dyn hal::DynBuffer>>,
-    fence: Option<Box<dyn hal::DynFence>>,
-    indirect_validation: Option<crate::indirect_validation::IndirectValidation>,
-}
-
 /// Structure describing a logical device. Some members are internally mutable,
 /// stored behind mutexes.
 pub struct Device {
@@ -338,45 +323,12 @@ impl fmt::Debug for Device {
     }
 }
 
-impl Drop for DeviceResources<'_> {
-    fn drop(&mut self) {
-        if let Some(indirect_validation) = self.indirect_validation.take() {
-            indirect_validation.dispose(self.raw);
-        }
-        unsafe {
-            if let Some(zero_buffer) = self.zero_buffer.take() {
-                self.raw.destroy_buffer(zero_buffer);
-            }
-            if let Some(empty_bgl) = self.empty_bgl.take() {
-                self.raw.destroy_bind_group_layout(empty_bgl);
-            }
-            if let Some(default_external_texture_params_buffer) =
-                self.default_external_texture_params_buffer.take()
-            {
-                self.raw
-                    .destroy_buffer(default_external_texture_params_buffer);
-            }
-            if let Some(fence) = self.fence.take() {
-                self.raw.destroy_fence(fence);
-            }
-        }
-    }
-}
-
 impl Drop for Device {
     #[allow(trivial_casts)]
     fn drop(&mut self) {
         profiling::scope!("Device::drop");
         api_log!("Device::drop {:?}", self as *const _);
         resource_log!("Drop {}", self.error_ident());
-
-        // The timestamp normalizer is late-initialized, so it is not included in `DeviceResources`.
-        if let Some(timestamp_normalizer) = self.timestamp_normalizer.take() {
-            timestamp_normalizer.dispose(self.raw.as_ref());
-        }
-
-        // Transfer the rest of the resources back to `DeviceResources`, which cleans them
-        // up for us.
 
         // SAFETY: We are in the Drop impl and we don't use self.zero_buffer anymore after this
         // point.
@@ -389,15 +341,19 @@ impl Drop for Device {
             unsafe { ManuallyDrop::take(&mut self.default_external_texture_params_buffer) };
         // SAFETY: We are in the Drop impl and we don't use self.fence anymore after this point.
         let fence = unsafe { ManuallyDrop::take(&mut self.fence) };
-
-        drop(DeviceResources {
-            raw: self.raw.as_ref(),
-            zero_buffer: Some(zero_buffer),
-            empty_bgl: Some(empty_bgl),
-            default_external_texture_params_buffer: Some(default_external_texture_params_buffer),
-            fence: Some(fence),
-            indirect_validation: self.indirect_validation.take(),
-        });
+        if let Some(indirect_validation) = self.indirect_validation.take() {
+            indirect_validation.dispose(self.raw.as_ref());
+        }
+        if let Some(timestamp_normalizer) = self.timestamp_normalizer.take() {
+            timestamp_normalizer.dispose(self.raw.as_ref());
+        }
+        unsafe {
+            self.raw.destroy_buffer(zero_buffer);
+            self.raw.destroy_bind_group_layout(empty_bgl);
+            self.raw
+                .destroy_buffer(default_external_texture_params_buffer);
+            self.raw.destroy_fence(fence);
+        }
     }
 }
 
@@ -533,17 +489,13 @@ impl Device {
         let ordered_buffer_usages = adapter.raw.adapter.get_ordered_buffer_usages();
         let ordered_texture_usages = adapter.raw.adapter.get_ordered_texture_usages();
 
-        let mut resources = DeviceResources {
-            raw: raw_device.as_ref(),
-            zero_buffer: None,
-            empty_bgl: None,
-            default_external_texture_params_buffer: None,
-            fence: None,
-            indirect_validation: None,
-        };
+        // Resources requiring explicit destruction ahead of the device are wrapped in
+        // `ScopeGuard`s, which are defused just before the `Device` takes ownership of the
+        // resources.
+        let raw = raw_device.as_ref();
 
-        resources.fence =
-            Some(unsafe { raw_device.create_fence() }.map_err(DeviceError::from_hal)?);
+        let fence = unsafe { raw_device.create_fence() }.map_err(DeviceError::from_hal)?;
+        let fence = guard(fence, |fence| unsafe { raw.destroy_fence(fence) });
 
         let command_allocator = command::CommandAllocator::new();
 
@@ -557,43 +509,45 @@ impl Device {
         };
 
         // Create zeroed buffer used for texture clears (and raytracing if required).
-        resources.zero_buffer = Some(
-            unsafe {
-                raw_device.create_buffer(&hal::BufferDescriptor {
-                    label: hal_label(Some("(wgpu internal) zero init buffer"), instance_flags),
-                    size: ZERO_BUFFER_SIZE,
-                    usage: wgt::BufferUses::COPY_SRC | wgt::BufferUses::COPY_DST | rt_uses,
-                    memory_flags: hal::MemoryFlags::empty(),
-                })
-            }
-            .map_err(DeviceError::from_hal)?,
-        );
+        let zero_buffer = unsafe {
+            raw_device.create_buffer(&hal::BufferDescriptor {
+                label: hal_label(Some("(wgpu internal) zero init buffer"), instance_flags),
+                size: ZERO_BUFFER_SIZE,
+                usage: wgt::BufferUses::COPY_SRC | wgt::BufferUses::COPY_DST | rt_uses,
+                memory_flags: hal::MemoryFlags::empty(),
+            })
+        }
+        .map_err(DeviceError::from_hal)?;
+        let zero_buffer = guard(zero_buffer, |buffer| unsafe { raw.destroy_buffer(buffer) });
 
-        resources.empty_bgl = Some(
-            unsafe {
-                raw_device.create_bind_group_layout(&hal::BindGroupLayoutDescriptor {
-                    label: None,
-                    flags: hal::BindGroupLayoutFlags::empty(),
-                    entries: &[],
-                })
-            }
-            .map_err(DeviceError::from_hal)?,
-        );
+        let empty_bgl = unsafe {
+            raw_device.create_bind_group_layout(&hal::BindGroupLayoutDescriptor {
+                label: None,
+                flags: hal::BindGroupLayoutFlags::empty(),
+                entries: &[],
+            })
+        }
+        .map_err(DeviceError::from_hal)?;
+        let empty_bgl = guard(empty_bgl, |bgl| unsafe {
+            raw.destroy_bind_group_layout(bgl)
+        });
 
-        resources.default_external_texture_params_buffer = Some(
-            unsafe {
-                raw_device.create_buffer(&hal::BufferDescriptor {
-                    label: hal_label(
-                        Some("(wgpu internal) default external texture params buffer"),
-                        instance_flags,
-                    ),
-                    size: size_of::<ExternalTextureParams>() as _,
-                    usage: wgt::BufferUses::COPY_DST | wgt::BufferUses::UNIFORM,
-                    memory_flags: hal::MemoryFlags::empty(),
-                })
-            }
-            .map_err(DeviceError::from_hal)?,
-        );
+        let default_external_texture_params_buffer = unsafe {
+            raw_device.create_buffer(&hal::BufferDescriptor {
+                label: hal_label(
+                    Some("(wgpu internal) default external texture params buffer"),
+                    instance_flags,
+                ),
+                size: size_of::<ExternalTextureParams>() as _,
+                usage: wgt::BufferUses::COPY_DST | wgt::BufferUses::UNIFORM,
+                memory_flags: hal::MemoryFlags::empty(),
+            })
+        }
+        .map_err(DeviceError::from_hal)?;
+        let default_external_texture_params_buffer =
+            guard(default_external_texture_params_buffer, |buffer| unsafe {
+                raw.destroy_buffer(buffer)
+            });
 
         // Cloned as we need them below anyway.
         let alignments = adapter.raw.capabilities.alignments.clone();
@@ -607,29 +561,30 @@ impl Device {
             )
             && limits.max_storage_buffers_per_shader_stage >= 2;
 
-        if enable_indirect_validation {
-            resources.indirect_validation =
-                Some(crate::indirect_validation::IndirectValidation::new(
-                    raw_device.as_ref(),
-                    &desc.required_limits,
-                    &desc.required_features,
-                    instance_flags,
-                    adapter.backend(),
-                )?);
-        }
+        let indirect_validation = if enable_indirect_validation {
+            let indirect_validation = crate::indirect_validation::IndirectValidation::new(
+                raw,
+                &desc.required_limits,
+                &desc.required_features,
+                instance_flags,
+                adapter.backend(),
+            )?;
+            Some(guard(indirect_validation, |indirect_validation| {
+                indirect_validation.dispose(raw)
+            }))
+        } else {
+            None
+        };
 
-        // Error returns after this point could bypass resource cleanup.
+        // Error returns after we start consuming guards could bypass resource cleanup.
         #[deny(clippy::question_mark_used)]
         {
-            let zero_buffer = resources.zero_buffer.take().unwrap();
-            let empty_bgl = resources.empty_bgl.take().unwrap();
-            let default_external_texture_params_buffer = resources
-                .default_external_texture_params_buffer
-                .take()
-                .unwrap();
-            let fence = resources.fence.take().unwrap();
-            let indirect_validation = resources.indirect_validation.take();
-            drop(resources);
+            let zero_buffer = ScopeGuard::into_inner(zero_buffer);
+            let empty_bgl = ScopeGuard::into_inner(empty_bgl);
+            let default_external_texture_params_buffer =
+                ScopeGuard::into_inner(default_external_texture_params_buffer);
+            let fence = ScopeGuard::into_inner(fence);
+            let indirect_validation = indirect_validation.map(ScopeGuard::into_inner);
 
             Ok(Self {
                 raw: raw_device,

--- a/wgpu-core/src/indirect_validation/dispatch.rs
+++ b/wgpu-core/src/indirect_validation/dispatch.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use alloc::{boxed::Box, format, string::ToString as _};
 use core::num::NonZeroU64;
+use scopeguard::{guard, ScopeGuard};
 
 /// This machinery requires the following limits:
 ///
@@ -129,6 +130,9 @@ impl Dispatch {
                     }
                 }
             })?;
+        let module = guard(module, |module| unsafe {
+            device.destroy_shader_module(module)
+        });
 
         let dst_bind_group_layout_desc = hal::BindGroupLayoutDescriptor {
             label: hal_label(
@@ -152,6 +156,9 @@ impl Dispatch {
                 .create_bind_group_layout(&dst_bind_group_layout_desc)
                 .map_err(DeviceError::from_hal)?
         };
+        let dst_bind_group_layout = guard(dst_bind_group_layout, |bgl| unsafe {
+            device.destroy_bind_group_layout(bgl)
+        });
 
         let src_bind_group_layout_desc = hal::BindGroupLayoutDescriptor {
             label: hal_label(
@@ -175,6 +182,9 @@ impl Dispatch {
                 .create_bind_group_layout(&src_bind_group_layout_desc)
                 .map_err(DeviceError::from_hal)?
         };
+        let src_bind_group_layout = guard(src_bind_group_layout, |bgl| unsafe {
+            device.destroy_bind_group_layout(bgl)
+        });
 
         let pipeline_layout_desc = hal::PipelineLayoutDescriptor {
             label: hal_label(
@@ -193,6 +203,9 @@ impl Dispatch {
                 .create_pipeline_layout(&pipeline_layout_desc)
                 .map_err(DeviceError::from_hal)?
         };
+        let pipeline_layout = guard(pipeline_layout, |pipeline_layout| unsafe {
+            device.destroy_pipeline_layout(pipeline_layout)
+        });
 
         let pipeline_desc = hal::ComputePipelineDescriptor {
             label: hal_label(
@@ -223,6 +236,9 @@ impl Dispatch {
                     CreateComputePipelineError::PipelineConstants(error)
                 }
             })?;
+        let pipeline = guard(pipeline, |pipeline| unsafe {
+            device.destroy_compute_pipeline(pipeline)
+        });
 
         let dst_buffer_desc = hal::BufferDescriptor {
             label: hal_label(
@@ -235,6 +251,9 @@ impl Dispatch {
         };
         let dst_buffer =
             unsafe { device.create_buffer(&dst_buffer_desc) }.map_err(DeviceError::from_hal)?;
+        let dst_buffer = guard(dst_buffer, |buffer| unsafe {
+            device.destroy_buffer(buffer)
+        });
 
         let dst_bind_group_desc = hal::BindGroupDescriptor {
             label: hal_label(
@@ -264,13 +283,15 @@ impl Dispatch {
                 .map_err(DeviceError::from_hal)
         }?;
 
+        // Error returns after we start consuming guards could bypass resource cleanup.
+        #[deny(clippy::question_mark_used)]
         Ok(Self {
-            module,
-            dst_bind_group_layout,
-            src_bind_group_layout,
-            pipeline_layout,
-            pipeline,
-            dst_buffer,
+            module: ScopeGuard::into_inner(module),
+            dst_bind_group_layout: ScopeGuard::into_inner(dst_bind_group_layout),
+            src_bind_group_layout: ScopeGuard::into_inner(src_bind_group_layout),
+            pipeline_layout: ScopeGuard::into_inner(pipeline_layout),
+            pipeline: ScopeGuard::into_inner(pipeline),
+            dst_buffer: ScopeGuard::into_inner(dst_buffer),
             dst_bind_group,
         })
     }

--- a/wgpu-core/src/indirect_validation/draw.rs
+++ b/wgpu-core/src/indirect_validation/draw.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use alloc::{boxed::Box, string::ToString, sync::Arc, vec, vec::Vec};
 use core::{mem::size_of, num::NonZeroU64};
+use scopeguard::{guard, ScopeGuard};
 use wgt::Limits;
 
 /// Note: This needs to be under:
@@ -72,6 +73,9 @@ impl Draw {
         assert!(limits.max_buffer_size <= u32::MAX as u64);
 
         let module = create_validation_module(device, instance_flags)?;
+        let module = guard(module, |module| unsafe {
+            device.destroy_shader_module(module)
+        });
 
         let metadata_bind_group_layout = create_bind_group_layout(
             device,
@@ -83,6 +87,10 @@ impl Draw {
                 instance_flags,
             ),
         )?;
+        let metadata_bind_group_layout = guard(metadata_bind_group_layout, |bgl| unsafe {
+            device.destroy_bind_group_layout(bgl)
+        });
+
         let src_bind_group_layout = create_bind_group_layout(
             device,
             true,
@@ -93,6 +101,10 @@ impl Draw {
                 instance_flags,
             ),
         )?;
+        let src_bind_group_layout = guard(src_bind_group_layout, |bgl| unsafe {
+            device.destroy_bind_group_layout(bgl)
+        });
+
         let dst_bind_group_layout = create_bind_group_layout(
             device,
             false,
@@ -103,6 +115,9 @@ impl Draw {
                 instance_flags,
             ),
         )?;
+        let dst_bind_group_layout = guard(dst_bind_group_layout, |bgl| unsafe {
+            device.destroy_bind_group_layout(bgl)
+        });
 
         let pipeline_layout_desc = hal::PipelineLayoutDescriptor {
             label: hal_label(
@@ -122,6 +137,9 @@ impl Draw {
                 .create_pipeline_layout(&pipeline_layout_desc)
                 .map_err(DeviceError::from_hal)?
         };
+        let pipeline_layout = guard(pipeline_layout, |pipeline_layout| unsafe {
+            device.destroy_pipeline_layout(pipeline_layout)
+        });
 
         let supports_indirect_first_instance =
             required_features.contains(wgt::Features::INDIRECT_FIRST_INSTANCE);
@@ -134,14 +152,19 @@ impl Draw {
             write_d3d12_special_constants,
             instance_flags,
         )?;
+        let pipeline = guard(pipeline, |pipeline| unsafe {
+            device.destroy_compute_pipeline(pipeline)
+        });
 
+        // Error returns after we start consuming guards could bypass resource cleanup.
+        #[deny(clippy::question_mark_used)]
         Ok(Self {
-            module,
-            metadata_bind_group_layout,
-            src_bind_group_layout,
-            dst_bind_group_layout,
-            pipeline_layout,
-            pipeline,
+            module: ScopeGuard::into_inner(module),
+            metadata_bind_group_layout: ScopeGuard::into_inner(metadata_bind_group_layout),
+            src_bind_group_layout: ScopeGuard::into_inner(src_bind_group_layout),
+            dst_bind_group_layout: ScopeGuard::into_inner(dst_bind_group_layout),
+            pipeline_layout: ScopeGuard::into_inner(pipeline_layout),
+            pipeline: ScopeGuard::into_inner(pipeline),
 
             free_indirect_entries: Mutex::new(rank::BUFFER_POOL, Vec::new()),
             free_metadata_entries: Mutex::new(rank::BUFFER_POOL, Vec::new()),

--- a/wgpu-core/src/indirect_validation/mod.rs
+++ b/wgpu-core/src/indirect_validation/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     pipeline::{CreateComputePipelineError, CreateShaderModuleError},
 };
 use alloc::boxed::Box;
+use scopeguard::{guard, ScopeGuard};
 use thiserror::Error;
 
 mod dispatch;
@@ -43,6 +44,8 @@ impl IndirectValidation {
                 return Err(DeviceError::Lost);
             }
         };
+        let dispatch = guard(dispatch, |dispatch| dispatch.dispose(device));
+
         let draw = match Draw::new(
             device,
             required_features,
@@ -56,7 +59,10 @@ impl IndirectValidation {
                 return Err(DeviceError::Lost);
             }
         };
-        Ok(Self { dispatch, draw })
+        Ok(Self {
+            dispatch: ScopeGuard::into_inner(dispatch),
+            draw,
+        })
     }
 
     pub(crate) fn dispose(self, device: &dyn hal::DynDevice) {


### PR DESCRIPTION
Revises the fix for `Device::new` in #9930 to use [`scopeguard`](https://docs.rs/scopeguard/latest/scopeguard/), and extends it to `indirect_validation::Draw::new` and `indirect_validation::dispatch::new`.

I also had Claude look for similar issues and there are a bunch more, listed in #10159.

**Testing**
Untested

**Squash or Rebase?** Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
