### PR TITLE
Implement `Send` for `WriteOnly<T>` even when `T` is not `Sized`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Many types now offer `pub const fn default()` in addition to implementing the `Default` trait, allowing constants to make use of default values. By @kpreid in [#9929](https://github.com/gfx-rs/wgpu/pull/9929).
 - `wgpu-core` now exposes `validate_device_descriptor` and `validate_texture_descriptor` functions that perform the same descriptor validation the corresponding resource creation APIs would, without actually creating a resource. This may be useful in conjunction with hal raw APIs. By @andyleiserson in [#9967](https://github.com/gfx-rs/wgpu/pull/9967) and [#9979](https://github.com/gfx-rs/wgpu/pull/9979).
 - Added `TextureDescriptor::theoretical_memory_footprint` to estimate memory footprint of a texture. By @sagudev in [#10032](https://github.com/gfx-rs/wgpu/pull/10032).
+- `wgpu::WriteOnly<[_]>` now implements `Send`. By @kpreid in [#10163](https://github.com/gfx-rs/wgpu/pull/10163).
 
 #### Hal
 

--- a/wgpu-types/src/write_only.rs
+++ b/wgpu-types/src/write_only.rs
@@ -65,10 +65,11 @@ pub struct WriteOnly<'a, T: ?Sized> {
 // `WriteOnly<T>` is like `&mut T` in that
 // * It provides only exclusive access to the memory it points to, so `T: Sync` is not required.
 // * Sending it creates the opportunity to send a `T`, so `T: Send` is required.
-unsafe impl<T: Send> Send for WriteOnly<'_, T> {}
+unsafe impl<T: ?Sized + Send> Send for WriteOnly<'_, T> {}
 
 // SAFETY:
-// `WriteOnly<T>` does not ever expose any `&T`, and therefore may unconditionally implement `Sync`.
+// `WriteOnly<T>` does not offer interior mutability itself, and does not ever expose any `&T`,
+// so there is no possibility of unsynchronized access for `!Sync` to protect against.
 unsafe impl<T: ?Sized> Sync for WriteOnly<'_, T> {}
 
 impl<'a, T: ?Sized> WriteOnly<'a, T> {
@@ -855,6 +856,10 @@ mod tests {
         }
     }
 
+    // Check trait impls, particularly for a `!Sized` pointee type.
+    static_assertions::assert_not_impl_any!(WriteOnly<'static, [u8]>: Clone, Copy);
+    static_assertions::assert_impl_all!(WriteOnly<'static, [u8]>: Send, Sync);
+
     #[test]
     fn debug() {
         let mut arr = [1u8, 2, 3];
@@ -869,6 +874,13 @@ mod tests {
         assert_eq!(
             format!("{:#?}", WriteOnly::from_mut(&mut arr[0])),
             "WriteOnly(u8)"
+        );
+
+        struct NotImplDebug;
+        let mut not = NotImplDebug;
+        assert_eq!(
+            format!("{:#?}", WriteOnly::from_mut(&mut not)),
+            "WriteOnly(wgpu_types::write_only::tests::debug::NotImplDebug)"
         );
     }
 


### PR DESCRIPTION
**Connections**
Fixes #10156.

**Description**

Added the missing `?Sized` bound so that `WriteOnly<'_, [T]>` will implement `Send`.

Also added some tests of other traits, and expanded the safety comment for `Sync`.

**Testing**
`cargo xtask test`

**Squash or Rebase?**
One commit

**Checklist**

- [X] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [X] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
