### PR TITLE
Move erroring of create_compute_pipeline into core

### DIFF
--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -475,9 +475,14 @@ impl GPUDevice {
     &self,
     #[webidl] descriptor: super::compute_pipeline::GPUComputePipelineDescriptor,
   ) -> GPUComputePipeline {
-    let (pipeline, err) = self.new_compute_pipeline(descriptor);
-    self.error_handler.push_error(err);
-    pipeline
+    let label = descriptor.label.clone();
+    let wgpu_descriptor = transform_compute_pipeline_descriptor(descriptor);
+    let wgpu_compute_pipeline =
+      self.wgpu_device.create_compute_pipeline(wgpu_descriptor);
+    GPUComputePipeline {
+      wgpu_compute_pipeline,
+      label,
+    }
   }
 
   #[required(1)]
@@ -503,18 +508,30 @@ impl GPUDevice {
     let resolver = v8::PromiseResolver::new(scope).unwrap();
     let promise = resolver.get_promise(scope);
 
-    let (pipeline, err) = self.new_compute_pipeline(descriptor);
-    if let Some(err) = err {
-      let err = make_pipeline_error(
-        scope,
-        GPUPipelineErrorReason::Validation,
-        &fmt_err(&err),
-      );
-      resolver.reject(scope, err.into());
-    } else {
-      let val = make_cppgc_object(scope, pipeline).into();
-      resolver.resolve(scope, val);
+    let label = descriptor.label.clone();
+    let wgpu_descriptor = transform_compute_pipeline_descriptor(descriptor);
+    match self
+      .wgpu_device
+      .create_compute_pipeline_or_error(wgpu_descriptor)
+    {
+      Ok(wgpu_compute_pipeline) => {
+        let pipeline = GPUComputePipeline {
+          wgpu_compute_pipeline,
+          label,
+        };
+        let val = make_cppgc_object(scope, pipeline).into();
+        resolver.resolve(scope, val);
+      }
+      Err(err) => {
+        let err = make_pipeline_error(
+          scope,
+          GPUPipelineErrorReason::Validation,
+          &fmt_err(&err),
+        );
+        resolver.reject(scope, err.into());
+      }
     }
+
     v8::Global::new(scope, promise)
   }
 
@@ -720,38 +737,23 @@ impl GPUDevice {
   }
 }
 
-impl GPUDevice {
-  fn new_compute_pipeline(
-    &self,
-    descriptor: super::compute_pipeline::GPUComputePipelineDescriptor,
-  ) -> (
-    GPUComputePipeline,
-    Option<wgpu_core::pipeline::CreateComputePipelineError>,
-  ) {
-    let wgpu_descriptor = wgpu_core::pipeline::ComputePipelineDescriptor {
-      label: crate::transform_label(descriptor.label.clone()),
-      layout: descriptor.layout.into(),
-      stage: ProgrammableStageDescriptor {
-        module: descriptor.compute.module.wgpu_shader_module.clone(),
-        entry_point: descriptor.compute.entry_point.map(Into::into),
-        constants: descriptor.compute.constants.into_iter().collect(),
-        zero_initialize_workgroup_memory: true,
-      },
-      cache: None,
-    };
-
-    let (wgpu_compute_pipeline, err) =
-      self.wgpu_device.create_compute_pipeline(wgpu_descriptor);
-
-    (
-      GPUComputePipeline {
-        wgpu_compute_pipeline,
-        label: descriptor.label.clone(),
-      },
-      err,
-    )
+fn transform_compute_pipeline_descriptor(
+  descriptor: super::compute_pipeline::GPUComputePipelineDescriptor,
+) -> wgpu_core::pipeline::ComputePipelineDescriptor<'static> {
+  wgpu_core::pipeline::ComputePipelineDescriptor {
+    label: crate::transform_label(descriptor.label.clone()),
+    layout: descriptor.layout.into(),
+    stage: ProgrammableStageDescriptor {
+      module: descriptor.compute.module.wgpu_shader_module.clone(),
+      entry_point: descriptor.compute.entry_point.map(Into::into),
+      constants: descriptor.compute.constants.into_iter().collect(),
+      zero_initialize_workgroup_memory: true,
+    },
+    cache: None,
   }
+}
 
+impl GPUDevice {
   fn new_render_pipeline(
     &self,
     descriptor: super::render_pipeline::GPURenderPipelineDescriptor,

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -319,7 +319,7 @@ impl Player {
             }
             Action::CreateComputePipeline { id, desc } => {
                 let resolved_desc = self.resolve_compute_pipeline_descriptor(desc);
-                let (pipeline, _error) = device.create_compute_pipeline(resolved_desc);
+                let pipeline = device.create_compute_pipeline(resolved_desc);
                 self.compute_pipelines.insert(id, pipeline);
             }
             Action::DropComputePipeline(id) => {

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -880,9 +880,6 @@ impl Global {
         device_id: DeviceId,
         desc: &ComputePipelineDescriptor,
         id_in: id::ComputePipelineId,
-    ) -> (
-        id::ComputePipelineId,
-        Option<pipeline::CreateComputePipelineError>,
     ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
@@ -916,11 +913,61 @@ impl Global {
             cache,
         };
 
-        let (pipeline, error) = device.create_compute_pipeline(desc);
+        let pipeline = device.create_compute_pipeline(desc);
 
-        let id = compute_pipelines.assign(id_in, pipeline);
+        compute_pipelines.assign(id_in, pipeline);
+    }
 
-        (id, error)
+    /// Error-returning version of `device_create_compute_pipeline` to implement
+    /// [GPUDevice.createComputePipelineAsync](https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcomputepipelineasync).
+    /// Returns an error if the pipeline creation fails instead of handling error in device.
+    ///
+    /// Id is assigned to the pipeline only if the creation succeeds.
+    pub fn device_create_compute_pipeline_or_error(
+        &self,
+        device_id: DeviceId,
+        desc: &ComputePipelineDescriptor,
+        id_in: id::ComputePipelineId,
+    ) -> Result<(), pipeline::CreateComputePipelineError> {
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            compute_pipelines,
+            devices,
+            shader_modules,
+            pipeline_layouts,
+            pipeline_caches,
+            ..
+        } = &mut *hub;
+
+        let device = devices.get(device_id);
+
+        let layout = desc.layout.map(|layout| pipeline_layouts.get(layout));
+
+        let cache = desc.cache.map(|cache| pipeline_caches.get(cache));
+
+        let module = shader_modules.get(desc.stage.module);
+
+        let stage = ProgrammableStageDescriptor {
+            module,
+            entry_point: desc.stage.entry_point.clone(),
+            constants: desc.stage.constants.clone(),
+            zero_initialize_workgroup_memory: desc.stage.zero_initialize_workgroup_memory,
+        };
+
+        let desc = pipeline::ComputePipelineDescriptor {
+            label: desc.label.clone(),
+            layout,
+            stage,
+            cache,
+        };
+
+        match device.create_compute_pipeline_or_error(desc) {
+            Ok(pipeline) => {
+                compute_pipelines.assign(id_in, pipeline);
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Get an ID of one of the bind group layouts. The ID adds a refcount,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4319,21 +4319,26 @@ impl Device {
         Ok(layout)
     }
 
+    /// Creates a compute pipeline. If the creation fails,
+    /// it will handle error in device and return an invalid compute pipeline.
+    ///
+    /// Corresponds to [GPUDevice.createComputePipeline](https://www.w3.org/TR/webgpu/#dom-gpudevice-createcomputepipeline)
     pub fn create_compute_pipeline(
         self: &Arc<Self>,
         desc: pipeline::ComputePipelineDescriptor,
-    ) -> (
-        Arc<pipeline::ComputePipeline>,
-        Option<pipeline::CreateComputePipelineError>,
-    ) {
+    ) -> Arc<pipeline::ComputePipeline> {
         profiling::scope!("Device::create_compute_pipeline");
-        let (compute_pipeline, error) = match self.create_compute_pipeline_inner(desc.clone()) {
-            Ok(compute_pipeline) => (compute_pipeline, None),
-            Err(error) => (
-                pipeline::ComputePipeline::invalid(self.clone(), desc.label.to_string()),
-                Some(error),
-            ),
-        };
+        let compute_pipeline = self
+            .create_compute_pipeline_or_error(desc.clone())
+            .unwrap_or_else(|err| {
+                self.handle_error(
+                    err,
+                    desc.label.as_deref(),
+                    "Device::create_compute_pipeline",
+                );
+
+                pipeline::ComputePipeline::invalid(self.clone(), desc.label.to_string())
+            });
         #[cfg(feature = "trace")]
         if let Some(ref mut trace) = *self.trace.lock() {
             use crate::device::trace;
@@ -4347,10 +4352,13 @@ impl Device {
             "Device::create_compute_pipeline -> {:?}",
             Arc::as_ptr(&compute_pipeline)
         );
-        (compute_pipeline, error)
+        compute_pipeline
     }
 
-    pub fn create_compute_pipeline_inner(
+    /// Creates a compute pipeline without raising any error to device.
+    ///
+    /// Corresponds to [GPUDevice.createComputePipelineAsync](https://www.w3.org/TR/webgpu/#dom-gpudevice-createcomputepipelineasync)
+    pub fn create_compute_pipeline_or_error(
         self: &Arc<Self>,
         desc: pipeline::ComputePipelineDescriptor,
     ) -> Result<Arc<pipeline::ComputePipeline>, pipeline::CreateComputePipelineError> {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1319,19 +1319,7 @@ impl dispatch::DeviceInterface for CoreDevice {
                 .map(|cache| cache.inner.as_core().wgpu_pipeline_cache.clone()),
         };
 
-        let (wgpu_compute_pipeline, error) = self.wgpu_device.create_compute_pipeline(descriptor);
-        if let Some(cause) = error {
-            if let wgc::pipeline::CreateComputePipelineError::Internal(ref error) = cause {
-                log::error!(
-                    "Shader translation error for stage {:?}: {}",
-                    wgt::ShaderStages::COMPUTE,
-                    error
-                );
-                log::error!("Please report it to https://github.com/gfx-rs/wgpu");
-            }
-            self.wgpu_device
-                .handle_error(cause, desc.label, "Device::create_compute_pipeline");
-        }
+        let wgpu_compute_pipeline = self.wgpu_device.create_compute_pipeline(descriptor);
         CoreComputePipeline {
             wgpu_compute_pipeline,
         }


### PR DESCRIPTION
**Connections**
Part of https://github.com/gfx-rs/wgpu/issues/8911
Towards https://github.com/gfx-rs/wgpu/issues/10073

**Description**
This is more tricky as we we still need the erroring variant to implement async version in browsers. Only compute pipeline is done as rendering pipeline needs additional content timeline validation.

**Testing**
Just refactor.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
