### PR TITLE
Move erroring of create_texture and implement missing validation

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -75,6 +75,8 @@ webgpu:api,validation,buffer,destroy:*
 webgpu:api,validation,capability_checks,features,clip_distances:*
 webgpu:api,validation,capability_checks,features,texture_component_swizzle:*
 webgpu:api,validation,capability_checks,features,texture_formats:render_bundle_encoder_descriptor_depth_stencil_format:*
+webgpu:api,validation,capability_checks,features,texture_formats:texture_descriptor_view_formats:*
+webgpu:api,validation,capability_checks,features,texture_formats:texture_descriptor:*
 webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*
 webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:validate,*
 webgpu:api,validation,capability_checks,limits,maxBufferSize:*

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -236,12 +236,18 @@ impl GPUDevice {
         .view_formats
         .into_iter()
         .map(Into::into)
-        .collect(),
+        .collect::<Vec<_>>(),
     };
 
-    let (wgpu_texture, err) = self.wgpu_device.create_texture(&wgpu_descriptor);
+    // 2. ? Validate texture format required features of descriptor.format with this.[[device]].
+    self.validate_texture_format_required_feature(wgpu_descriptor.format)?;
 
-    self.error_handler.push_error(err);
+    // 3. Validate texture format required features of each element of descriptor.viewFormats with this.[[device]].
+    for format in &wgpu_descriptor.view_formats {
+      self.validate_texture_format_required_feature(*format)?;
+    }
+
+    let wgpu_texture = self.wgpu_device.create_texture(&wgpu_descriptor);
 
     Ok(GPUTexture {
       error_handler: self.error_handler.clone(),

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -129,7 +129,7 @@ impl Player {
                 let _ = buffer.unmap();
             }
             Action::CreateTexture(id, desc) => {
-                let (texture, _) = device.create_texture(&desc);
+                let texture = device.create_texture(&desc);
 
                 self.textures.insert(id, texture);
             }

--- a/tests/tests/wgpu_trace.rs
+++ b/tests/tests/wgpu_trace.rs
@@ -199,9 +199,11 @@ fn trace_texture_test() {
         view_formats: Vec::new(),
     };
 
-    let (texture, error) = device.create_texture(&desc);
+    device.push_error_scope(wgpu::ErrorFilter::Validation);
 
-    assert!(error.is_none());
+    let texture = device.create_texture(&desc);
+
+    assert!(device.pop_error_scope().unwrap().is_none());
 
     let texture_error = device.create_texture_error(&desc);
 

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -223,7 +223,7 @@ impl Global {
         device_id: DeviceId,
         desc: &TextureDescriptor,
         id_in: id::TextureId,
-    ) -> (id::TextureId, Option<resource::CreateTextureError>) {
+    ) {
         let mut hub = self.hub.borrow_mut();
 
         let Hub {
@@ -232,11 +232,9 @@ impl Global {
 
         let device = devices.get(device_id);
 
-        let (texture, error) = device.create_texture(desc);
+        let texture = device.create_texture(desc);
 
-        let id = textures.assign(id_in, texture);
-
-        (id, error)
+        textures.assign(id_in, texture);
     }
 
     pub fn device_validate_texture_descriptor(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2015,6 +2015,8 @@ impl Device {
 
         let mut hal_view_formats = Vec::new();
         for format in desc.view_formats.iter() {
+            self.require_features(format.required_features())
+                .map_err(|error| CreateTextureError::MissingFeatures(*format, error))?;
             if desc.format == *format {
                 continue;
             }
@@ -2139,18 +2141,14 @@ impl Device {
         Ok(texture)
     }
 
-    pub fn create_texture(
-        self: &Arc<Self>,
-        desc: &resource::TextureDescriptor,
-    ) -> (Arc<Texture>, Option<resource::CreateTextureError>) {
+    /// <https://www.w3.org/TR/webgpu/#dom-gpudevice-createtexture>
+    pub fn create_texture(self: &Arc<Self>, desc: &resource::TextureDescriptor) -> Arc<Texture> {
         profiling::scope!("Device::create_texture");
-        let (texture, error) = match self.create_texture_inner(desc) {
-            Ok(texture) => (texture, None),
-            Err(e) => {
-                let texture = Texture::invalid(self, desc);
-                (texture, Some(e))
-            }
-        };
+
+        let texture = self.create_texture_inner(desc).unwrap_or_else(|err| {
+            self.handle_error(err, desc.label.as_deref(), "Device::create_texture");
+            Texture::invalid(self, desc)
+        });
         api_log!(
             "Device::create_texture({desc:?}) -> {:?}",
             Arc::as_ptr(&texture)
@@ -2165,7 +2163,7 @@ impl Device {
                 desc.clone(),
             ));
         }
-        (texture, error)
+        texture
     }
 
     /// Creates a texture that is guaranteed to be invalid

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1392,11 +1392,7 @@ impl dispatch::DeviceInterface for CoreDevice {
 
     fn create_texture(&self, desc: &crate::TextureDescriptor<'_>) -> dispatch::DispatchTexture {
         let wgt_desc = desc.map_label_and_view_formats(|l| l.map(Borrowed), |v| v.to_vec());
-        let (wgpu_texture, error) = self.wgpu_device.create_texture(&wgt_desc);
-        if let Some(cause) = error {
-            self.wgpu_device
-                .handle_error(cause, desc.label, "Device::create_texture");
-        }
+        let wgpu_texture = self.wgpu_device.create_texture(&wgt_desc);
 
         CoreTexture {
             context: self.context.clone(),


### PR DESCRIPTION
**Connections**
Part of https://github.com/gfx-rs/wgpu/issues/8911
Towards https://github.com/gfx-rs/wgpu/issues/10073
Continuation of https://github.com/gfx-rs/wgpu/pull/10115, #10179

**Description**
As always we move erroring into wgc. I also added missing content timeline validation in wgc (we did not validate required features of view_formats) and implement this content timeline validation in deno as in #10179.


Just head up: In firefox beta some CTS checks fail so firefox - we get validation instead of TypeError, but it might be fixed on nightly. In deno all stuff passes now (before we got 40% fail).

**Testing**
Covered by CTS tests

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
