### PR TITLE
fix(naga): compile interpolation support with glsl-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,6 +356,9 @@ jobs:
           # If we don't check this then errors inside `profiling::scope!()` will not be caught.
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} --tests --benches --all-features --features test-build-with-profiling
 
+          # Check Naga's GLSL frontend in isolation to catch missing feature/dependency activations.
+          cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p naga --no-default-features --features glsl-in
+
           # Check wgpu-hal with main backends in isolation to catch missing feature/dependencies activations which may be overlooked when they are dragged in via other features.
           # (best effort: in theory we'd need to test all combinations)
           cargo --locked clippy --target ${{ matrix.target }} ${{ matrix.extra-flags }} -p wgpu-hal --no-default-features --features vulkan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ By @sagudev in [#10115](https://github.com/gfx-rs/wgpu/pull/10115).
 
 #### naga
 
+- Fix Naga failing to compile with `glsl-in` as its only enabled feature. By @andrewtdiz in [#10166](https://github.com/gfx-rs/wgpu/pull/10166).
 - Fix panics when shader `var<immediate>` size is larger than 256 bytes. By @beicause in [#9725](https://github.com/gfx-rs/wgpu/pull/9725).
 - Fix a panic in the SPIR-V frontend when a subgroup collective operation (e.g. `OpGroupNonUniformUMin`) or `OpGroupNonUniformBallot` used an argument whose value needed to be spilled to a temporary variable, such as when the argument was computed inside a loop. By @nazar-pc in [#9957](https://github.com/gfx-rs/wgpu/issues/9957).
 

--- a/naga/src/front/mod.rs
+++ b/naga/src/front/mod.rs
@@ -2,7 +2,7 @@
 Frontend parsers that consume binary and text shaders and load them into [`Module`](super::Module)s.
 */
 
-#[cfg(any(feature = "spv-in", feature = "wgsl-in"))]
+#[cfg(any(feature = "glsl-in", feature = "spv-in", feature = "wgsl-in"))]
 pub(crate) mod interpolator;
 mod type_gen;
 


### PR DESCRIPTION
## Description

Naga's GLSL frontend calls `Binding::apply_default_interpolation`, which is implemented in `front::interpolator`. Since #9321, that module has only been enabled by the `spv-in` and `wgsl-in` features, so building Naga with only `glsl-in` fails with E0599.

Include `glsl-in` in the module's feature gate and check that frontend configuration independently in CI.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --locked -p naga --no-default-features --features glsl-in`
- `cargo clippy --locked -p naga --no-default-features --features glsl-in -- -D warnings`
- `cargo clippy --tests -- -D warnings`