### PR TITLE
Remove CoreContext from Core*

### DIFF
--- a/wgpu/src/api/adapter.rs
+++ b/wgpu/src/api/adapter.rs
@@ -80,11 +80,7 @@ impl Adapter {
         desc: &DeviceDescriptor<'_>,
     ) -> Result<(Device, Queue), RequestDeviceError> {
         let core_adapter = self.inner.as_core();
-        let (device, queue) = unsafe {
-            core_adapter
-                .context
-                .create_device_from_hal(core_adapter, hal_device, desc)
-        }?;
+        let (device, queue) = unsafe { core_adapter.create_device_from_hal(hal_device, desc) }?;
 
         Ok((
             Device {
@@ -133,7 +129,7 @@ impl Adapter {
     ) -> Option<impl Deref<Target = A::Adapter> + WasmNotSendSync> {
         let adapter = self.inner.as_core_opt()?;
 
-        unsafe { adapter.context.adapter_as_hal::<A>(adapter) }
+        unsafe { adapter.as_hal::<A>() }
     }
 
     #[cfg(custom)]

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -234,7 +234,7 @@ impl Blas {
         &mut self,
     ) -> Option<impl Deref<Target = A::AccelerationStructure> + WasmNotSendSync> {
         let blas = self.inner.as_core_opt()?;
-        unsafe { blas.context.blas_as_hal::<A>(blas) }
+        unsafe { blas.as_hal::<A>() }
     }
 
     #[cfg(custom)]

--- a/wgpu/src/api/buffer.rs
+++ b/wgpu/src/api/buffer.rs
@@ -289,7 +289,7 @@ impl Buffer {
         &self,
     ) -> Option<impl core::ops::Deref<Target = A::Buffer> + WasmNotSendSync> {
         let buffer = self.inner.as_core_opt()?;
-        unsafe { buffer.context.buffer_as_hal::<A>(buffer) }
+        unsafe { buffer.as_hal::<A>() }
     }
 
     /// Returns a [`BufferSlice`] referring to the portion of `self`'s contents

--- a/wgpu/src/api/command_encoder.rs
+++ b/wgpu/src/api/command_encoder.rs
@@ -279,11 +279,7 @@ impl CommandEncoder {
         hal_command_encoder_callback: F,
     ) -> R {
         if let Some(encoder) = self.inner.as_core_mut_opt() {
-            unsafe {
-                encoder
-                    .context
-                    .command_encoder_as_hal_mut::<A, F, R>(encoder, hal_command_encoder_callback)
-            }
+            unsafe { encoder.as_hal_mut::<A, F, R>(hal_command_encoder_callback) }
         } else {
             hal_command_encoder_callback(None)
         }

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -519,10 +519,7 @@ impl Device {
         // not created on this device.
         let core_device = self.inner.as_core_opt()?;
         let core_texture = texture.inner.as_core_opt()?;
-        if !core_device
-            .context
-            .texture_belongs_to_device(core_texture, core_device)
-        {
+        if !core_device.texture_belongs_to_device(core_texture) {
             return None;
         }
 

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -363,13 +363,7 @@ impl Device {
     ) -> Texture {
         let texture = unsafe {
             let core_device = self.inner.as_core();
-            core_device.context.create_texture_from_hal::<A>(
-                hal_texture,
-                core_device,
-                desc,
-                initial_state,
-                cleared,
-            )
+            core_device.create_texture_from_hal::<A>(hal_texture, desc, initial_state, cleared)
         };
         Texture {
             inner: texture.into(),
@@ -622,9 +616,7 @@ impl Device {
 
         let buffer = unsafe {
             let core_device = self.inner.as_core();
-            core_device
-                .context
-                .create_buffer_from_hal::<A>(hal_buffer, core_device, desc)
+            core_device.create_buffer_from_hal::<A>(hal_buffer, desc)
         };
 
         Buffer {
@@ -816,7 +808,7 @@ impl Device {
         &self,
     ) -> Option<impl Deref<Target = A::Device> + WasmNotSendSync> {
         let device = self.inner.as_core_opt()?;
-        unsafe { device.context.device_as_hal::<A>(device) }
+        unsafe { device.as_hal::<A>() }
     }
 
     /// Destroy this device.

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -390,10 +390,7 @@ impl Instance {
     ) -> Adapter {
         let core_instance = self.inner.as_core();
         let wgpu_adapter = unsafe { core_instance.create_adapter_from_hal(hal_adapter) };
-        let core = backend::wgpu_core::CoreAdapter {
-            context: core_instance.clone(),
-            wgpu_adapter,
-        };
+        let core = backend::wgpu_core::CoreAdapter { wgpu_adapter };
 
         Adapter { inner: core.into() }
     }

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -407,15 +407,9 @@ impl Instance {
     /// # Arguments
     ///
     /// - `core_instance` - wgpu-core instance.
-    ///
-    /// # Safety
-    ///
-    /// Refer to the creation of wgpu-core Instance.
-    pub unsafe fn from_core(core_instance: Arc<wgc::instance::Instance>) -> Self {
+    pub fn from_core(core_instance: Arc<wgc::instance::Instance>) -> Self {
         Self {
-            inner: unsafe {
-                crate::backend::ContextWgpuCore::from_core_instance(core_instance).into()
-            },
+            inner: crate::backend::ContextWgpuCore::from_core_instance(core_instance).into(),
         }
     }
 }

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -365,7 +365,7 @@ impl Queue {
         &self,
     ) -> Option<impl core::ops::Deref<Target = A::Queue> + WasmNotSendSync> {
         let queue = self.inner.as_core_opt()?;
-        unsafe { queue.context.queue_as_hal::<A>(queue) }
+        unsafe { queue.as_hal::<A>() }
     }
 
     /// Schedule a surface texture to be presented on the owning surface.

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -229,7 +229,7 @@ impl Surface<'_> {
     ) -> Option<impl Deref<Target = A::Surface> + WasmNotSendSync> {
         let core_surface = self.inner.as_core_opt()?;
 
-        unsafe { core_surface.context.surface_as_hal::<A>(core_surface) }
+        unsafe { core_surface.as_hal::<A>() }
     }
 
     #[cfg(custom)]

--- a/wgpu/src/api/texture.rs
+++ b/wgpu/src/api/texture.rs
@@ -60,7 +60,7 @@ impl Texture {
     #[cfg(wgpu_core)]
     pub unsafe fn as_hal<A: hal::Api>(&self) -> Option<impl Deref<Target = A::Texture>> {
         let texture = self.inner.as_core_opt()?;
-        unsafe { texture.context.texture_as_hal::<A>(texture) }
+        unsafe { texture.as_hal::<A>() }
     }
 
     /// Returns the underlying [`webgpu::GpuTexture`] handle if this `Texture`

--- a/wgpu/src/api/texture_view.rs
+++ b/wgpu/src/api/texture_view.rs
@@ -73,7 +73,7 @@ impl TextureView {
     #[cfg(wgpu_core)]
     pub unsafe fn as_hal<A: hal::Api>(&self) -> Option<impl Deref<Target = A::TextureView>> {
         let view = self.inner.as_core_opt()?;
-        unsafe { view.context.texture_view_as_hal::<A>(view) }
+        unsafe { view.as_hal::<A>() }
     }
 
     /// Returns the underlying [`webgpu::GpuTextureView`] handle if this view

--- a/wgpu/src/api/tlas.rs
+++ b/wgpu/src/api/tlas.rs
@@ -72,7 +72,7 @@ impl Tlas {
         &mut self,
     ) -> Option<impl Deref<Target = A::AccelerationStructure>> {
         let tlas = self.inner.as_core_opt()?;
-        unsafe { tlas.context.tlas_as_hal::<A>(tlas) }
+        unsafe { tlas.as_hal::<A>() }
     }
 
     /// Returns custom implementation of Tlas (if custom backend and is internally T)

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -104,68 +104,10 @@ impl ContextWgpuCore {
             )
         }?;
         let device = CoreDevice {
-            context: self.clone(),
             wgpu_device: device.clone(),
         };
         let queue = CoreQueue { wgpu_queue: queue };
         Ok((device, queue))
-    }
-
-    pub unsafe fn create_texture_from_hal<A: hal::Api>(
-        &self,
-        hal_texture: A::Texture,
-        device: &CoreDevice,
-        desc: &TextureDescriptor<'_>,
-        initial_state: wgt::TextureUses,
-        cleared: bool,
-    ) -> CoreTexture {
-        let descriptor = desc.map_label_and_view_formats(|l| l.map(Borrowed), |v| v.to_vec());
-        let (wgpu_texture, error) = unsafe {
-            device.wgpu_device.create_texture_from_hal(
-                Box::new(hal_texture),
-                &descriptor,
-                initial_state,
-                cleared,
-            )
-        };
-        if let Some(cause) = error {
-            device
-                .wgpu_device
-                .handle_error(cause, desc.label, "Device::create_texture_from_hal");
-        }
-        CoreTexture { wgpu_texture }
-    }
-
-    /// # Safety
-    ///
-    /// - `hal_buffer` must be created from `device`.
-    /// - `hal_buffer` must be created respecting `desc`
-    /// - `hal_buffer` must be initialized
-    /// - `hal_buffer` must not have zero size.
-    pub unsafe fn create_buffer_from_hal<A: hal::Api>(
-        &self,
-        hal_buffer: A::Buffer,
-        device: &CoreDevice,
-        desc: &BufferDescriptor<'_>,
-    ) -> CoreBuffer {
-        let (wgpu_buffer, error) = unsafe {
-            device
-                .wgpu_device
-                .create_buffer_from_hal(Box::new(hal_buffer), &desc.map_label(|l| l.map(Borrowed)))
-        };
-        if let Some(cause) = error {
-            device
-                .wgpu_device
-                .handle_error(cause, desc.label, "Device::create_buffer_from_hal");
-        }
-        CoreBuffer { wgpu_buffer }
-    }
-
-    pub unsafe fn device_as_hal<A: hal::Api>(
-        &self,
-        device: &CoreDevice,
-    ) -> Option<impl Deref<Target = A::Device>> {
-        unsafe { device.wgpu_device.clone().as_hal::<A>() }
     }
 }
 
@@ -266,11 +208,59 @@ impl fmt::Debug for CoreAdapter {
 
 #[derive(Debug, Clone)]
 pub struct CoreDevice {
-    pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_device: Arc<wgc::device::Device>,
 }
 
 impl CoreDevice {
+    pub unsafe fn as_hal<A: hal::Api>(&self) -> Option<impl Deref<Target = A::Device>> {
+        unsafe { self.wgpu_device.clone().as_hal::<A>() }
+    }
+
+    pub unsafe fn create_texture_from_hal<A: hal::Api>(
+        &self,
+        hal_texture: A::Texture,
+        desc: &TextureDescriptor<'_>,
+        initial_state: wgt::TextureUses,
+        cleared: bool,
+    ) -> CoreTexture {
+        let descriptor = desc.map_label_and_view_formats(|l| l.map(Borrowed), |v| v.to_vec());
+        let (wgpu_texture, error) = unsafe {
+            self.wgpu_device.create_texture_from_hal(
+                Box::new(hal_texture),
+                &descriptor,
+                initial_state,
+                cleared,
+            )
+        };
+        if let Some(cause) = error {
+            self.wgpu_device
+                .handle_error(cause, desc.label, "Device::create_texture_from_hal");
+        }
+        CoreTexture { wgpu_texture }
+    }
+
+    /// # Safety
+    ///
+    /// - `hal_buffer` must be created from `device`.
+    /// - `hal_buffer` must be created respecting `desc`
+    /// - `hal_buffer` must be initialized
+    /// - `hal_buffer` must not have zero size.
+    pub unsafe fn create_buffer_from_hal<A: hal::Api>(
+        &self,
+        hal_buffer: A::Buffer,
+        desc: &BufferDescriptor<'_>,
+    ) -> CoreBuffer {
+        let (wgpu_buffer, error) = unsafe {
+            self.wgpu_device
+                .create_buffer_from_hal(Box::new(hal_buffer), &desc.map_label(|l| l.map(Borrowed)))
+        };
+        if let Some(cause) = error {
+            self.wgpu_device
+                .handle_error(cause, desc.label, "Device::create_buffer_from_hal");
+        }
+        CoreBuffer { wgpu_buffer }
+    }
+
     /// Returns `true` if `texture` was created on `device`.
     #[cfg(webgl)]
     pub fn texture_belongs_to_device(&self, texture: &CoreTexture) -> bool {
@@ -730,7 +720,6 @@ impl dispatch::AdapterInterface for CoreAdapter {
             }
         };
         let device = CoreDevice {
-            context: self.context.clone(),
             wgpu_device: device,
         };
         let queue = CoreQueue { wgpu_queue: queue };

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -107,10 +107,7 @@ impl ContextWgpuCore {
             context: self.clone(),
             wgpu_device: device.clone(),
         };
-        let queue = CoreQueue {
-            context: self.clone(),
-            wgpu_queue: queue,
-        };
+        let queue = CoreQueue { wgpu_queue: queue };
         Ok((device, queue))
     }
 
@@ -169,13 +166,6 @@ impl ContextWgpuCore {
         device: &CoreDevice,
     ) -> Option<impl Deref<Target = A::Device>> {
         unsafe { device.wgpu_device.clone().as_hal::<A>() }
-    }
-
-    pub unsafe fn queue_as_hal<A: hal::Api>(
-        &self,
-        queue: &CoreQueue,
-    ) -> Option<impl Deref<Target = A::Queue> + WasmNotSendSync> {
-        unsafe { queue.wgpu_queue.clone().as_hal::<A>() }
     }
 }
 
@@ -390,16 +380,22 @@ pub struct CoreRenderBundle {
 
 #[derive(Clone)]
 pub struct CoreQueue {
-    pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_queue: Arc<wgc::device::queue::Queue>,
 }
 
 impl fmt::Debug for CoreQueue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CoreQueue")
-            .field("context", &self.context)
             .field("wgpu_queue", &Arc::as_ptr(&self.wgpu_queue))
             .finish()
+    }
+}
+
+impl CoreQueue {
+    pub unsafe fn as_hal<A: hal::Api>(
+        &self,
+    ) -> Option<impl Deref<Target = A::Queue> + WasmNotSendSync> {
+        unsafe { self.wgpu_queue.clone().as_hal::<A>() }
     }
 }
 
@@ -737,10 +733,7 @@ impl dispatch::AdapterInterface for CoreAdapter {
             context: self.context.clone(),
             wgpu_device: device,
         };
-        let queue = CoreQueue {
-            context: self.context.clone(),
-            wgpu_queue: queue,
-        };
+        let queue = CoreQueue { wgpu_queue: queue };
         Box::pin(ready(Ok((device.into(), queue.into()))))
     }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -202,13 +202,6 @@ impl ContextWgpuCore {
             .is_ok()
     }
 
-    pub unsafe fn texture_view_as_hal<A: hal::Api>(
-        &self,
-        texture_view: &CoreTextureView,
-    ) -> Option<impl Deref<Target = A::TextureView>> {
-        unsafe { texture_view.wgpu_texture_view.clone().as_hal::<A>() }
-    }
-
     /// This method will start the wgpu_core level command recording.
     pub unsafe fn command_encoder_as_hal_mut<
         A: hal::Api,
@@ -378,8 +371,13 @@ pub struct CoreTexture {
 
 #[derive(Debug, Clone)]
 pub struct CoreTextureView {
-    pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_texture_view: Arc<wgc::resource::TextureView>,
+}
+
+impl CoreTextureView {
+    pub unsafe fn as_hal<A: hal::Api>(&self) -> Option<impl Deref<Target = A::TextureView>> {
+        unsafe { self.wgpu_texture_view.clone().as_hal::<A>() }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1876,11 +1874,7 @@ impl dispatch::TextureInterface for CoreTexture {
                 .device()
                 .handle_error(cause, desc.label, "Texture::create_view");
         }
-        CoreTextureView {
-            context: self.context.clone(),
-            wgpu_texture_view,
-        }
-        .into()
+        CoreTextureView { wgpu_texture_view }.into()
     }
 
     fn destroy(&self) {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -83,32 +83,6 @@ impl ContextWgpuCore {
     ) -> Arc<wgc::instance::Adapter> {
         unsafe { self.0.create_adapter_from_hal(hal_adapter.into()) }
     }
-
-    pub unsafe fn adapter_as_hal<A: hal::Api>(
-        &self,
-        adapter: &CoreAdapter,
-    ) -> Option<impl Deref<Target = A::Adapter> + WasmNotSendSync> {
-        unsafe { adapter.wgpu_adapter.clone().as_hal::<A>() }
-    }
-
-    pub unsafe fn create_device_from_hal<A: hal::Api>(
-        &self,
-        adapter: &CoreAdapter,
-        hal_device: hal::OpenDevice<A>,
-        desc: &crate::DeviceDescriptor<'_>,
-    ) -> Result<(CoreDevice, CoreQueue), crate::RequestDeviceError> {
-        let (device, queue) = unsafe {
-            adapter.wgpu_adapter.create_device_and_queue_from_hal(
-                hal_device.into(),
-                &desc.map_label(|l| l.map(Borrowed)),
-            )
-        }?;
-        let device = CoreDevice {
-            wgpu_device: device.clone(),
-        };
-        let queue = CoreQueue { wgpu_queue: queue };
-        Ok((device, queue))
-    }
 }
 
 fn map_buffer_copy_view(
@@ -193,16 +167,40 @@ impl CoreSurface {
 
 #[derive(Clone)]
 pub struct CoreAdapter {
-    pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_adapter: Arc<wgc::instance::Adapter>,
 }
 
 impl fmt::Debug for CoreAdapter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CoreAdapter")
-            .field("context", &self.context)
             .field("wgpu_adapter", &Arc::as_ptr(&self.wgpu_adapter))
             .finish()
+    }
+}
+
+impl CoreAdapter {
+    pub unsafe fn as_hal<A: hal::Api>(
+        &self,
+    ) -> Option<impl Deref<Target = A::Adapter> + WasmNotSendSync> {
+        unsafe { self.wgpu_adapter.clone().as_hal::<A>() }
+    }
+
+    pub unsafe fn create_device_from_hal<A: hal::Api>(
+        &self,
+        hal_device: hal::OpenDevice<A>,
+        desc: &crate::DeviceDescriptor<'_>,
+    ) -> Result<(CoreDevice, CoreQueue), crate::RequestDeviceError> {
+        let (device, queue) = unsafe {
+            self.wgpu_adapter.create_device_and_queue_from_hal(
+                hal_device.into(),
+                &desc.map_label(|l| l.map(Borrowed)),
+            )
+        }?;
+        let device = CoreDevice {
+            wgpu_device: device.clone(),
+        };
+        let queue = CoreQueue { wgpu_queue: queue };
+        Ok((device, queue))
     }
 }
 
@@ -645,10 +643,7 @@ impl dispatch::InstanceInterface for ContextWgpuCore {
             wgt::Backends::all(),
         );
         let adapter = adapter.map(|wgpu_adapter| {
-            let core = CoreAdapter {
-                context: self.clone(),
-                wgpu_adapter,
-            };
+            let core = CoreAdapter { wgpu_adapter };
             let generic: dispatch::DispatchAdapter = core.into();
             generic
         });
@@ -695,7 +690,6 @@ impl dispatch::InstanceInterface for ContextWgpuCore {
             .into_iter()
             .map(|adapter| {
                 let core = crate::backend::wgpu_core::CoreAdapter {
-                    context: self.clone(),
                     wgpu_adapter: adapter,
                 };
                 core.into()

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -490,7 +490,6 @@ impl CoreTlas {
 
 #[derive(Clone)]
 pub struct CoreSurfaceOutputDetail {
-    pub(crate) context: ContextWgpuCore,
     wgpu_surface: Arc<wgc::instance::Surface>,
     error_sink: ErrorSink,
 }
@@ -498,7 +497,6 @@ pub struct CoreSurfaceOutputDetail {
 impl fmt::Debug for CoreSurfaceOutputDetail {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CoreSurfaceOutputDetail")
-            .field("context", &self.context)
             .field("wgpu_surface", &Arc::as_ptr(&self.wgpu_surface))
             .finish()
     }
@@ -2844,7 +2842,6 @@ impl dispatch::SurfaceInterface for CoreSurface {
         };
 
         let output_detail = CoreSurfaceOutputDetail {
-            context: self.context.clone(),
             wgpu_surface: self.wgpu_surface.clone(),
             error_sink,
         }

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -137,10 +137,7 @@ impl ContextWgpuCore {
                 .wgpu_device
                 .handle_error(cause, desc.label, "Device::create_texture_from_hal");
         }
-        CoreTexture {
-            context: self.clone(),
-            wgpu_texture,
-        }
+        CoreTexture { wgpu_texture }
     }
 
     /// # Safety
@@ -183,23 +180,6 @@ impl ContextWgpuCore {
         surface: &CoreSurface,
     ) -> Option<impl Deref<Target = A::Surface>> {
         unsafe { surface.wgpu_surface.clone().as_hal::<A>() }
-    }
-
-    pub unsafe fn texture_as_hal<A: hal::Api>(
-        &self,
-        texture: &CoreTexture,
-    ) -> Option<impl Deref<Target = A::Texture>> {
-        unsafe { texture.wgpu_texture.clone().as_hal::<A>() }
-    }
-
-    /// Returns `true` if `texture` was created on `device`.
-    #[cfg(webgl)]
-    pub fn texture_belongs_to_device(&self, texture: &CoreTexture, device: &CoreDevice) -> bool {
-        use wgc::resource::ParentDevice as _;
-        texture
-            .wgpu_texture
-            .same_device(&device.wgpu_device)
-            .is_ok()
     }
 
     /// This method will start the wgpu_core level command recording.
@@ -341,6 +321,15 @@ pub struct CoreDevice {
     pub(crate) wgpu_device: Arc<wgc::device::Device>,
 }
 
+impl CoreDevice {
+    /// Returns `true` if `texture` was created on `device`.
+    #[cfg(webgl)]
+    pub fn texture_belongs_to_device(&self, texture: &CoreTexture) -> bool {
+        use wgc::resource::ParentDevice as _;
+        texture.wgpu_texture.same_device(&self.wgpu_device).is_ok()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CoreBuffer {
     pub(crate) context: ContextWgpuCore,
@@ -365,8 +354,13 @@ pub struct CoreBindGroup {
 
 #[derive(Debug, Clone)]
 pub struct CoreTexture {
-    pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_texture: Arc<wgc::resource::Texture>,
+}
+
+impl CoreTexture {
+    pub unsafe fn as_hal<A: hal::Api>(&self) -> Option<impl Deref<Target = A::Texture>> {
+        unsafe { self.wgpu_texture.clone().as_hal::<A>() }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1396,11 +1390,7 @@ impl dispatch::DeviceInterface for CoreDevice {
                 .handle_error(cause, desc.label, "Device::create_texture");
         }
 
-        CoreTexture {
-            context: self.context.clone(),
-            wgpu_texture,
-        }
-        .into()
+        CoreTexture { wgpu_texture }.into()
     }
 
     fn create_external_texture(
@@ -2899,10 +2889,7 @@ impl dispatch::SurfaceInterface for CoreSurface {
                 texture: texture_id,
             }) => {
                 let data = texture_id
-                    .map(|wgpu_texture| CoreTexture {
-                        context: self.context.clone(),
-                        wgpu_texture,
-                    })
+                    .map(|wgpu_texture| CoreTexture { wgpu_texture })
                     .map(Into::into);
 
                 (data, status, output_detail)

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -61,7 +61,7 @@ impl ContextWgpuCore {
         unsafe { self.0.as_hal::<A>() }
     }
 
-    pub unsafe fn from_core_instance(core_instance: Arc<wgc::instance::Instance>) -> Self {
+    pub fn from_core_instance(core_instance: Arc<wgc::instance::Instance>) -> Self {
         Self(core_instance)
     }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -189,13 +189,6 @@ impl ContextWgpuCore {
         }
     }
 
-    pub unsafe fn blas_as_hal<A: hal::Api>(
-        &self,
-        blas: &CoreBlas,
-    ) -> Option<impl Deref<Target = A::AccelerationStructure>> {
-        unsafe { blas.wgpu_blas.clone().as_hal::<A>() }
-    }
-
     #[track_caller]
     #[cold]
     fn handle_error_fatal(
@@ -479,8 +472,15 @@ impl fmt::Debug for CoreCommandEncoder {
 
 #[derive(Debug, Clone)]
 pub struct CoreBlas {
-    pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_blas: Arc<wgc::resource::Blas>,
+}
+
+impl CoreBlas {
+    pub unsafe fn as_hal<A: hal::Api>(
+        &self,
+    ) -> Option<impl Deref<Target = A::AccelerationStructure>> {
+        unsafe { self.wgpu_blas.clone().as_hal::<A>() }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1414,14 +1414,7 @@ impl dispatch::DeviceInterface for CoreDevice {
             self.wgpu_device
                 .handle_error(cause, desc.label, "Device::create_blas");
         }
-        (
-            wgpu_blas.handle(),
-            CoreBlas {
-                context: self.context.clone(),
-                wgpu_blas,
-            }
-            .into(),
-        )
+        (wgpu_blas.handle(), CoreBlas { wgpu_blas }.into())
     }
 
     fn create_tlas(&self, desc: &crate::CreateTlasDescriptor<'_>) -> dispatch::DispatchTlas {
@@ -1717,14 +1710,7 @@ impl dispatch::QueueInterface for CoreQueue {
                 .device()
                 .handle_error_nolabel(cause, "Queue::compact_blas");
         }
-        (
-            wgpu_blas.handle(),
-            CoreBlas {
-                context: self.context.clone(),
-                wgpu_blas,
-            }
-            .into(),
-        )
+        (wgpu_blas.handle(), CoreBlas { wgpu_blas }.into())
     }
 
     fn present(&self, detail: &dispatch::DispatchSurfaceOutputDetail) {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -85,13 +85,6 @@ impl ContextWgpuCore {
         unsafe { adapter.wgpu_adapter.clone().as_hal::<A>() }
     }
 
-    pub unsafe fn buffer_as_hal<A: hal::Api>(
-        &self,
-        buffer: &CoreBuffer,
-    ) -> Option<impl Deref<Target = A::Buffer>> {
-        unsafe { buffer.wgpu_buffer.clone().as_hal::<A>() }
-    }
-
     pub unsafe fn create_device_from_hal<A: hal::Api>(
         &self,
         adapter: &CoreAdapter,
@@ -162,10 +155,7 @@ impl ContextWgpuCore {
                 .wgpu_device
                 .handle_error(cause, desc.label, "Device::create_buffer_from_hal");
         }
-        CoreBuffer {
-            context: self.clone(),
-            wgpu_buffer,
-        }
+        CoreBuffer { wgpu_buffer }
     }
 
     pub unsafe fn device_as_hal<A: hal::Api>(
@@ -332,8 +322,13 @@ impl CoreDevice {
 
 #[derive(Debug, Clone)]
 pub struct CoreBuffer {
-    pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_buffer: Arc<wgc::resource::Buffer>,
+}
+
+impl CoreBuffer {
+    pub unsafe fn as_hal<A: hal::Api>(&self) -> Option<impl Deref<Target = A::Buffer>> {
+        unsafe { self.wgpu_buffer.clone().as_hal::<A>() }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1375,11 +1370,7 @@ impl dispatch::DeviceInterface for CoreDevice {
                 .handle_error(cause, desc.label, "Device::create_buffer");
         }
 
-        CoreBuffer {
-            context: self.context.clone(),
-            wgpu_buffer,
-        }
-        .into()
+        CoreBuffer { wgpu_buffer }.into()
     }
 
     fn create_texture(&self, desc: &crate::TextureDescriptor<'_>) -> dispatch::DispatchTexture {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -233,13 +233,6 @@ impl ContextWgpuCore {
         unsafe { blas.wgpu_blas.clone().as_hal::<A>() }
     }
 
-    pub unsafe fn tlas_as_hal<A: hal::Api>(
-        &self,
-        tlas: &CoreTlas,
-    ) -> Option<impl Deref<Target = A::AccelerationStructure>> {
-        unsafe { tlas.wgpu_tlas.clone().as_hal::<A>() }
-    }
-
     #[track_caller]
     #[cold]
     fn handle_error_fatal(
@@ -505,8 +498,15 @@ pub struct CoreBlas {
 
 #[derive(Debug, Clone)]
 pub struct CoreTlas {
-    pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_tlas: Arc<wgc::resource::Tlas>,
+}
+
+impl CoreTlas {
+    pub unsafe fn as_hal<A: hal::Api>(
+        &self,
+    ) -> Option<impl Deref<Target = A::AccelerationStructure>> {
+        unsafe { self.wgpu_tlas.clone().as_hal::<A>() }
+    }
 }
 
 #[derive(Clone)]
@@ -1453,11 +1453,7 @@ impl dispatch::DeviceInterface for CoreDevice {
             self.wgpu_device
                 .handle_error(cause, desc.label, "Device::create_tlas");
         }
-        CoreTlas {
-            context: self.context.clone(),
-            wgpu_tlas,
-        }
-        .into()
+        CoreTlas { wgpu_tlas }.into()
     }
 
     fn create_sampler(&self, desc: &crate::SamplerDescriptor<'_>) -> dispatch::DispatchSampler {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -388,14 +388,12 @@ pub struct CorePipelineCache {
 }
 
 pub struct CoreCommandBuffer {
-    pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_command_buffer: Arc<wgc::command::CommandBuffer>,
 }
 
 impl fmt::Debug for CoreCommandBuffer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CoreCommandBuffer")
-            .field("context", &self.context)
             .field(
                 "wgpu_command_buffer",
                 &Arc::as_ptr(&self.wgpu_command_buffer),
@@ -2097,7 +2095,6 @@ impl dispatch::CommandEncoderInterface for CoreCommandEncoder {
         let descriptor = wgt::CommandBufferDescriptor::default();
         let wgpu_command_buffer = self.wgpu_command_encoder.finish(&descriptor);
         CoreCommandBuffer {
-            context: self.context.clone(),
             wgpu_command_buffer,
         }
         .into()

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -171,13 +171,6 @@ impl ContextWgpuCore {
         unsafe { device.wgpu_device.clone().as_hal::<A>() }
     }
 
-    pub unsafe fn surface_as_hal<A: hal::Api>(
-        &self,
-        surface: &CoreSurface,
-    ) -> Option<impl Deref<Target = A::Surface>> {
-        unsafe { surface.wgpu_surface.clone().as_hal::<A>() }
-    }
-
     pub unsafe fn queue_as_hal<A: hal::Api>(
         &self,
         queue: &CoreQueue,
@@ -245,7 +238,6 @@ fn map_pass_channel<V: Copy>(ops: Option<&Operations<V>>) -> wgc::command::PassC
 
 #[derive(Clone)]
 pub struct CoreSurface {
-    pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_surface: Arc<wgc::instance::Surface>,
     /// Configured device is needed to know which backend
     /// code to execute when acquiring a new frame.
@@ -255,10 +247,15 @@ pub struct CoreSurface {
 impl fmt::Debug for CoreSurface {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CoreSurface")
-            .field("context", &self.context)
             .field("wgpu_surface", &Arc::as_ptr(&self.wgpu_surface))
             .field("configured_device", &self.configured_device)
             .finish()
+    }
+}
+
+impl CoreSurface {
+    pub unsafe fn as_hal<A: hal::Api>(&self) -> Option<impl Deref<Target = A::Surface>> {
+        unsafe { self.wgpu_surface.clone().as_hal::<A>() }
     }
 }
 
@@ -640,7 +637,6 @@ impl dispatch::InstanceInterface for ContextWgpuCore {
         }?;
 
         Ok(CoreSurface {
-            context: self.clone(),
             wgpu_surface,
             configured_device: Arc::new(Mutex::default()),
         }

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -172,23 +172,6 @@ impl ContextWgpuCore {
         unsafe { surface.wgpu_surface.clone().as_hal::<A>() }
     }
 
-    /// This method will start the wgpu_core level command recording.
-    pub unsafe fn command_encoder_as_hal_mut<
-        A: hal::Api,
-        F: FnOnce(Option<&mut A::CommandEncoder>) -> R,
-        R,
-    >(
-        &self,
-        command_encoder: &CoreCommandEncoder,
-        hal_command_encoder_callback: F,
-    ) -> R {
-        unsafe {
-            command_encoder
-                .wgpu_command_encoder
-                .as_hal_mut::<A, F, R>(hal_command_encoder_callback)
-        }
-    }
-
     #[track_caller]
     #[cold]
     fn handle_error_fatal(
@@ -452,19 +435,30 @@ pub struct CoreRenderPass {
 }
 
 pub struct CoreCommandEncoder {
-    pub(crate) context: ContextWgpuCore,
     pub(crate) wgpu_command_encoder: Arc<wgc::command::CommandEncoder>,
 }
 
 impl fmt::Debug for CoreCommandEncoder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CoreCommandEncoder")
-            .field("context", &self.context)
             .field(
                 "wgpu_command_encoder",
                 &Arc::as_ptr(&self.wgpu_command_encoder),
             )
             .finish()
+    }
+}
+
+impl CoreCommandEncoder {
+    /// This method will start the wgpu_core level command recording.
+    pub unsafe fn as_hal_mut<A: hal::Api, F: FnOnce(Option<&mut A::CommandEncoder>) -> R, R>(
+        &self,
+        hal_command_encoder_callback: F,
+    ) -> R {
+        unsafe {
+            self.wgpu_command_encoder
+                .as_hal_mut::<A, F, R>(hal_command_encoder_callback)
+        }
     }
 }
 
@@ -1468,7 +1462,6 @@ impl dispatch::DeviceInterface for CoreDevice {
             .create_command_encoder(&desc.map_label(|l| l.map(Borrowed)));
 
         CoreCommandEncoder {
-            context: self.context.clone(),
             wgpu_command_encoder,
         }
         .into()

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -46,6 +46,12 @@ impl fmt::Debug for ContextWgpuCore {
     }
 }
 
+#[track_caller]
+#[cold]
+fn handle_error_fatal(cause: impl Error + WasmNotSendSync + 'static, operation: &'static str) -> ! {
+    panic!("Error in {operation}: {f}", f = format_error(&cause));
+}
+
 impl ContextWgpuCore {
     pub unsafe fn from_hal_instance<A: hal::Api>(hal_instance: A::Instance) -> Self {
         Self(wgc::instance::Instance::from_hal_instance::<A>(
@@ -170,16 +176,6 @@ impl ContextWgpuCore {
         surface: &CoreSurface,
     ) -> Option<impl Deref<Target = A::Surface>> {
         unsafe { surface.wgpu_surface.clone().as_hal::<A>() }
-    }
-
-    #[track_caller]
-    #[cold]
-    fn handle_error_fatal(
-        &self,
-        cause: impl Error + WasmNotSendSync + 'static,
-        operation: &'static str,
-    ) -> ! {
-        panic!("Error in {operation}: {f}", f = format_error(&cause));
     }
 
     pub unsafe fn queue_as_hal<A: hal::Api>(
@@ -680,7 +676,7 @@ impl dispatch::InstanceInterface for ContextWgpuCore {
     fn poll_all_devices(&self, force_wait: bool) -> bool {
         match self.0.poll_all_devices(force_wait) {
             Ok(all_queue_empty) => all_queue_empty,
-            Err(err) => self.handle_error_fatal(err, "Instance::poll_all_devices"),
+            Err(err) => handle_error_fatal(err, "Instance::poll_all_devices"),
         }
     }
 
@@ -1514,7 +1510,7 @@ impl dispatch::DeviceInterface for CoreDevice {
                     return Err(poll_error);
                 }
 
-                self.context.handle_error_fatal(err, "Device::poll")
+                handle_error_fatal(err, "Device::poll")
             }
         }
     }
@@ -2865,9 +2861,7 @@ impl dispatch::SurfaceInterface for CoreSurface {
                         error_sink.handle_error_nolabel(err, "Surface::get_current_texture_view");
                         (None, crate::SurfaceStatus::Validation, output_detail)
                     }
-                    None => self
-                        .context
-                        .handle_error_fatal(err, "Surface::get_current_texture_view"),
+                    None => handle_error_fatal(err, "Surface::get_current_texture_view"),
                 }
             }
         }


### PR DESCRIPTION
**Connections**
Towards #10073 

**Description**
I wanted to get `from_core` on wgpu resources but `CoreContext` is getting in the way, so let's remove it and move it's methods down. Historically we needed it because of Global and error handling.

**Testing**
Just refactor

**Squash or Rebase?**
Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
