### PR TITLE
Revert part of #10115 by removing result from `create_render_bundle_encoder` and reimpl content validation in deno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,17 +60,6 @@ Bottom level categories:
 
 By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
-#### `Device::create_render_bundle_encoder` now returns error
-
-Error is raised if for provided texture formats required features are not enabled on the device as per spec.
-
-```diff
-- device.create_render_bundle_encoder(&RenderBundleEncoderDescriptor::default())
-+ device.create_render_bundle_encoder(&RenderBundleEncoderDescriptor::default()).unwrap()
-```
-
-By @sagudev in [#10115](https://github.com/gfx-rs/wgpu/pull/10115).
-
 ### Added/New Features
 
 #### General

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -63,6 +63,22 @@ pub struct GPUDevice {
   pub(crate) weak: std::sync::OnceLock<v8::Weak<v8::Object>>,
 }
 
+impl GPUDevice {
+  /// <https://www.w3.org/TR/webgpu/#abstract-opdef-validate-texture-format-required-features>
+  fn validate_texture_format_required_feature(
+    &self,
+    format: wgpu_types::TextureFormat,
+  ) -> Result<(), JsErrorBox> {
+    self
+      .wgpu_device
+      .require_features(format.required_features())
+      .map_err(|err| {
+        let err = fmt_err(&err);
+        JsErrorBox::type_error(err)
+      })
+  }
+}
+
 impl WebIdlInterfaceConverter for GPUDevice {
   const NAME: &'static str = "GPUDevice";
 }
@@ -649,13 +665,20 @@ impl GPUDevice {
       multiview: None,
     };
 
+    // 1. Validate texture format required features of each non-null element of descriptor.colorFormats with this.[[device]].
+    for &format in wgpu_descriptor.color_formats.iter().flatten() {
+      self.validate_texture_format_required_feature(format)?;
+    }
+
+    // 2. If descriptor.depthStencilFormat is provided:
+    if let Some(ds) = wgpu_descriptor.depth_stencil {
+      // Validate texture format required features of descriptor.depthStencilFormat with this.[[device]].
+      self.validate_texture_format_required_feature(ds.format)?;
+    }
+
     let encoder = self
       .wgpu_device
-      .create_render_bundle_encoder(&wgpu_descriptor)
-      .map_err(|err| {
-        let err = fmt_err(&err);
-        JsErrorBox::type_error(err)
-      })?;
+      .create_render_bundle_encoder(&wgpu_descriptor);
 
     Ok(GPURenderBundleEncoder {
       encoder: RefCell::new(encoder),

--- a/examples/features/src/msaa_line/mod.rs
+++ b/examples/features/src/msaa_line/mod.rs
@@ -80,15 +80,14 @@ impl Example {
             multiview_mask: None,
             cache: None,
         });
-        let mut encoder = device
-            .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+        let mut encoder =
+            device.create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
                 label: None,
                 color_formats: &[Some(config.view_formats[0])],
                 depth_stencil: None,
                 sample_count,
                 multiview: None,
-            })
-            .unwrap();
+            });
         encoder.set_pipeline(&pipeline);
         encoder.set_vertex_buffer(0, vertex_buffer.slice(..));
         encoder.draw(0..vertex_count, 0..1);

--- a/examples/features/src/water/mod.rs
+++ b/examples/features/src/water/mod.rs
@@ -610,8 +610,8 @@ impl crate::framework::Example for Example {
 
         // A render bundle to draw the terrain.
         let terrain_bundle = {
-            let mut encoder = device
-                .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+            let mut encoder =
+                device.create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
                     label: None,
                     color_formats: &[Some(config.view_formats[0])],
                     depth_stencil: Some(wgpu::RenderBundleDepthStencil {
@@ -621,8 +621,7 @@ impl crate::framework::Example for Example {
                     }),
                     sample_count: 1,
                     multiview: None,
-                })
-                .unwrap();
+                });
             encoder.set_pipeline(&terrain_pipeline);
             encoder.set_bind_group(0, &terrain_flipped_bind_group, &[]);
             encoder.set_vertex_buffer(0, terrain_vertex_buf.slice(..));

--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -247,8 +247,7 @@ impl DeviceInterface for CustomDevice {
     fn create_render_bundle_encoder(
         &self,
         _desc: &wgpu::RenderBundleEncoderDescriptor<'_>,
-    ) -> Result<wgpu::custom::DispatchRenderBundleEncoder, wgpu::CreateRenderBundleEncoderError>
-    {
+    ) -> wgpu::custom::DispatchRenderBundleEncoder {
         unimplemented!()
     }
 

--- a/tests/tests/wgpu-gpu/immediates.rs
+++ b/tests/tests/wgpu-gpu/immediates.rs
@@ -344,14 +344,13 @@ async fn render_pass_test(ctx: &TestingContext, use_render_bundle: bool) {
         let mut render_pass = command_encoder.begin_render_pass(&render_pass_desc);
         if use_render_bundle {
             // Execute the commands in a render_bundle_encoder.
-            let mut render_bundle_encoder = ctx
-                .device
-                .create_render_bundle_encoder(&RenderBundleEncoderDescriptor {
-                    color_formats: &[Some(output_texture.format())],
-                    sample_count: 1,
-                    ..RenderBundleEncoderDescriptor::default()
-                })
-                .unwrap();
+            let mut render_bundle_encoder =
+                ctx.device
+                    .create_render_bundle_encoder(&RenderBundleEncoderDescriptor {
+                        color_formats: &[Some(output_texture.format())],
+                        sample_count: 1,
+                        ..RenderBundleEncoderDescriptor::default()
+                    });
             do_encoding(&mut render_bundle_encoder, &pipeline, &bind_group, &data);
             let render_bundle = render_bundle_encoder.finish(&RenderBundleDescriptor::default());
             render_pass.execute_bundles([&render_bundle]);

--- a/tests/tests/wgpu-gpu/life_cycle.rs
+++ b/tests/tests/wgpu-gpu/life_cycle.rs
@@ -310,16 +310,15 @@ fn record_encoder_with_resource(
                 pass.set_bind_group(0, &bind_group, &[]);
                 pass.draw(0..0, 0..0);
             } else {
-                let mut rbe = ctx
-                    .device
-                    .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
-                        label: None,
-                        color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
-                        depth_stencil: None,
-                        sample_count: 1,
-                        multiview: None,
-                    })
-                    .unwrap();
+                let mut rbe =
+                    ctx.device
+                        .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+                            label: None,
+                            color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
+                            depth_stencil: None,
+                            sample_count: 1,
+                            multiview: None,
+                        });
                 rbe.set_pipeline(&pipeline);
                 rbe.set_bind_group(0, &bind_group, &[]);
                 rbe.draw(0..0, 0..0);
@@ -1025,16 +1024,15 @@ fn test_replaced_bind_group(ctx: &TestingContext, usage: UsageKind) {
                 pass.set_bind_group(0, &bind_group_b, &[]);
                 pass.draw(0..0, 0..0);
             } else {
-                let mut rbe = ctx
-                    .device
-                    .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
-                        label: None,
-                        color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
-                        depth_stencil: None,
-                        sample_count: 1,
-                        multiview: None,
-                    })
-                    .unwrap();
+                let mut rbe =
+                    ctx.device
+                        .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+                            label: None,
+                            color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
+                            depth_stencil: None,
+                            sample_count: 1,
+                            multiview: None,
+                        });
                 rbe.set_pipeline(&pipeline);
                 rbe.set_bind_group(0, &bind_group_a, &[]);
                 rbe.set_bind_group(0, &bind_group_b, &[]);

--- a/tests/tests/wgpu-gpu/vertex_indices/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_indices/mod.rs
@@ -375,17 +375,15 @@ async fn vertex_index_common(ctx: TestingContext) {
             // (it is dropped via `take` + `finish` earlier, but compiler does not take this into account)
             let mut render_bundle_encoder = match test.encoder_kind {
                 EncoderKind::RenderPass => None,
-                EncoderKind::RenderBundle => Some(
-                    ctx.device
-                        .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
-                            label: Some("test renderbundle encoder"),
-                            color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
-                            depth_stencil: None,
-                            sample_count: 1,
-                            multiview: None,
-                        })
-                        .unwrap(),
-                ),
+                EncoderKind::RenderBundle => Some(ctx.device.create_render_bundle_encoder(
+                    &wgpu::RenderBundleEncoderDescriptor {
+                        label: Some("test renderbundle encoder"),
+                        color_formats: &[Some(wgpu::TextureFormat::Rgba8Unorm)],
+                        depth_stencil: None,
+                        sample_count: 1,
+                        multiview: None,
+                    },
+                )),
             };
 
             let render_encoder: &mut dyn RenderEncoder = render_bundle_encoder

--- a/tests/tests/wgpu-validation/api/immediates.rs
+++ b/tests/tests/wgpu-validation/api/immediates.rs
@@ -537,13 +537,12 @@ fn render_multi_immediates_auto_layout_with_all_immediates_set_succeeds() {
     wgpu_test::valid(&device, || encoder.finish());
 
     let mut encoder = device.create_command_encoder(&Default::default());
-    let mut bundle_encoder = device
-        .create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
+    let mut bundle_encoder =
+        device.create_render_bundle_encoder(&wgpu::RenderBundleEncoderDescriptor {
             color_formats: &[Some(output_texture_view.texture().format())],
             sample_count: 1,
             ..wgpu::RenderBundleEncoderDescriptor::default()
-        })
-        .unwrap();
+        });
     do_encoding(&mut bundle_encoder, &pipeline);
     let bundle = bundle_encoder.finish(&wgpu::RenderBundleDescriptor::default());
 

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -11,7 +11,7 @@ use wgpu_core_remote_types::{
 use wgpu_core::{
     binding_model::{self},
     command,
-    device::{DeviceLostClosure, MissingFeatures, WaitIdleError},
+    device::{DeviceLostClosure, WaitIdleError},
     error::EmptyErrorScopeStack,
     pipeline::{
         self, ProgrammableStageDescriptor, RenderPipelineVertexProcessor,
@@ -704,7 +704,7 @@ impl Global {
         device_id: DeviceId,
         desc: &RenderBundleEncoderDescriptor,
         id_in: id::RenderBundleEncoderId,
-    ) -> Result<(), MissingFeatures> {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             render_bundle_encoders,
@@ -722,11 +722,9 @@ impl Global {
             multiview: None,
         };
 
-        let render_bundle_encoder = device.create_render_bundle_encoder(&desc)?;
+        let render_bundle_encoder = device.create_render_bundle_encoder(&desc);
 
         render_bundle_encoders.assign(id_in, *render_bundle_encoder);
-
-        Ok(())
     }
 
     pub fn render_bundle_encoder_finish(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -426,7 +426,8 @@ impl Device {
     pub(crate) fn raw(&self) -> &dyn hal::DynDevice {
         self.raw.as_ref()
     }
-    pub(crate) fn require_features(&self, feature: wgt::Features) -> Result<(), MissingFeatures> {
+
+    pub fn require_features(&self, feature: wgt::Features) -> Result<(), MissingFeatures> {
         if self.features.contains(feature) {
             Ok(())
         } else {
@@ -2846,22 +2847,19 @@ impl Device {
     pub fn create_render_bundle_encoder(
         self: &Arc<Self>,
         desc: &command::RenderBundleEncoderDescriptor,
-    ) -> Result<Box<command::RenderBundleEncoder>, MissingFeatures> {
+    ) -> Box<command::RenderBundleEncoder> {
         profiling::scope!("Device::create_render_bundle_encoder");
         api_log!("Device::create_render_bundle_encoder");
-        command::RenderBundleEncoder::new(self, desc)
-            .or_else(|err| match err {
-                command::CreateRenderBundleError::MissingFeatures(missing) => Err(missing),
-                err => {
-                    self.handle_error(
-                        err,
-                        desc.label.as_ref().map(|l| l.as_ref()),
-                        "Device::create_render_bundle_encoder",
-                    );
-                    Ok(command::RenderBundleEncoder::dummy(self))
-                }
-            })
-            .map(Box::new)
+        Box::new(
+            command::RenderBundleEncoder::new(self, desc).unwrap_or_else(|err| {
+                self.handle_error(
+                    err,
+                    desc.label.as_deref(),
+                    "Device::create_render_bundle_encoder",
+                );
+                command::RenderBundleEncoder::dummy(self)
+            }),
+        )
     }
 
     /// Generate information about late-validated buffer bindings for pipelines.

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -228,12 +228,12 @@ impl Device {
     pub fn create_render_bundle_encoder<'a>(
         &self,
         desc: &RenderBundleEncoderDescriptor<'_>,
-    ) -> Result<RenderBundleEncoder<'a>, CreateRenderBundleEncoderError> {
-        let encoder = self.inner.create_render_bundle_encoder(desc)?;
-        Ok(RenderBundleEncoder {
+    ) -> RenderBundleEncoder<'a> {
+        let encoder = self.inner.create_render_bundle_encoder(desc);
+        RenderBundleEncoder {
             inner: encoder,
             _p: PhantomData,
-        })
+        }
     }
 
     /// Creates a new [`BindGroup`].

--- a/wgpu/src/api/render_bundle_encoder.rs
+++ b/wgpu/src/api/render_bundle_encoder.rs
@@ -1,29 +1,7 @@
-use alloc::string::String;
-use core::error::Error;
-use core::fmt::Display;
 use core::{marker::PhantomData, num::NonZeroU32, ops::Range};
 
 use crate::dispatch::RenderBundleEncoderInterface;
 use crate::*;
-
-/// Error type for [`Device::create_render_bundle_encoder`].
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct CreateRenderBundleEncoderError(String);
-
-impl CreateRenderBundleEncoderError {
-    /// Creates a new `CreateRenderBundleEncoderError` with the given message.
-    pub fn new(msg: String) -> Self {
-        Self(msg)
-    }
-}
-
-impl Display for CreateRenderBundleEncoderError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> Result<(), core::fmt::Error> {
-        write!(f, "Error while creating render bundle encoder: {}", self.0)
-    }
-}
-
-impl Error for CreateRenderBundleEncoderError {}
 
 /// Encodes a series of GPU operations into a reusable "render bundle".
 ///

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2621,7 +2621,7 @@ impl dispatch::DeviceInterface for WebDevice {
     fn create_render_bundle_encoder(
         &self,
         desc: &crate::RenderBundleEncoderDescriptor<'_>,
-    ) -> Result<dispatch::DispatchRenderBundleEncoder, crate::CreateRenderBundleEncoderError> {
+    ) -> dispatch::DispatchRenderBundleEncoder {
         let mapped_color_formats = desc
             .color_formats
             .iter()
@@ -2648,16 +2648,13 @@ impl dispatch::DeviceInterface for WebDevice {
         let render_bundle_encoder = self
             .inner
             .create_render_bundle_encoder(&mapped_desc)
-            .map_err(|e| {
-                let e = e.dyn_ref::<js_sys::Error>().expect("Expected a JS Error");
-                crate::CreateRenderBundleEncoderError::new(e.message().as_string().unwrap())
-            })?;
+            .unwrap();
 
-        Ok(WebRenderBundleEncoder {
+        WebRenderBundleEncoder {
             inner: render_bundle_encoder,
             ident: crate::cmp::Identifier::create(),
         }
-        .into())
+        .into()
     }
 
     fn set_device_lost_callback(&self, device_lost_callback: dispatch::BoxDeviceLostCallback) {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1489,7 +1489,7 @@ impl dispatch::DeviceInterface for CoreDevice {
     fn create_render_bundle_encoder(
         &self,
         desc: &crate::RenderBundleEncoderDescriptor<'_>,
-    ) -> Result<dispatch::DispatchRenderBundleEncoder, crate::CreateRenderBundleEncoderError> {
+    ) -> dispatch::DispatchRenderBundleEncoder {
         let descriptor = wgc::command::RenderBundleEncoderDescriptor {
             label: desc.label.map(Borrowed),
             color_formats: Borrowed(desc.color_formats),
@@ -1497,12 +1497,9 @@ impl dispatch::DeviceInterface for CoreDevice {
             sample_count: desc.sample_count,
             multiview: desc.multiview,
         };
-        let encoder = self
-            .wgpu_device
-            .create_render_bundle_encoder(&descriptor)
-            .map_err(|e| crate::CreateRenderBundleEncoderError::new(e.to_string()))?;
+        let encoder = self.wgpu_device.create_render_bundle_encoder(&descriptor);
 
-        Ok(CoreRenderBundleEncoder { encoder }.into())
+        CoreRenderBundleEncoder { encoder }.into()
     }
 
     fn set_device_lost_callback(&self, device_lost_callback: dispatch::BoxDeviceLostCallback) {

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -202,7 +202,7 @@ pub trait DeviceInterface: CommonTraits {
     fn create_render_bundle_encoder(
         &self,
         desc: &crate::RenderBundleEncoderDescriptor<'_>,
-    ) -> Result<DispatchRenderBundleEncoder, crate::CreateRenderBundleEncoderError>;
+    ) -> DispatchRenderBundleEncoder;
 
     fn set_device_lost_callback(&self, device_lost_callback: BoxDeviceLostCallback);
 


### PR DESCRIPTION
**Connections**
Reverts part of https://github.com/gfx-rs/wgpu/pull/10115 as per https://github.com/gfx-rs/wgpu/issues/9710#issuecomment-5428692274
Closes https://github.com/gfx-rs/wgpu/issues/10174 as we remove the types and do not return Result anymore

**Description**
This PR mostly just revert https://github.com/gfx-rs/wgpu/pull/10115 to not return Result but return invalid RenderBundleEncoder on error. Because of that we need to reimplement validation in deno to make the tests pass again.

**Testing**
Refactor/revert, new changes have CTS.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
