### PR TITLE
fix(core-remote)!: Opt `Global` out of `Send` and `Sync`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4863,6 +4863,7 @@ version = "30.0.0"
 dependencies = [
  "raw-window-handle",
  "serde",
+ "static_assertions",
  "wgpu-core",
  "wgpu-core-remote-types",
  "wgpu-hal",

--- a/wgpu-core-remote-types/Cargo.toml
+++ b/wgpu-core-remote-types/Cargo.toml
@@ -25,6 +25,6 @@ targets = [
 ]
 
 [dependencies]
-wgpu-types = { workspace = true, features = ["serde"] }
-serde = { workspace = true }
 hashbrown = { workspace = true }
+serde = { workspace = true }
+wgpu-types = { workspace = true, features = ["serde"] }

--- a/wgpu-core-remote/Cargo.toml
+++ b/wgpu-core-remote/Cargo.toml
@@ -29,9 +29,9 @@ targets = [
 serde = ["dep:serde", "wgpu-types/serde", "wgpu-core/serde"]
 
 [dependencies]
-wgpu-core = { workspace = true, default-features = false }
-wgpu-hal = { workspace = true, default-features = false }
-wgpu-types.workspace = true
-wgpu-core-remote-types.workspace = true
 raw-window-handle.workspace = true
 serde = { workspace = true, optional = true }
+wgpu-core = { workspace = true, default-features = false }
+wgpu-core-remote-types.workspace = true
+wgpu-hal = { workspace = true, default-features = false }
+wgpu-types.workspace = true

--- a/wgpu-core-remote/Cargo.toml
+++ b/wgpu-core-remote/Cargo.toml
@@ -31,6 +31,7 @@ serde = ["dep:serde", "wgpu-types/serde", "wgpu-core/serde"]
 [dependencies]
 raw-window-handle.workspace = true
 serde = { workspace = true, optional = true }
+static_assertions = { workspace = true }
 wgpu-core = { workspace = true, default-features = false }
 wgpu-core-remote-types.workspace = true
 wgpu-hal = { workspace = true, default-features = false }

--- a/wgpu-core-remote/src/global/mod.rs
+++ b/wgpu-core-remote/src/global/mod.rs
@@ -392,3 +392,7 @@ impl fmt::Debug for Global {
         f.debug_struct("Global").finish()
     }
 }
+
+// Force the Rust compiler to compute `Send + Sync` for `Global`, which can avoid `recursion_limit`
+// issues in the resolver.
+static_assertions::assert_not_impl_any!(Global: Send, Sync);

--- a/wgpu-core-remote/src/global/mod.rs
+++ b/wgpu-core-remote/src/global/mod.rs
@@ -1,6 +1,7 @@
 use alloc::sync::Arc;
 use core::cell::RefCell;
 use core::fmt;
+use core::marker::PhantomData;
 use wgpu_core::binding_model::{BindGroup, BindGroupLayout, PipelineLayout};
 use wgpu_core::command::{
     CommandBuffer, CommandEncoder, ComputePass, RenderBundle, RenderBundleEncoder, RenderPass,
@@ -40,6 +41,7 @@ pub struct Global {
     pub(crate) hub: RefCell<Hub>,
     // the instance must be dropped last
     pub instance: Arc<Instance>,
+    _prevent_send_and_sync: PhantomData<*const ()>,
 }
 
 impl Global {
@@ -51,6 +53,7 @@ impl Global {
         Self {
             instance: Instance::new(name, instance_desc, telemetry),
             hub: RefCell::new(Hub::new()),
+            _prevent_send_and_sync: PhantomData,
         }
     }
 
@@ -58,6 +61,7 @@ impl Global {
         Self {
             instance,
             hub: RefCell::new(Hub::new()),
+            _prevent_send_and_sync: PhantomData,
         }
     }
 

--- a/wgpu-core/src/lib.rs
+++ b/wgpu-core/src/lib.rs
@@ -7,8 +7,6 @@
 //!
 
 #![no_std]
-// `-Znext-solver` requires deeper recursion limits (at least for now) to prove Send/Sync
-#![recursion_limit = "256"]
 // When we have no backends, we end up with a lot of dead or otherwise unreachable code.
 #![cfg_attr(
     all(

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -36,8 +36,6 @@
 #![doc = crate::macros::doc_image!("render_coordinates.webp")]
 #![doc = crate::macros::doc_image!("texture_coordinates.webp")]
 #![no_std]
-// `-Znext-solver` requires deeper recursion limits (at least for now) to prove Send/Sync
-#![recursion_limit = "256"]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/gfx-rs/wgpu/trunk/logo.png")]
 #![warn(


### PR DESCRIPTION
**Connections**

- Prompted by discussion in #9953 and the 2026-08-26 wgpu maintainers' meeting.
- See also an opting _in_ to `Send` and `Sync` for other types in #10177.

**Description**

Now that `Global` is only intended to be consumed by downstreams who will be using from a single thread, we'd like to be conservative with what we promise for it. Opt out of `Send` and `Sync` for `Global` by adding a `PhantomData<*const ()>` member for it.

N.B. that this also includes the replacement of an NBSP, lifted from @nazar-pc's contribution in #9953 (which ended up being retarget to `v30` instead of `trunk`).

**Testing**

An according `assert_not_impl_any!(…)` call has been added to `wgpu-core-remote`.

**Squash or Rebase?** Rebase.

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] ~~WebGPU implementations built with `wgpu` may be affected behaviorally.~~ Not at all.
- [x] ~~Validation and feature gates are in place to confine behavioral changes.~~ None needed.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] ~~`CHANGELOG.md` entries for the user-facing effects of this change are present.~~ Typical `wgpu` downstreams won't use `Global` any more, so I didn't add an entry.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
