### PR TITLE
perf(core): allocate the zero buffer on first use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ By @sagudev in [#10115](https://github.com/gfx-rs/wgpu/pull/10115).
 
 #### General
 
+- The 512 KiB buffer used to zero-initialize resources is now allocated on first use instead of with every device. By @jlucaso1 in [#10182](https://github.com/gfx-rs/wgpu/pull/10182).
 - Allow `set_immediates` before `set_pipeline` by deferring actual setting of immediates to draw/dispatch call time. By @beicause in [#9597](https://github.com/gfx-rs/wgpu/pull/9597).
 - Validate pipeline layout `immediate_size` and fix its calculation when there are multiple immediate variables. Now it must be >= required size of the shader entry point. By @beicause in [#9711](https://github.com/gfx-rs/wgpu/pull/9711).
 - [`immediate_address_space`](https://www.w3.org/TR/WGSL/#language_extension-immediate_address_space) WGSL language extension is implemented. By @beicause in [#9711](https://github.com/gfx-rs/wgpu/pull/9711).

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -87,6 +87,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         VERTEX_BUFFER_TAIL_INIT_MAP_WRITE_MAPPED_AT_CREATION,
         COPY_TEXTURE_TO_BUFFER_UNALIGNED_OFFSET_ROW_PADDING_INIT,
         COPY_TEXTURE_TO_BUFFER_UNALIGNED_OFFSET_IMAGE_PADDING_INIT,
+        ZERO_BUFFER_IS_ALLOCATED_LAZILY,
     ]);
 }
 
@@ -2822,3 +2823,64 @@ async fn test_copy_texture_to_buffer_padding_init(
         "the destination buffer of copies from a never-written texture is not all zero",
     );
 }
+
+/// The zero buffer costs half a megabyte of GPU memory, so it must not be
+/// allocated until something actually needs zero-initialization.
+#[apply(gpu_test!)]
+static ZERO_BUFFER_IS_ALLOCATED_LAZILY: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default())
+    .run_sync(|ctx| {
+        fn zero_buffer_size(device: &Device) -> Option<u64> {
+            let report = device.generate_allocator_report()?;
+            Some(
+                report
+                    .allocations
+                    .iter()
+                    .filter(|allocation| allocation.name.contains("zero init buffer"))
+                    .map(|allocation| allocation.size)
+                    .sum(),
+            )
+        }
+
+        let Some(size) = zero_buffer_size(&ctx.device) else {
+            return;
+        };
+        assert_eq!(size, 0, "a fresh device allocated the zero buffer");
+
+        let texture = ctx.device.create_texture(&TextureDescriptor {
+            label: None,
+            size: Extent3d {
+                width: 64,
+                height: 64,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: TextureDimension::D2,
+            format: TextureFormat::Rgba8Unorm,
+            usage: TextureUsages::COPY_DST | TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        ctx.queue.write_texture(
+            texture.as_image_copy(),
+            &[0u8; 4 * 16 * 16],
+            TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(4 * 16),
+                rows_per_image: Some(16),
+            },
+            Extent3d {
+                width: 16,
+                height: 16,
+                depth_or_array_layers: 1,
+            },
+        );
+        ctx.queue.submit([]);
+        ctx.device.poll(PollType::wait_indefinitely()).unwrap();
+
+        assert_ne!(
+            zero_buffer_size(&ctx.device),
+            Some(0),
+            "a partial write did not allocate the zero buffer"
+        );
+    });

--- a/wgpu-core/src/command/clear.rs
+++ b/wgpu-core/src/command/clear.rs
@@ -293,7 +293,7 @@ pub(super) fn clear_texture_cmd(
         state.raw_encoder,
         &mut state.tracker.textures,
         &state.device.alignments,
-        state.device.zero_buffer.as_ref(),
+        state.device.zero_buffer()?,
         state.snatch_guard,
         state.device.instance_flags,
     )?;

--- a/wgpu-core/src/command/compute.rs
+++ b/wgpu-core/src/command/compute.rs
@@ -895,7 +895,8 @@ pub(super) fn encode_compute_pass(
         &mut parent_state.tracker.textures,
         device,
         parent_state.snatch_guard,
-    );
+    )
+    .map_pass_err(pass_scope)?;
     CommandEncoder::insert_barriers_from_tracker(
         transit,
         parent_state.tracker,

--- a/wgpu-core/src/command/memory_init.rs
+++ b/wgpu-core/src/command/memory_init.rs
@@ -192,7 +192,7 @@ pub(crate) fn fixup_discarded_surfaces<InitIter: Iterator<Item = TextureSurfaceD
     texture_tracker: &mut TextureTracker,
     device: &Device,
     snatch_guard: &SnatchGuard<'_>,
-) {
+) -> Result<(), DeviceError> {
     for init in inits {
         let (layer_range, depth_slice) = if init.texture.desc.dimension == wgt::TextureDimension::D3
         {
@@ -213,12 +213,13 @@ pub(crate) fn fixup_discarded_surfaces<InitIter: Iterator<Item = TextureSurfaceD
             encoder,
             texture_tracker,
             &device.alignments,
-            device.zero_buffer.as_ref(),
+            device.zero_buffer()?,
             snatch_guard,
             device.instance_flags,
         )
         .unwrap();
     }
+    Ok(())
 }
 
 impl BakedCommands {
@@ -397,7 +398,7 @@ impl BakedCommands {
                     self.encoder.raw.as_mut(),
                     &mut device_tracker.textures,
                     &device.alignments,
-                    device.zero_buffer.as_ref(),
+                    device.zero_buffer()?,
                     snatch_guard,
                     device.instance_flags,
                 );
@@ -475,7 +476,7 @@ impl BakedCommands {
                 self.encoder.raw.as_mut(),
                 &mut device_tracker.textures,
                 &device.alignments,
-                device.zero_buffer.as_ref(),
+                device.zero_buffer()?,
                 snatch_guard,
                 device.instance_flags,
             );

--- a/wgpu-core/src/command/render.rs
+++ b/wgpu-core/src/command/render.rs
@@ -2688,7 +2688,8 @@ pub(super) fn encode_render_pass(
             &mut tracker.textures,
             device,
             parent_state.snatch_guard,
-        );
+        )
+        .map_pass_err(pass_scope)?;
 
         pending_query_resets
             .reset_queries(transit, parent_state.snatch_guard)

--- a/wgpu-core/src/command/transfer.rs
+++ b/wgpu-core/src/command/transfer.rs
@@ -700,7 +700,7 @@ fn handle_texture_init(
                 state.raw_encoder,
                 &mut state.tracker.textures,
                 &state.device.alignments,
-                state.device.zero_buffer.as_ref(),
+                state.device.zero_buffer()?,
                 state.snatch_guard,
                 state.device.instance_flags,
             )?;

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -74,33 +74,7 @@ impl Queue {
             }
         };
 
-        let mut pending_writes = PendingWrites::new(pending_encoder, instance_flags);
-
-        let zero_buffer = device.zero_buffer.as_ref();
-        pending_writes.activate();
-        unsafe {
-            pending_writes
-                .command_encoder
-                .transition_buffers(&[hal::BufferBarrier {
-                    buffer: zero_buffer,
-                    usage: hal::StateTransition {
-                        from: wgt::BufferUses::empty(),
-                        to: wgt::BufferUses::COPY_DST,
-                    },
-                }]);
-            pending_writes
-                .command_encoder
-                .clear_buffer(zero_buffer, 0..super::ZERO_BUFFER_SIZE);
-            pending_writes
-                .command_encoder
-                .transition_buffers(&[hal::BufferBarrier {
-                    buffer: zero_buffer,
-                    usage: hal::StateTransition {
-                        from: wgt::BufferUses::COPY_DST,
-                        to: wgt::BufferUses::COPY_SRC,
-                    },
-                }]);
-        }
+        let pending_writes = PendingWrites::new(pending_encoder, instance_flags);
 
         Ok(Queue {
             raw,
@@ -146,6 +120,8 @@ impl Queue {
         let mut pending_writes = self.pending_writes.lock();
 
         if needs_clear {
+            let zero_buffer = device.zero_buffer()?;
+            device.clear_zero_buffer_if_needed(&mut pending_writes);
             // After encoding the clear operation, we must not return without
             // adding the texture to `pending_writes`.
             let encoder = pending_writes.activate();
@@ -160,7 +136,7 @@ impl Queue {
                 encoder,
                 &mut trackers.textures,
                 &device.alignments,
-                device.zero_buffer.as_ref(),
+                zero_buffer,
                 &submission.snatch_guard,
                 device.instance_flags,
             )
@@ -485,6 +461,10 @@ impl PendingWrites {
         device: &Arc<Device>,
         queue: &Queue,
     ) -> Result<Option<EncoderInFlight>, DeviceError> {
+        // Pending writes go in ahead of every other command buffer in the
+        // submission, so this covers uses recorded outside of them.
+        device.clear_zero_buffer_if_needed(self);
+
         if self.is_recording {
             let pending_buffers = mem::take(&mut self.dst_buffers);
             let pending_textures = mem::take(&mut self.dst_textures);
@@ -1049,7 +1029,6 @@ impl Queue {
         }
 
         let mut pending_writes = self.pending_writes.lock();
-        let encoder = pending_writes.activate();
 
         // If the copy does not fully cover the layers, we need to initialize to
         // zero *first* as we don't keep track of partial texture layer inits.
@@ -1082,6 +1061,9 @@ impl Queue {
             }
         };
         if !layer_ranges_to_clear.is_empty() {
+            let zero_buffer = self.device.zero_buffer()?;
+            self.device.clear_zero_buffer_if_needed(&mut pending_writes);
+            let encoder = pending_writes.activate();
             let mut trackers = self.device.trackers.lock();
             for layer_range in layer_ranges_to_clear {
                 crate::command::clear_texture(
@@ -1094,7 +1076,7 @@ impl Queue {
                     encoder,
                     &mut trackers.textures,
                     &self.device.alignments,
-                    self.device.zero_buffer.as_ref(),
+                    zero_buffer,
                     &snatch_guard,
                     self.device.instance_flags,
                 )
@@ -1193,6 +1175,7 @@ impl Queue {
                 },
             };
 
+            let encoder = pending_writes.activate();
             let mut trackers = self.device.trackers.lock();
             let transition =
                 trackers
@@ -1338,7 +1321,6 @@ impl Queue {
         }
 
         let mut pending_writes = self.pending_writes.lock();
-        let encoder = pending_writes.activate();
 
         // If the copy does not fully cover the layers, we need to initialize to
         // zero *first* as we don't keep track of partial texture layer inits.
@@ -1371,6 +1353,9 @@ impl Queue {
             }
         };
         if !layer_ranges_to_clear.is_empty() {
+            let zero_buffer = self.device.zero_buffer()?;
+            self.device.clear_zero_buffer_if_needed(&mut pending_writes);
+            let encoder = pending_writes.activate();
             let mut trackers = self.device.trackers.lock();
             for layer_range in layer_ranges_to_clear {
                 crate::command::clear_texture(
@@ -1383,7 +1368,7 @@ impl Queue {
                     encoder,
                     &mut trackers.textures,
                     &self.device.alignments,
-                    self.device.zero_buffer.as_ref(),
+                    zero_buffer,
                     &snatch_guard,
                     self.device.instance_flags,
                 )
@@ -1402,6 +1387,7 @@ impl Queue {
             size: hal_copy_size,
         };
 
+        let encoder = pending_writes.activate();
         let mut trackers = self.device.trackers.lock();
         let transitions = trackers
             .textures
@@ -1896,10 +1882,9 @@ impl Queue {
                 .textures
                 .set_from_usage_scope_and_drain_transitions(&used_surface_textures, &snatch_guard)
                 .collect::<Vec<_>>();
+            let encoder = pending_writes.activate();
             unsafe {
-                pending_writes
-                    .command_encoder
-                    .transition_textures(&texture_barriers);
+                encoder.transition_textures(&texture_barriers);
             };
         }
 

--- a/wgpu-core/src/device/ray_tracing.rs
+++ b/wgpu-core/src/device/ray_tracing.rs
@@ -61,6 +61,7 @@ impl Device {
             self.require_features(Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN)?;
         }
 
+        let zero_buffer = self.zero_buffer()?;
         let size_info = match &sizes {
             wgt::BlasGeometrySizeDescriptors::Triangles { descriptors } => {
                 if descriptors.len() as u32 > self.limits.max_blas_geometry_count {
@@ -84,7 +85,7 @@ impl Device {
                                 dyn hal::DynBuffer,
                             > {
                                 format: desc.index_format.unwrap(),
-                                buffer: Some(self.zero_buffer.as_ref()),
+                                buffer: Some(zero_buffer),
                                 offset: 0,
                                 count,
                             });
@@ -106,7 +107,7 @@ impl Device {
                         .contains(wgt::AccelerationStructureFlags::USE_TRANSFORM)
                     {
                         transform = Some(wgpu_hal::AccelerationStructureTriangleTransform {
-                            buffer: self.zero_buffer.as_ref(),
+                            buffer: zero_buffer,
                             offset: 0,
                         })
                     }
@@ -119,7 +120,7 @@ impl Device {
                     }
 
                     entries.push(hal::AccelerationStructureTriangles::<dyn hal::DynBuffer> {
-                        vertex_buffer: Some(self.zero_buffer.as_ref()),
+                        vertex_buffer: Some(zero_buffer),
                         vertex_format: desc.vertex_format,
                         first_vertex: 0,
                         vertex_count: desc.vertex_count,
@@ -159,7 +160,7 @@ impl Device {
                     }
 
                     entries.push(hal::AccelerationStructureAABBs::<dyn hal::DynBuffer> {
-                        buffer: Some(self.zero_buffer.as_ref()),
+                        buffer: Some(zero_buffer),
                         offset: 0,
                         count: desc.primitive_count,
                         stride: AABB_GEOMETRY_MIN_STRIDE,
@@ -286,12 +287,13 @@ impl Device {
             self.require_features(Features::EXPERIMENTAL_RAY_HIT_VERTEX_RETURN)?;
         }
 
+        let zero_buffer = self.zero_buffer()?;
         let size_info = unsafe {
             self.raw().get_acceleration_structure_build_sizes(
                 &hal::GetAccelerationStructureBuildSizesDescriptor {
                     entries: &hal::AccelerationStructureEntries::Instances(
                         hal::AccelerationStructureInstances {
-                            buffer: Some(self.zero_buffer.as_ref()),
+                            buffer: Some(zero_buffer),
                             offset: 0,
                             count: desc.max_instances,
                         },

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -62,8 +62,9 @@ use crate::{
 };
 
 use super::{
-    queue::Queue, DeviceDescriptor, DeviceError, DeviceLostClosure, UserClosures,
-    ENTRYPOINT_FAILURE_ERROR, ZERO_BUFFER_SIZE,
+    queue::{PendingWrites, Queue},
+    DeviceDescriptor, DeviceError, DeviceLostClosure, UserClosures, ENTRYPOINT_FAILURE_ERROR,
+    ZERO_BUFFER_SIZE,
 };
 
 #[cfg(supports_64bit_atomics)]
@@ -245,7 +246,8 @@ pub struct Device {
     raw: Box<dyn hal::DynDevice>,
     pub(crate) adapter: Arc<Adapter>,
     pub(crate) queue: OnceCell<Weak<Queue>>,
-    pub(crate) zero_buffer: ManuallyDrop<Box<dyn hal::DynBuffer>>,
+    zero_buffer: OnceCell<Box<dyn hal::DynBuffer>>,
+    zero_buffer_needs_clear: AtomicBool,
     pub(crate) empty_bgl: ManuallyDrop<Box<dyn hal::DynBindGroupLayout>>,
     /// The `label` from the descriptor used to create the resource.
     label: String,
@@ -381,9 +383,6 @@ impl Drop for Device {
         // Transfer the rest of the resources back to `DeviceResources`, which cleans them
         // up for us.
 
-        // SAFETY: We are in the Drop impl and we don't use self.zero_buffer anymore after this
-        // point.
-        let zero_buffer = unsafe { ManuallyDrop::take(&mut self.zero_buffer) };
         // SAFETY: We are in the Drop impl and we don't use self.empty_bgl anymore after this point.
         let empty_bgl = unsafe { ManuallyDrop::take(&mut self.empty_bgl) };
         // SAFETY: We are in the Drop impl and we don't use
@@ -395,7 +394,7 @@ impl Drop for Device {
 
         drop(DeviceResources {
             raw: self.raw.as_ref(),
-            zero_buffer: Some(zero_buffer),
+            zero_buffer: self.zero_buffer.take(),
             empty_bgl: Some(empty_bgl),
             default_external_texture_params_buffer: Some(default_external_texture_params_buffer),
             fence: Some(fence),
@@ -405,6 +404,71 @@ impl Drop for Device {
 }
 
 impl Device {
+    /// Source of zeroed bytes for resource initialization, created on first use.
+    /// It only reads as zeroes once [`Device::clear_zero_buffer_if_needed`] has
+    /// encoded the clear.
+    pub(crate) fn zero_buffer(&self) -> Result<&dyn hal::DynBuffer, DeviceError> {
+        let zero_buffer = self
+            .zero_buffer
+            .get_or_try_init(|| -> Result<_, DeviceError> {
+                let rt_uses = if self
+                    .features
+                    .intersects(wgt::Features::EXPERIMENTAL_RAY_QUERY)
+                {
+                    wgt::BufferUses::TOP_LEVEL_ACCELERATION_STRUCTURE_INPUT
+                } else {
+                    wgt::BufferUses::empty()
+                };
+                let buffer = unsafe {
+                    self.raw.create_buffer(&hal::BufferDescriptor {
+                        label: hal_label(
+                            Some("(wgpu internal) zero init buffer"),
+                            self.instance_flags,
+                        ),
+                        size: ZERO_BUFFER_SIZE,
+                        usage: wgt::BufferUses::COPY_SRC | wgt::BufferUses::COPY_DST | rt_uses,
+                        memory_flags: hal::MemoryFlags::empty(),
+                    })
+                }
+                .map_err(|e| self.handle_hal_error(e))?;
+                self.zero_buffer_needs_clear.store(true, Ordering::Relaxed);
+                Ok(buffer)
+            })?;
+        Ok(zero_buffer.as_ref())
+    }
+
+    /// Encodes the clear that [`Device::zero_buffer`] still owes, if any. Callers
+    /// recording a use of it into `pending_writes` must call this first, so that
+    /// the clear precedes that use in the same command buffer.
+    pub(crate) fn clear_zero_buffer_if_needed(&self, pending_writes: &mut PendingWrites) {
+        let Some(zero_buffer) = self.zero_buffer.get() else {
+            return;
+        };
+        if !self.zero_buffer_needs_clear.swap(false, Ordering::Relaxed) {
+            return;
+        }
+
+        let zero_buffer = zero_buffer.as_ref();
+        let encoder = pending_writes.activate();
+        unsafe {
+            encoder.transition_buffers(&[hal::BufferBarrier {
+                buffer: zero_buffer,
+                usage: hal::StateTransition {
+                    from: wgt::BufferUses::empty(),
+                    to: wgt::BufferUses::COPY_DST,
+                },
+            }]);
+            encoder.clear_buffer(zero_buffer, 0..ZERO_BUFFER_SIZE);
+            encoder.transition_buffers(&[hal::BufferBarrier {
+                buffer: zero_buffer,
+                usage: hal::StateTransition {
+                    from: wgt::BufferUses::COPY_DST,
+                    to: wgt::BufferUses::COPY_SRC,
+                },
+            }]);
+        }
+    }
+
     pub fn features(&self) -> &wgt::Features {
         &self.features
     }
@@ -549,28 +613,6 @@ impl Device {
 
         let command_allocator = command::CommandAllocator::new();
 
-        let rt_uses = if desc
-            .required_features
-            .intersects(wgt::Features::EXPERIMENTAL_RAY_QUERY)
-        {
-            wgt::BufferUses::TOP_LEVEL_ACCELERATION_STRUCTURE_INPUT
-        } else {
-            wgt::BufferUses::empty()
-        };
-
-        // Create zeroed buffer used for texture clears (and raytracing if required).
-        resources.zero_buffer = Some(
-            unsafe {
-                raw_device.create_buffer(&hal::BufferDescriptor {
-                    label: hal_label(Some("(wgpu internal) zero init buffer"), instance_flags),
-                    size: ZERO_BUFFER_SIZE,
-                    usage: wgt::BufferUses::COPY_SRC | wgt::BufferUses::COPY_DST | rt_uses,
-                    memory_flags: hal::MemoryFlags::empty(),
-                })
-            }
-            .map_err(DeviceError::from_hal)?,
-        );
-
         resources.empty_bgl = Some(
             unsafe {
                 raw_device.create_bind_group_layout(&hal::BindGroupLayoutDescriptor {
@@ -623,7 +665,6 @@ impl Device {
         // Error returns after this point could bypass resource cleanup.
         #[deny(clippy::question_mark_used)]
         {
-            let zero_buffer = resources.zero_buffer.take().unwrap();
             let empty_bgl = resources.empty_bgl.take().unwrap();
             let default_external_texture_params_buffer = resources
                 .default_external_texture_params_buffer
@@ -637,7 +678,8 @@ impl Device {
                 raw: raw_device,
                 adapter: adapter.clone(),
                 queue: OnceCell::new(),
-                zero_buffer: ManuallyDrop::new(zero_buffer),
+                zero_buffer: OnceCell::new(),
+                zero_buffer_needs_clear: AtomicBool::new(false),
                 empty_bgl: ManuallyDrop::new(empty_bgl),
                 default_external_texture_params_buffer: ManuallyDrop::new(
                     default_external_texture_params_buffer,
@@ -728,17 +770,16 @@ impl Device {
         let queue = self.get_queue().unwrap();
         let mut pending_writes = queue.pending_writes.lock();
 
+        let encoder = pending_writes.activate();
         unsafe {
-            pending_writes
-                .command_encoder
-                .transition_buffers(&[hal::BufferBarrier {
-                    buffer: params_buffer,
-                    usage: hal::StateTransition {
-                        from: wgt::BufferUses::MAP_WRITE,
-                        to: wgt::BufferUses::COPY_DST,
-                    },
-                }]);
-            pending_writes.command_encoder.copy_buffer_to_buffer(
+            encoder.transition_buffers(&[hal::BufferBarrier {
+                buffer: params_buffer,
+                usage: hal::StateTransition {
+                    from: wgt::BufferUses::MAP_WRITE,
+                    to: wgt::BufferUses::COPY_DST,
+                },
+            }]);
+            encoder.copy_buffer_to_buffer(
                 staging_buffer.raw(),
                 params_buffer,
                 &[hal::BufferCopy {
@@ -747,17 +788,15 @@ impl Device {
                     size: staging_buffer.size,
                 }],
             );
-            pending_writes.consume(staging_buffer);
-            pending_writes
-                .command_encoder
-                .transition_buffers(&[hal::BufferBarrier {
-                    buffer: params_buffer,
-                    usage: hal::StateTransition {
-                        from: wgt::BufferUses::COPY_DST,
-                        to: wgt::BufferUses::UNIFORM,
-                    },
-                }]);
+            encoder.transition_buffers(&[hal::BufferBarrier {
+                buffer: params_buffer,
+                usage: hal::StateTransition {
+                    from: wgt::BufferUses::COPY_DST,
+                    to: wgt::BufferUses::UNIFORM,
+                },
+            }]);
         }
+        pending_writes.consume(staging_buffer);
 
         Ok(())
     }


### PR DESCRIPTION
`Device::new` created a `ZERO_BUFFER_SIZE` (512 KiB) buffer for every device, and `Queue::new` encoded the clear that zeroes it. Applications that never trigger zero-initialization pay for it anyway. On a small GPUI application it accounted for 28% of everything the app allocated on the GPU.

The buffer is now created on first use. The clear stays anchored to the queue's pending writes, which are always inserted at index 0 of a submission, so it still precedes any use recorded in a user command buffer. Callers that record a use into pending writes themselves encode the clear first, so it precedes that use within the same command buffer.

Measured on Vulkan with `Device::generate_allocator_report()`:

| | before | after |
| --- | --- | --- |
| freshly created device | 524 816 B | 528 B |
| after a partial `write_texture` | 544 584 B | 544 584 B |

Two places relied on `Queue::new` having called `PendingWrites::activate()` and recorded into an unopened encoder once that call went away: `late_init_resources_with_queue`, which segfaulted in `request_device`, and the surface texture transition in `submit_pending_submission`. Both now call `activate()`.

`fixup_discarded_surfaces` returns `Result<(), DeviceError>` because obtaining the zero buffer can now fail.

`zero_buffer_is_allocated_lazily` covers the new behaviour and fails against the previous code with `a fresh device allocated the zero buffer`. It skips backends that do not report allocations.

Tested on Linux: `cargo test -p wgpu-core` (59 passed), `cargo clippy --tests`, `cargo fmt --check`, and `cargo nextest run -p wgpu-test --test wgpu-gpu` compared against trunk. The set of failing tests is identical before and after, so no regressions; the failures on this machine are pre-existing and concentrated in the GL backend. DX12, Metal and CTS were not exercised.
