### PR TITLE
fix(core): Free prepared ids that are never assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Bottom level categories:
 #### General
 
 - Explicitly implement `Send` and `Sync` in `wgpu-core` to reduce the risk of `recursion_limit` overflow. By @nazar-pc in [#9953](https://github.com/gfx-rs/wgpu/pull/9953)
+- Fix a texture id leak when surface acquire returns no texture. By @jnb in [#10184](https://github.com/gfx-rs/wgpu/pull/10184).
 
 ## v30.0.1 (2026-08-21)
 

--- a/wgpu-core/src/registry.rs
+++ b/wgpu-core/src/registry.rs
@@ -63,6 +63,7 @@ impl<T: StorageItem> Registry<T> {
 #[must_use]
 pub(crate) struct FutureId<'a, T: StorageItem> {
     id: Id<T::Marker>,
+    identity: &'a IdentityManager<T::Marker>,
     data: &'a RwLock<Storage<T>>,
 }
 
@@ -73,7 +74,17 @@ impl<T: StorageItem> FutureId<'_, T> {
     pub fn assign(self, value: T) -> Id<T::Marker> {
         let mut data = self.data.write();
         data.insert(self.id, value);
-        self.id
+        // Assigned ids are freed by `Registry::remove`, not `Drop`.
+        let id = self.id;
+        core::mem::forget(self);
+        id
+    }
+}
+
+/// Free the id if it was never assigned, so that its index can be reused.
+impl<T: StorageItem> Drop for FutureId<'_, T> {
+    fn drop(&mut self) {
+        self.identity.free(self.id);
     }
 }
 
@@ -87,6 +98,7 @@ impl<T: StorageItem> Registry<T> {
                 }
                 None => self.identity.process(),
             },
+            identity: &self.identity,
             data: &self.storage,
         }
     }
@@ -168,5 +180,18 @@ mod tests {
                 });
             }
         })
+    }
+
+    #[test]
+    fn dropped_ids_are_reused() {
+        let registry = Registry::new();
+
+        let fid = registry.prepare(None);
+        let index = fid.id.unzip().0;
+        drop(fid);
+
+        let fid = registry.prepare(None);
+        assert_eq!(fid.id.unzip().0, index);
+        fid.assign(Arc::new(TestData));
     }
 }


### PR DESCRIPTION
**Connections**

No issue filed; found via memory profiling of a production application. This bug is specific to the v30 release line: the `wgpu-core-remote` refactor on trunk (#10053 and follow-ups) eliminated the id-before-acquire pattern, so this PR targets the `v30` branch only.

**Description**

`Global::surface_get_current_texture` allocates a texture id before calling `Surface::get_current_texture`. When the acquire fails or succeeds without a texture (e.g. `Occluded`), the `FutureId` is dropped, permanently leaking its index. Repeated drops drain the free list, so allocations bump `next_index` instead; each successful assign then grows the registry's storage vector.

In production, an application that kept polling `get_current_texture` on an occluded surface at display rate (~60 ids/second) grew the mostly-vacant storage vector to 128 MB over a 21-hour run.

The fix implements `Drop` for `FutureId`, returning an unassigned prepared id to the allocator automatically; `assign` skips the drop with `mem::forget`.

Happy to rework this however fits, or to close it if the v30 branch isn't expected to receive further patch releases.

**Testing**

- New registry unit test `dropped_ids_are_reused`: a dropped id's index is handed out again by the next `prepare` and is usable by `assign` (`cargo test -p wgpu-core`).
- Validated in the production application that surfaced the leak: with this fix, its Rust heap has been flat over a nine-day continuous run, versus steady growth (~5 MB/hour) before.

**Squash or Rebase?**

Single commit.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.