### PR TITLE
wgpu-types: fix cast_elements documentation

### DIFF
--- a/wgpu-types/src/write_only.rs
+++ b/wgpu-types/src/write_only.rs
@@ -648,7 +648,7 @@ impl<'a, T> WriteOnly<'a, [T]> {
     /// or if the alignment of type `U` is greater than the alignment of type `T`.
     ///
     /// This panic occurs regardless of the run-time length or alignment of the slice;
-    /// any call to `cast_elements()` with a particular type `T` and typ` U` will
+    /// any call to `cast_elements()` with particular types `T` and `U` will
     /// either always succeed or always fail.
     #[inline]
     #[track_caller]


### PR DESCRIPTION
**Connections**

None.

**Description**

Fix the malformed type names in the `WriteOnly::cast_elements` safety explanation. The sentence now consistently refers to “particular types `T` and `U`”, making the aliasing argument readable in generated API documentation.

**Testing**

- `cargo clippy -p wgpu-types --lib`
- `cargo fmt --all -- --check`

**Squash or Rebase?**

Single commit, ready to rebase.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] The PR is minimal and does not make sense to split.
- [x] The PR description contains the motivation and solution.
- [ ] WebGPU implementations are affected behaviorally (not applicable).
- [ ] Changelog entry (not applicable: documentation-only).