### PR TITLE
perf(core): Inline small bind group descriptor storage

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3696,7 +3696,6 @@ impl Device {
             }
         }
 
-        // TODO: arrayvec/smallvec, or re-use allocations
         // Record binding info for dynamic offset validation
         let mut dynamic_binding_info = Vec::new();
         // Map of binding -> shader reflected size
@@ -3708,13 +3707,13 @@ impl Device {
 
         let mut buffer_init_actions = Vec::new();
         let mut texture_init_actions = Vec::new();
-        let mut hal_entries = Vec::with_capacity(desc.entries.len());
-        let mut hal_buffers = Vec::new();
-        let mut hal_samplers = Vec::new();
-        let mut hal_textures = Vec::new();
-        let mut hal_tlas_s = Vec::new();
-        let mut hal_external_textures = Vec::new();
         let snatch_guard = self.snatchable_lock.read();
+        let mut hal_entries = SmallVec::<[_; 4]>::with_capacity(desc.entries.len());
+        let mut hal_buffers = SmallVec::<[_; 1]>::new();
+        let mut hal_samplers = SmallVec::<[_; 1]>::new();
+        let mut hal_textures = SmallVec::<[_; 8]>::new();
+        let mut hal_tlas_s = SmallVec::<[_; 1]>::new();
+        let mut hal_external_textures = SmallVec::<[_; 1]>::new();
         for entry in desc.entries.iter() {
             let binding = entry.binding;
             // Find the corresponding declaration in the layout


### PR DESCRIPTION
**Description**

Bind group creation previously allocated several temporary vectors while assembling the HAL bind group descriptor. These vectors are discarded immediately after the HAL bind group is created.

This replaces those vectors with `SmallVec` using inline capacities suited to common small bind groups:
- Four descriptor entries
- Eight texture bindings
- One inline binding for each other resource type

Larger bind groups automatically fall back to heap storage, preserving existing behavior without imposing a fixed limit. For the five-texture case, this avoids the temporary descriptor-entry allocation and the texture-binding allocation and growth. The existing `Device::create_bind_group` benchmark was run for ten seconds per case on Vulkan using an NVIDIA GeForce GTX 1650 SUPER.

| Five textures | Before | After | Change |
| --- | ---: | ---: | ---: |
| Latency | 3.290 µs | 2.824 µs | -14.16% |
| Throughput | 1.52M bindings/s | 1.77M bindings/s | +16.50% |

Repeated runs showed a 14.2–15.1% latency reduction for the common case. Larger cases exercise the heap fallback and showed no repeatable regression.

This is an internal implementation change and does not alter any public API or observable behavior.

**Testing**
- `cargo +stable test -p wgpu-core`
  - 59 passed
- `cargo +stable test -p wgpu-test --test wgpu-validation`
  - 98 passed, including binding arrays and external textures
- `cargo +stable clippy --tests`
- `cargo +stable fmt -p wgpu-core -- --check`
- `cargo +stable bench -p wgpu-benchmark --bench wgpu-benchmark -- --exact "Device::create_bind_group" --time 10`

The benchmark also exercised heap-fallback cases containing up to 50,000 textures.

**Squash or Rebase?**
Ready to rebase as a single commit.

**Checklist**
- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the existing behavior still works.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.