### PR TITLE
POLYGON_MODE_LINE and POLYGON_MODE_POINT are supported on desktop OpenGL

### DIFF
--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -922,7 +922,7 @@ bitflags_array! {
         /// - DX12
         /// - Vulkan
         /// - Metal
-        /// - OpenGL
+        /// - OpenGL (not GLES)
         ///
         /// This is a native only feature.
         ///
@@ -936,7 +936,7 @@ bitflags_array! {
         ///
         /// Supported platforms:
         /// - Vulkan
-        /// - OpenGL
+        /// - OpenGL (not GLES)
         ///
         /// This is a native only feature.
         ///

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -922,6 +922,7 @@ bitflags_array! {
         /// - DX12
         /// - Vulkan
         /// - Metal
+        /// - OpenGL
         ///
         /// This is a native only feature.
         ///
@@ -935,6 +936,7 @@ bitflags_array! {
         ///
         /// Supported platforms:
         /// - Vulkan
+        /// - OpenGL
         ///
         /// This is a native only feature.
         ///


### PR DESCRIPTION
**Connections**

**Description**

Both `POLYGON_MODE_LINE` and `POLYGON_MODE_POINT` are exposed by OpenGL (not ES):
https://github.com/gfx-rs/wgpu/blob/87a57fb330f162854dac13873a669d2436e6bf7d/wgpu-hal/src/gles/adapter.rs#L640


**Testing**

**Squash or Rebase?**

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
