### PR TITLE
Enable `clippy::allow_attributes` and `clippy::allow_attributes_without_reason`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,10 @@ missing_debug_implementations = "warn"
 
 [workspace.lints.clippy]
 ref_as_ptr = "warn"
+allow_attributes = "warn"
+allow_attributes_without_reason = "warn"
 # NOTE: clippy configuration values (disallowed-types and
 # large-error-threshold) are in other file: clippy.toml
-
 [workspace.package]
 edition = "2021"
 rust-version = "1.93"

--- a/deno_webgpu/error.rs
+++ b/deno_webgpu/error.rs
@@ -325,7 +325,10 @@ pub enum GPUGenericError {
 
 pub enum GPUPipelineErrorReason {
   Validation,
-  #[expect(dead_code)]
+  #[expect(
+    dead_code,
+    reason = "used by some feature/backend combinations or not yet wired up"
+  )]
   Internal,
 }
 

--- a/deno_webgpu/lib.rs
+++ b/deno_webgpu/lib.rs
@@ -50,7 +50,10 @@ pub const UNSTABLE_FEATURE_NAME: &str = "webgpu";
 pub const DX12_COMPILER_ENV_VAR: &str = "DENO_WEBGPU_DX12_COMPILER";
 pub const STRICT_COMPLIANCE_ENV_VAR: &str = "DENO_WEBGPU_STRICT_COMPLIANCE";
 
-#[allow(clippy::print_stdout)]
+#[allow(
+  clippy::print_stdout,
+  reason = "intended for example/user-facing output"
+)]
 pub fn print_linker_flags(name: &str) {
   if cfg!(windows) {
     // these dls load slowly, so delay loading them

--- a/examples/features/src/framework.rs
+++ b/examples/features/src/framework.rs
@@ -351,7 +351,10 @@ enum AppAction {
     },
 }
 
-#[expect(clippy::large_enum_variant)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "variant size is inherent to the schema"
+)]
 enum AppState<E> {
     /// Waiting for the first `resumed()` call.
     Uninitialized,

--- a/examples/features/src/hello_triangle/mod.rs
+++ b/examples/features/src/hello_triangle/mod.rs
@@ -35,7 +35,10 @@ enum TriangleAction {
     Initialized(WgpuState),
 }
 
-#[expect(clippy::large_enum_variant)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "variant size is inherent to the schema"
+)]
 enum AppState {
     Uninitialized,
     Loading,

--- a/examples/features/src/msaa_line/mod.rs
+++ b/examples/features/src/msaa_line/mod.rs
@@ -216,7 +216,7 @@ impl crate::framework::Example for Example {
         }
     }
 
-    #[expect(clippy::single_match)]
+    #[expect(clippy::single_match, reason = "single arm kept for readability")]
     fn update(&mut self, event: winit::event::WindowEvent) {
         match event {
             WindowEvent::KeyboardInput {

--- a/examples/features/src/ray_aabb_compute/mod.rs
+++ b/examples/features/src/ray_aabb_compute/mod.rs
@@ -47,13 +47,25 @@ fn affine_to_rows(mat: &Affine3A) -> [f32; 12] {
 
 struct Example {
     rt_target: wgpu::Texture,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     rt_view: wgpu::TextureView,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     sampler: wgpu::Sampler,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     uniform_buf: wgpu::Buffer,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     aabb_buf: wgpu::Buffer,
     tlas: wgpu::Tlas,
     compute_pipeline: wgpu::ComputePipeline,

--- a/examples/features/src/ray_cube_compute/mod.rs
+++ b/examples/features/src/ray_cube_compute/mod.rs
@@ -100,15 +100,30 @@ fn affine_to_rows(mat: &Affine3A) -> [f32; 12] {
 
 struct Example {
     rt_target: wgpu::Texture,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     rt_view: wgpu::TextureView,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     sampler: wgpu::Sampler,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     uniform_buf: wgpu::Buffer,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     vertex_buf: wgpu::Buffer,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     index_buf: wgpu::Buffer,
     tlas: wgpu::Tlas,
     compute_pipeline: wgpu::ComputePipeline,

--- a/examples/features/src/skybox/mod.rs
+++ b/examples/features/src/skybox/mod.rs
@@ -377,7 +377,7 @@ impl crate::framework::Example for Example {
         }
     }
 
-    #[expect(clippy::single_match)]
+    #[expect(clippy::single_match, reason = "single arm kept for readability")]
     fn update(&mut self, event: winit::event::WindowEvent) {
         match event {
             winit::event::WindowEvent::CursorMoved { position, .. } => {

--- a/examples/features/src/uniform_values/mod.rs
+++ b/examples/features/src/uniform_values/mod.rs
@@ -238,7 +238,10 @@ enum UniformAction {
     Initialized(WgpuContext),
 }
 
-#[expect(clippy::large_enum_variant)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "variant size is inherent to the schema"
+)]
 enum RunState {
     Uninitialized,
     Loading,

--- a/naga/src/arena/handlevec.rs
+++ b/naga/src/arena/handlevec.rs
@@ -34,7 +34,10 @@ impl<T, U> Default for HandleVec<T, U> {
     }
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "used by some feature/backend combinations or not yet wired up"
+)]
 impl<T, U> HandleVec<T, U> {
     pub(crate) const fn new() -> Self {
         Self {

--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -2425,7 +2425,10 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// # Notes
     /// Doesn't add any newlines or leading/trailing spaces
-    #[allow(clippy::large_stack_frames)] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
+    #[allow(
+        clippy::large_stack_frames,
+        reason = "legitimate recursive/stack use, tracked in #9456"
+    )] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
     fn write_expr(
         &mut self,
         expr: Handle<crate::Expression>,
@@ -4083,7 +4086,10 @@ impl<'a, W: Write> Writer<'a, W> {
     }
 
     /// Helper method for writing an `ImageLoad` expression.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn write_image_load(
         &mut self,
         handle: Handle<crate::Expression>,

--- a/naga/src/back/hlsl/mesh_shader.rs
+++ b/naga/src/back/hlsl/mesh_shader.rs
@@ -37,7 +37,10 @@ impl NestedEntryPointArgs {
 }
 
 impl<W: fmt::Write> super::Writer<'_, W> {
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn write_mesh_shader_wrapper(
         &mut self,
         module: &Module,
@@ -306,7 +309,10 @@ impl<W: fmt::Write> super::Writer<'_, W> {
     /// Mesh and task entry points must all return at the same `return` statement,
     /// so we have a nested function that can return wherever. This writes the caller,
     /// or the actual entry point.
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub(super) fn write_nested_function_outer(
         &mut self,
         module: &Module,

--- a/naga/src/back/hlsl/ray.rs
+++ b/naga/src/back/hlsl/ray.rs
@@ -242,7 +242,10 @@ impl<W: Write> super::Writer<'_, W> {
         Ok(())
     }
 
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub(super) fn write_initialize_function(
         &mut self,
         module: &crate::Module,

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -3068,7 +3068,10 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn write_math_expression(
         &mut self,
         module: &Module,
@@ -4670,7 +4673,10 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn write_image_load(
         &mut self,
         module: &&Module,

--- a/naga/src/back/mod.rs
+++ b/naga/src/back/mod.rs
@@ -241,8 +241,11 @@ impl FunctionCtx<'_> {
             }
             // This is a const function, which _sometimes_ gets called,
             // so this lint is _sometimes_ triggered, depending on feature set.
-            #[expect(clippy::allow_attributes)]
-            #[allow(clippy::panic)]
+            #[expect(
+                clippy::allow_attributes,
+                reason = "allow_attributes not yet enabled workspace-wide"
+            )]
+            #[allow(clippy::panic, reason = "panic is the intended contract here")]
             FunctionType::EntryPoint(_) => {
                 panic!("External textures cannot be used as arguments to entry points")
             }

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -2008,7 +2008,10 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn put_possibly_const_expression<C, I, E>(
         &mut self,
         expr_handle: Handle<crate::Expression>,
@@ -6119,7 +6122,10 @@ template <typename A>
         format!("{DOT_FUNCTION_PREFIX}_{type_name}{size_suffix}")
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn write_wrapped_math_function(
         &mut self,
         module: &crate::Module,
@@ -6359,7 +6365,10 @@ template <typename A>
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn write_wrapped_image_load(
         &mut self,
         module: &crate::Module,
@@ -6445,7 +6454,10 @@ template <typename A>
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn write_wrapped_image_sample(
         &mut self,
         module: &crate::Module,

--- a/naga/src/back/pipeline_constants.rs
+++ b/naga/src/back/pipeline_constants.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 // Possibly unused if not compiled with no_std
-#[allow(unused_imports)]
+#[allow(unused_imports, reason = "kept for feature-gated use")]
 use num_traits::float::FloatCore as _;
 
 #[derive(Error, Debug, Clone)]

--- a/naga/src/back/spv/block.rs
+++ b/naga/src/back/spv/block.rs
@@ -3081,7 +3081,10 @@ impl BlockContext<'_> {
     }
 
     /// Build the instructions for matrix - matrix column operations
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn write_matrix_matrix_column_op(
         &mut self,
         block: &mut Block,
@@ -3184,7 +3187,10 @@ impl BlockContext<'_> {
     /// composite_id, index)` to an instruction that extracts the `index`th
     /// entry of the value with ID `composite_id` and assigns it to the slot
     /// with id `result_id` (which must have type `result_type_id`).
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn write_dot_product(
         &mut self,
         result_id: Word,

--- a/naga/src/back/spv/helpers.rs
+++ b/naga/src/back/spv/helpers.rs
@@ -45,7 +45,10 @@ pub(super) fn debug_str_bytes_to_words(bytes: &[u8]) -> Vec<Word> {
 }
 
 /// split a string into chunks and keep utf8 valid
-#[allow(unstable_name_collisions)]
+#[allow(
+    unstable_name_collisions,
+    reason = "API naming matches the upstream unstable method"
+)]
 pub(super) fn string_to_byte_chunks(input: &str, limit: usize) -> Vec<&[u8]> {
     let mut offset: usize = 0;
     let mut start: usize = 0;
@@ -54,7 +57,10 @@ pub(super) fn string_to_byte_chunks(input: &str, limit: usize) -> Vec<&[u8]> {
         offset = input.floor_char_boundary_polyfill(offset + limit);
         // Clippy wants us to call as_bytes() first to avoid the UTF-8 check,
         // but we want to assert the output is valid UTF-8.
-        #[allow(clippy::sliced_string_as_bytes)]
+        #[allow(
+            clippy::sliced_string_as_bytes,
+            reason = "bytes form used intentionally for performance"
+        )]
         words.push(input[start..offset].as_bytes());
         start = offset;
     }

--- a/naga/src/back/spv/image.rs
+++ b/naga/src/back/spv/image.rs
@@ -719,7 +719,10 @@ impl BlockContext<'_> {
     /// Generate code for an `ImageLoad` expression.
     ///
     /// The arguments are the components of an `Expression::ImageLoad` variant.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub(super) fn write_image_load(
         &mut self,
         result_type_id: Word,
@@ -799,7 +802,10 @@ impl BlockContext<'_> {
     /// Generate code for an `ImageSample` expression.
     ///
     /// The arguments are the components of an `Expression::ImageSample` variant.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub(super) fn write_image_sample(
         &mut self,
         result_type_id: Word,

--- a/naga/src/back/spv/instructions.rs
+++ b/naga/src/back/spv/instructions.rs
@@ -778,7 +778,10 @@ impl super::Instruction {
     //
     //  Ray Query Instructions
     //
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub(super) fn ray_query_initialize(
         query: Word,
         acceleration_structure: Word,
@@ -869,7 +872,10 @@ impl super::Instruction {
     //  Ray Tracing Pipeline Instructions
     //
 
-    #[expect(clippy::too_many_arguments)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub(super) fn trace_ray(
         acceleration_structure: Word,
         ray_flags: Word,

--- a/naga/src/back/spv/mesh_shader.rs
+++ b/naga/src/back/spv/mesh_shader.rs
@@ -441,7 +441,10 @@ impl super::Writer {
     }
 
     /// This writes the actual loop
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn write_mesh_copy_loop(
         &mut self,
         body: &mut Vec<Instruction>,

--- a/naga/src/front/glsl/context.rs
+++ b/naga/src/front/glsl/context.rs
@@ -503,7 +503,10 @@ impl<'a> Context<'a> {
                 vector = pointer;
             }
 
-            #[allow(clippy::needless_range_loop)]
+            #[allow(
+                clippy::needless_range_loop,
+                reason = "loop kept for clarity of index math"
+            )]
             for index in 0..size {
                 let dst = self.add_expression(
                     Expression::AccessIndex {
@@ -540,7 +543,10 @@ impl<'a> Context<'a> {
     }
 
     /// Internal implementation of [`lower`](Self::lower)
-    #[allow(clippy::large_stack_frames)] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
+    #[allow(
+        clippy::large_stack_frames,
+        reason = "legitimate recursive/stack use, tracked in #9456"
+    )] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
     fn lower_inner(
         &mut self,
         stmt: &StmtContext,

--- a/naga/src/front/glsl/functions.rs
+++ b/naga/src/front/glsl/functions.rs
@@ -207,7 +207,10 @@ impl Frontend {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn matrix_one_arg(
         &mut self,
         ctx: &mut Context,
@@ -869,7 +872,10 @@ impl Frontend {
 
     /// Processes a function call argument that appears in place of an output
     /// parameter.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn process_lhs_argument(
         &mut self,
         ctx: &mut Context,

--- a/naga/src/front/spv/image.rs
+++ b/naga/src/front/spv/image.rs
@@ -486,7 +486,10 @@ impl<I: Iterator<Item = u32>> super::Frontend<I> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub(super) fn parse_image_sample(
         &mut self,
         mut words_left: u16,

--- a/naga/src/front/spv/mod.rs
+++ b/naga/src/front/spv/mod.rs
@@ -1111,7 +1111,10 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
     /// A more complicated version of the binary op,
     /// where we force the operand to have the same type as the result.
     /// This is mostly needed for "i++" and "i--" coming from GLSL.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn parse_expr_binary_op_sign_adjusted(
         &mut self,
         ctx: &mut BlockContext,
@@ -1189,7 +1192,10 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
     /// A version of the binary op where one or both of the arguments might need to be casted to a
     /// specific integer kind (unsigned or signed), used for operations like OpINotEqual or
     /// OpUGreaterThan.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn parse_expr_int_comparison(
         &mut self,
         ctx: &mut BlockContext,
@@ -1337,7 +1343,10 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn insert_composite(
         &self,
         root_expr: Handle<crate::Expression>,
@@ -1461,7 +1470,10 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
         Ok((p_lexp_handle, p_base_ty.handle))
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn parse_atomic_expr_with_value(
         &mut self,
         inst: Instruction,

--- a/naga/src/front/spv/next_block.rs
+++ b/naga/src/front/spv/next_block.rs
@@ -18,7 +18,10 @@ impl<I: Iterator<Item = u32>> Frontend<I> {
     /// Except for the function's entry block, `block_id` should be the label of
     /// a block we've seen mentioned before, with an entry in
     /// `block_ctx.body_for_label` to tell us which `Body` it contributes to.
-    #[allow(clippy::large_stack_frames)] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
+    #[allow(
+        clippy::large_stack_frames,
+        reason = "legitimate recursive/stack use, tracked in #9456"
+    )] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
     pub(in crate::front::spv) fn next_block(
         &mut self,
         block_id: spirv::Word,

--- a/naga/src/front/wgsl/error.rs
+++ b/naga/src/front/wgsl/error.rs
@@ -652,7 +652,10 @@ impl<'a> Error<'a> {
     #[inline(never)]
     // This function is not recursive, so it can exceed our conservatively-set
     // `stack-frame-limit` without causing problems.
-    #[allow(clippy::large_stack_frames)]
+    #[allow(
+        clippy::large_stack_frames,
+        reason = "legitimate recursive/stack use, tracked in #9456"
+    )]
     pub(crate) fn as_parse_error(&self, source: &'a str) -> ParseError {
         // This function normally produces a lot of binary bloat, so has been structured in a
         // non-idiomatic way to minimize its size.

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -256,7 +256,10 @@ impl<'a, 'temp> StatementContext<'a, 'temp, '_> {
         }
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     const fn as_global(&mut self) -> GlobalContext<'a, '_, '_> {
         GlobalContext {
             enable_extensions: self.enable_extensions,
@@ -434,7 +437,10 @@ impl<'source, 'temp, 'out> ExpressionContext<'source, 'temp, 'out> {
         }
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     const fn as_const(&mut self) -> ExpressionContext<'source, '_, '_> {
         ExpressionContext {
             enable_extensions: self.enable_extensions,
@@ -3042,7 +3048,10 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
     }
 
     /// Generate Naga IR for a call to a WGSL builtin function.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn call_builtin<'phrase>(
         &mut self,
         function_name: &'source str,

--- a/naga/src/ir/block.rs
+++ b/naga/src/ir/block.rs
@@ -34,7 +34,7 @@ impl Block {
         }
     }
 
-    #[allow(unused_variables)]
+    #[allow(unused_variables, reason = "kept for API symmetry across backends")]
     pub fn push(&mut self, end: Statement, span: Span) {
         self.body.push(end);
         self.span_info.push(span);

--- a/naga/src/ir/mod.rs
+++ b/naga/src/ir/mod.rs
@@ -1973,7 +1973,10 @@ pub enum RayQueryFunction {
         /// [`AccelerationStructure`]: TypeInner::AccelerationStructure
         acceleration_structure: Handle<Expression>,
 
-        #[allow(rustdoc::private_intra_doc_links)]
+        #[allow(
+            rustdoc::private_intra_doc_links,
+            reason = "links to private items kept for convenience"
+        )]
         /// A struct of detailed parameters for the ray query.
         ///
         /// This expression should have the struct type given in
@@ -2726,7 +2729,10 @@ pub enum MeshOutputTopology {
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "deserialize", derive(Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "used by some feature/backend combinations or not yet wired up"
+)]
 pub struct MeshStageInfo {
     /// The type of primitive outputted.
     pub topology: MeshOutputTopology,
@@ -2761,7 +2767,10 @@ pub enum RayPipelineFunction {
         /// [`AccelerationStructure`]: TypeInner::AccelerationStructure
         acceleration_structure: Handle<Expression>,
 
-        #[allow(rustdoc::private_intra_doc_links)]
+        #[allow(
+            rustdoc::private_intra_doc_links,
+            reason = "links to private items kept for convenience"
+        )]
         /// A struct of detailed parameters for the ray query.
         ///
         /// This expression should have the struct type given in

--- a/naga/src/proc/constant_evaluator.rs
+++ b/naga/src/proc/constant_evaluator.rs
@@ -186,7 +186,7 @@ macro_rules! gen_component_wise_extractor {
 
         with_dollar_sign! {
             ($d:tt) => {
-                #[allow(unused)]
+                #[allow(unused, reason = "kept for tooling/other backends")]
                 #[doc = concat!(
                     "A convenience macro for using the same RHS for each [`",
                     stringify!($target),
@@ -377,7 +377,10 @@ impl LiteralVector {
         })
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     /// Returns [`ArrayVec`] of [`Literal`]s
     fn to_literal_vec(&self) -> ArrayVec<Literal, { crate::VectorSize::MAX }> {
         macro_rules! decompose_literals {
@@ -405,7 +408,10 @@ impl LiteralVector {
         }
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     /// Puts self into eval's expressions arena and returns handle to it
     fn register_as_evaluated_expr(
         &self,
@@ -605,7 +611,7 @@ macro_rules! match_literal_vector {
     ) => {
         match $lit_vec {
             $(
-                #[allow(unused_parens)]
+                #[allow(unused_parens, reason = "parens kept for grouping clarity")]
                 ($(LiteralVector::$ty(ref $var)),+) => { Ok(match_literal_vector!(@expand_ret $out; $ty $(; $ret)? ; $body)) }
             )+
             _ => Err(ConstantEvaluatorError::InvalidMathArg),
@@ -1785,7 +1791,10 @@ impl<'a> ConstantEvaluator<'a> {
             // bits
             crate::MathFunction::CountTrailingZeros => {
                 component_wise_concrete_int!(self, span, [arg], |e| {
-                    #[allow(clippy::useless_conversion)]
+                    #[allow(
+                        clippy::useless_conversion,
+                        reason = "conversion kept explicit for clarity"
+                    )]
                     Ok([e
                         .trailing_zeros()
                         .try_into()
@@ -1794,7 +1803,10 @@ impl<'a> ConstantEvaluator<'a> {
             }
             crate::MathFunction::CountLeadingZeros => {
                 component_wise_concrete_int!(self, span, [arg], |e| {
-                    #[allow(clippy::useless_conversion)]
+                    #[allow(
+                        clippy::useless_conversion,
+                        reason = "conversion kept explicit for clarity"
+                    )]
                     Ok([e
                         .leading_zeros()
                         .try_into()
@@ -1803,7 +1815,10 @@ impl<'a> ConstantEvaluator<'a> {
             }
             crate::MathFunction::CountOneBits => {
                 component_wise_concrete_int!(self, span, [arg], |e| {
-                    #[allow(clippy::useless_conversion)]
+                    #[allow(
+                        clippy::useless_conversion,
+                        reason = "conversion kept explicit for clarity"
+                    )]
                     Ok([e
                         .count_ones()
                         .try_into()

--- a/naga/src/proc/layouter.rs
+++ b/naga/src/proc/layouter.rs
@@ -167,7 +167,10 @@ impl Layouter {
         self.layouts.clear();
     }
 
-    #[expect(rustdoc::private_intra_doc_links)]
+    #[expect(
+        rustdoc::private_intra_doc_links,
+        reason = "links to private items kept for convenience"
+    )]
     /// Extend this `Layouter` with layouts for any new entries in `gctx.types`.
     ///
     /// Ensure that every type in `gctx.types` has a corresponding [TypeLayout]
@@ -181,7 +184,10 @@ impl Layouter {
     /// end can call this function at any time, passing its current type and
     /// constant arenas, and then assume that layouts are available for all
     /// types.
-    #[allow(clippy::or_fun_call)]
+    #[allow(
+        clippy::or_fun_call,
+        reason = "lazy eval avoided intentionally as cost is trivial"
+    )]
     pub fn update(&mut self, gctx: super::GlobalCtx) -> Result<(), LayoutError> {
         use crate::TypeInner as Ti;
 

--- a/naga/src/proc/mod.rs
+++ b/naga/src/proc/mod.rs
@@ -710,7 +710,10 @@ impl crate::Module {
     /// treated as expressions elsewhere, but that requires mutably modifying the
     /// module and the expressions should only be created at parse time, not validation
     /// time.
-    #[allow(clippy::type_complexity)]
+    #[allow(
+        clippy::type_complexity,
+        reason = "kept as it reads clearer with the concrete type"
+    )]
     pub fn analyze_mesh_shader_info(
         &self,
         gv: crate::Handle<crate::GlobalVariable>,

--- a/naga/src/proc/overloads/list.rs
+++ b/naga/src/proc/overloads/list.rs
@@ -167,7 +167,7 @@ const fn len_to_full_mask(n: usize) -> u64 {
         reason = "This is a const function, which _sometimes_ gets called, \
             so this lint is _sometimes_ triggered, depending on feature set."
     )]
-    #[allow(clippy::panic)]
+    #[allow(clippy::panic, reason = "panic is the intended contract here")]
     if n >= 64 {
         panic!("List::rules can only hold up to 63 rules");
     }

--- a/naga/src/proc/overloads/mod.rs
+++ b/naga/src/proc/overloads/mod.rs
@@ -31,7 +31,10 @@ use crate::proc::TypeResolution;
 use alloc::vec::Vec;
 use core::fmt;
 
-#[expect(rustdoc::private_intra_doc_links)]
+#[expect(
+    rustdoc::private_intra_doc_links,
+    reason = "links to private items kept for convenience"
+)]
 /// A trait for types representing of a set of Naga IR type rules.
 ///
 /// Given an expression like `max(x, y)`, there are multiple type rules that

--- a/naga/src/proc/overloads/scalar_set.rs
+++ b/naga/src/proc/overloads/scalar_set.rs
@@ -6,7 +6,7 @@ use crate::proc::overloads::one_bits_iter::OneBitsIter;
 macro_rules! define_scalar_set {
     { $( $scalar:ident, )* } => {
         /// An enum used to assign distinct bit numbers to [`ScalarSet`] elements.
-        #[expect(non_camel_case_types, clippy::upper_case_acronyms)]
+        #[expect(non_camel_case_types, clippy::upper_case_acronyms, reason = "kept to mirror spec acronym casing")]
         #[repr(u32)]
         enum ScalarSetBits {
             $( $scalar, )*
@@ -38,7 +38,7 @@ macro_rules! define_scalar_set {
 
         impl ScalarSet {
             /// Return the set of scalars containing only `scalar`.
-            #[expect(dead_code)]
+            #[expect(dead_code, reason = "used by some feature/backend combinations or not yet wired up")]
             pub const fn singleton(scalar: Scalar) -> Self {
                 match scalar {
                     $(

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -527,7 +527,10 @@ impl FunctionInfo {
     /// [`sampling_set`]: FunctionInfo::sampling_set
     /// [`sampling`]: FunctionInfo::sampling
     /// [`global_uses`]: FunctionInfo::global_uses
-    #[allow(clippy::or_fun_call)]
+    #[allow(
+        clippy::or_fun_call,
+        reason = "lazy eval avoided intentionally as cost is trivial"
+    )]
     fn process_expression(
         &mut self,
         handle: Handle<crate::Expression>,
@@ -875,7 +878,10 @@ impl FunctionInfo {
     ///
     /// Returns a `NonUniformControlFlow` error if any of the expressions in the block
     /// require uniformity, but the current flow is non-uniform.
-    #[allow(clippy::or_fun_call)]
+    #[allow(
+        clippy::or_fun_call,
+        reason = "lazy eval avoided intentionally as cost is trivial"
+    )]
     fn process_block(
         &mut self,
         statements: &crate::Block,

--- a/naga/src/valid/expression.rs
+++ b/naga/src/valid/expression.rs
@@ -202,7 +202,7 @@ struct ExpressionTypeResolver<'a> {
 impl core::ops::Index<Handle<crate::Expression>> for ExpressionTypeResolver<'_> {
     type Output = crate::TypeInner;
 
-    #[allow(clippy::panic)]
+    #[allow(clippy::panic, reason = "panic is the intended contract here")]
     fn index(&self, handle: Handle<crate::Expression>) -> &Self::Output {
         if handle < self.root {
             self.info[handle].ty.inner_with(self.types)
@@ -378,7 +378,10 @@ impl super::Validator {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub(super) fn validate_expression(
         &self,
         root: Handle<crate::Expression>,

--- a/naga/src/valid/function.rs
+++ b/naga/src/valid/function.rs
@@ -779,7 +779,10 @@ impl super::Validator {
         Ok(())
     }
 
-    #[allow(clippy::large_stack_frames)] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
+    #[allow(
+        clippy::large_stack_frames,
+        reason = "legitimate recursive/stack use, tracked in #9456"
+    )] // TODO(https://github.com/gfx-rs/wgpu/issues/9456)
     fn validate_block_impl(
         &mut self,
         statements: &crate::Block,

--- a/naga/src/valid/handles.rs
+++ b/naga/src/valid/handles.rs
@@ -487,7 +487,10 @@ impl super::Validator {
         Ok(max_type)
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn validate_expression_handles(
         (handle, expression): (Handle<crate::Expression>, &crate::Expression),
         constants: &Arena<crate::Constant>,

--- a/naga/tests/naga/snapshots.rs
+++ b/naga/tests/naga/snapshots.rs
@@ -4,7 +4,7 @@ use naga_test::*;
 const DIR_IN: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/in");
 const DIR_OUT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/out");
 
-#[allow(unused_variables)]
+#[allow(unused_variables, reason = "kept for API symmetry across backends")]
 fn check_targets(input: &Input, module: &mut naga::Module, source_code: Option<&str>) {
     let params = input.read_parameters(DIR_IN);
     let name = input.file_name.display().to_string();
@@ -418,7 +418,10 @@ fn write_output_msl(
     input.write_output_file("msl", "metal", string, DIR_OUT);
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "kept for API compatibility and readability"
+)]
 fn write_output_glsl(
     input: &Input,
     module: &naga::Module,

--- a/naga/tests/naga/wgsl_errors.rs
+++ b/naga/tests/naga/wgsl_errors.rs
@@ -1015,7 +1015,7 @@ macro_rules! check_one_validation {
     ( $source:expr, $pattern:pat $( if $guard:expr )? ) => {
         let source = $source;
         let error = validation_error($source, naga::valid::Capabilities::default());
-        #[allow(clippy::redundant_pattern_matching)]
+        #[allow(clippy::redundant_pattern_matching, reason = "pattern kept explicit for clarity")]
         if ! matches!(&error, $pattern $( if $guard )? ) {
             eprintln!("validation error does not match pattern:\n\
                        source code: {}\n\
@@ -1035,7 +1035,7 @@ macro_rules! check_one_validation {
     ( $source:expr, $pattern:pat $( if $guard:expr )?, $capabilities:expr ) => {
         let source = $source;
         let error = validation_error($source, $capabilities);
-        #[allow(clippy::redundant_pattern_matching)]
+        #[allow(clippy::redundant_pattern_matching, reason = "pattern kept explicit for clarity")]
         if ! matches!(&error, $pattern $( if $guard )? ) {
             eprintln!("validation error does not match pattern:\n\
                        source code: {}\n\
@@ -1088,7 +1088,7 @@ macro_rules! check_one_validation {
 /// and ray tracing pipelines.
 macro_rules! check_extension_validation {
     ( $caps:expr, $source:expr, $parse_err:expr, $val_err_pat:pat $(, $other_caps:expr)? ) => {
-        #[allow(unused_mut, unused_assignments)]
+        #[allow(unused_mut, unused_assignments, reason = "kept for generated/feature-gated code")]
         let mut other_caps = naga::valid::Capabilities::empty();
         $(other_caps = $other_caps;)?
         let caps = $caps;
@@ -1147,7 +1147,7 @@ macro_rules! check_extension_validation {
         let error = naga::valid::Validator::new(naga::valid::ValidationFlags::all(), !(caps | other_caps))
             .validate(&module).map_err(|e|e.into_inner());
         let error = error.as_ref(); // TODO(https://github.com/gfx-rs/wgpu/issues/8153): Add tests for spans
-        #[allow(clippy::redundant_pattern_matching)]
+        #[allow(clippy::redundant_pattern_matching, reason = "pattern kept explicit for clarity")]
         if !matches!(error, $val_err_pat) {
             eprintln!(
                 concat!(

--- a/tests/src/init.rs
+++ b/tests/src/init.rs
@@ -116,11 +116,11 @@ pub async fn initialize_adapter(
         .unwrap_or_default();
 
     let instance = initialize_instance(backends, params);
-    #[allow(unused_variables)]
+    #[allow(unused_variables, reason = "kept for API symmetry across backends")]
     let surface: Option<wgpu::Surface>;
     let surface_guard: Option<SurfaceGuard>;
 
-    #[allow(unused_assignments)]
+    #[allow(unused_assignments, reason = "kept for side effects / uniform shape")]
     // Create a canvas if we need a WebGL2RenderingContext to have a working device.
     #[cfg(not(all(
         target_arch = "wasm32",
@@ -235,7 +235,7 @@ pub fn initialize_html_canvas() -> web_sys::HtmlCanvasElement {
 
 pub struct SurfaceGuard {
     #[cfg(target_arch = "wasm32")]
-    #[allow(unused)]
+    #[allow(unused, reason = "kept for tooling/other backends")]
     canvas: web_sys::HtmlCanvasElement,
 }
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -157,7 +157,7 @@ macro_rules! gpu_test {
     ) => {
         $crate::macro_support::paste! {
             $( #[ $meta ] )*
-            #[allow(non_snake_case)]
+            #[allow(non_snake_case, reason = "kept to mirror the source specification naming")]
             $vis fn $static_name() -> $crate::GpuTestConfiguration {
                 struct S;
 

--- a/tests/tests/wgpu-gpu/encoder.rs
+++ b/tests/tests/wgpu-gpu/encoder.rs
@@ -154,7 +154,10 @@ fn encoder_operations_fail_while_pass_alive(ctx: TestingContext) {
     let target_tex = ctx.device.create_texture(&target_desc);
     let color_attachment_view = target_tex.create_view(&wgpu::TextureViewDescriptor::default());
 
-    #[allow(clippy::type_complexity)]
+    #[allow(
+        clippy::type_complexity,
+        reason = "kept as it reads clearer with the concrete type"
+    )]
     let recording_ops: Vec<(_, Box<dyn Fn(&mut CommandEncoder)>)> = vec![
         (
             "begin_compute_pass",

--- a/tests/tests/wgpu-gpu/mesh_shader/mod.rs
+++ b/tests/tests/wgpu-gpu/mesh_shader/mod.rs
@@ -131,7 +131,10 @@ fn mesh_pipeline_build(ctx: &TestingContext, info: MeshPipelineTestInfo) {
 
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum DrawType {
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     Standard,
     Indirect,
     MultiIndirect,

--- a/tests/tests/wgpu-gpu/passthrough/mod.rs
+++ b/tests/tests/wgpu-gpu/passthrough/mod.rs
@@ -493,7 +493,7 @@ static WGSL_PASSTHROUGH_SHADER: GpuTestConfiguration = GpuTestConfiguration::new
     .run_sync(wgsl_test);
 
 fn all_passthrough_shaders_binary(ctx: TestingContext) {
-    #[allow(unused_variables)]
+    #[allow(unused_variables, reason = "kept for API symmetry across backends")]
     let test_hash = test_hash(&ctx, "all_passthrough_binary");
     let desc = CreateShaderModuleDescriptorPassthrough {
         entry_points: Cow::Borrowed(&[wgpu::PassthroughShaderEntryPoint {
@@ -531,7 +531,7 @@ static ALL_PASSTHROUGH_SHADERS_BINARY: GpuTestConfiguration = GpuTestConfigurati
     .run_sync(all_passthrough_shaders_binary);
 
 fn all_passthrough_shader_source(ctx: TestingContext) {
-    #[allow(unused_variables)]
+    #[allow(unused_variables, reason = "kept for API symmetry across backends")]
     let test_hash = test_hash(&ctx, "all_passthrough_source");
     let desc = CreateShaderModuleDescriptorPassthrough {
         entry_points: Cow::Borrowed(&[wgpu::PassthroughShaderEntryPoint {
@@ -565,7 +565,7 @@ static ALL_PASSTHROUGH_SHADERS_SOURCE: GpuTestConfiguration = GpuTestConfigurati
     .run_sync(all_passthrough_shader_source);
 
 fn explicit_layout_validation(ctx: TestingContext) {
-    #[allow(unused_variables)]
+    #[allow(unused_variables, reason = "kept for API symmetry across backends")]
     let test_hash = test_hash(&ctx, "explicit_layout_validation");
     let desc = CreateShaderModuleDescriptorPassthrough {
         entry_points: Cow::Borrowed(&[wgpu::PassthroughShaderEntryPoint {

--- a/tests/tests/wgpu-gpu/regression/issue_6827.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_6827.rs
@@ -85,7 +85,10 @@ async fn run_test(ctx: TestingContext, use_many_writes: bool) {
 
     let mut wrong_texels = Vec::new();
     for (zyx_index, cube) in texel_iter(&texture).enumerate() {
-        #[allow(clippy::cast_possible_wrap)]
+        #[allow(
+            clippy::cast_possible_wrap,
+            reason = "wrap is checked/guarded at the call site"
+        )]
         let expected = texel_for_cube(cube);
         let actual = light_texels[zyx_index];
         if expected != actual {

--- a/tests/tests/wgpu-gpu/shader/data_builtins.rs
+++ b/tests/tests/wgpu-gpu/shader/data_builtins.rs
@@ -7,7 +7,10 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.extend([UNPACK4xU8, UNPACK4xI8, PACK4xU8, PACK4xI8]);
 }
 
-#[allow(non_snake_case)]
+#[allow(
+    non_snake_case,
+    reason = "kept to mirror the source specification naming"
+)]
 fn create_unpack4xU8_test() -> Vec<ShaderTest> {
     let mut tests = Vec::new();
 
@@ -44,7 +47,10 @@ static UNPACK4xU8: GpuTestConfiguration = GpuTestConfiguration::new()
         shader_input_output_test(ctx, InputStorageType::Storage, create_unpack4xU8_test())
     });
 
-#[allow(non_snake_case)]
+#[allow(
+    non_snake_case,
+    reason = "kept to mirror the source specification naming"
+)]
 fn create_unpack4xI8_test() -> Vec<ShaderTest> {
     let mut tests = Vec::with_capacity(2);
 
@@ -88,7 +94,10 @@ static UNPACK4xI8: GpuTestConfiguration = GpuTestConfiguration::new()
         shader_input_output_test(ctx, InputStorageType::Storage, create_unpack4xI8_test())
     });
 
-#[allow(non_snake_case)]
+#[allow(
+    non_snake_case,
+    reason = "kept to mirror the source specification naming"
+)]
 fn create_pack4xU8_test() -> Vec<ShaderTest> {
     let mut tests = Vec::new();
 
@@ -117,7 +126,10 @@ static PACK4xU8: GpuTestConfiguration = GpuTestConfiguration::new()
         shader_input_output_test(ctx, InputStorageType::Storage, create_pack4xU8_test())
     });
 
-#[allow(non_snake_case)]
+#[allow(
+    non_snake_case,
+    reason = "kept to mirror the source specification naming"
+)]
 fn create_pack4xI8_test() -> Vec<ShaderTest> {
     let mut tests = Vec::with_capacity(2);
 

--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -16,7 +16,10 @@ use wgpu_test::{
 
 /// A way to write data into a texture.
 #[derive(Clone, Copy)]
-#[allow(clippy::enum_variant_names)]
+#[allow(
+    clippy::enum_variant_names,
+    reason = "variants names differ for API clarity"
+)]
 enum WriteMethod {
     WriteTexture,
     CopyBufferToTexture,

--- a/wgpu-core-remote/src/hub.rs
+++ b/wgpu-core-remote/src/hub.rs
@@ -97,7 +97,10 @@ use wgpu_core::{
     resource::{Buffer, ExternalTexture, QuerySet, Sampler, Texture, TextureView},
 };
 
-#[allow(rustdoc::private_intra_doc_links)]
+#[allow(
+    rustdoc::private_intra_doc_links,
+    reason = "links to private items kept for convenience"
+)]
 /// All the resources tracked by a [`crate::global::Global`].
 ///
 /// Each field in [`Hub`] is a [`Registry`] holding all the values of a

--- a/wgpu-core-remote/src/storage.rs
+++ b/wgpu-core-remote/src/storage.rs
@@ -84,7 +84,10 @@ where
         }
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) fn iter(&self) -> impl Iterator<Item = (Id<T::Marker>, &T)> {
         self.map
             .iter()

--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -708,7 +708,10 @@ pub struct BindGroupDescriptor<
         ))
     )]
     /// The resources to bind to this bind group.
-    #[allow(clippy::type_complexity)]
+    #[allow(
+        clippy::type_complexity,
+        reason = "kept as it reads clearer with the concrete type"
+    )]
     pub entries: Cow<'a, [BindGroupEntry<'a, B, S, TV, TLAS, ET>]>,
 }
 
@@ -800,7 +803,10 @@ pub struct BindGroupLayout {
 }
 
 impl Drop for BindGroupLayout {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("BindGroupLayout::drop");
         api_log!("BindGroupLayout::drop {:?}", self as *const _);
@@ -1016,7 +1022,10 @@ pub struct PipelineLayout {
 }
 
 impl Drop for PipelineLayout {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("PipelineLayout::drop");
         api_log!("PipelineLayout::drop {:?}", self as *const _);
@@ -1300,7 +1309,10 @@ pub struct BindGroup {
 }
 
 impl Drop for BindGroup {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("BindGroup::drop");
         api_log!("BindGroup::drop {:?}", self as *const _);

--- a/wgpu-core/src/command/bind.rs
+++ b/wgpu-core/src/command/bind.rs
@@ -275,7 +275,10 @@ mod compat {
                 .filter_map(|(i, e)| if e.is_valid() { Some(i) } else { None })
         }
 
-        #[allow(clippy::result_large_err)]
+        #[allow(
+            clippy::result_large_err,
+            reason = "error size kept as it is inherent to the error type"
+        )]
         pub fn get_invalid(&self) -> Result<(), (usize, Error)> {
             for (index, entry) in self.entries.iter().enumerate() {
                 entry.check().map_err(|e| (index, e))?;

--- a/wgpu-core/src/command/bundle.rs
+++ b/wgpu-core/src/command/bundle.rs
@@ -1406,7 +1406,10 @@ pub struct RenderBundle {
 }
 
 impl Drop for RenderBundle {
-    #[expect(trivial_casts)]
+    #[expect(
+        trivial_casts,
+        reason = "casts kept explicit for type clarity across feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("RenderBundle::drop");
         api_log!("RenderBundle::drop {:?}", self as *const _);

--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -522,7 +522,10 @@ crate::impl_parent_device!(CommandEncoder);
 crate::impl_storage_item!(CommandEncoder);
 
 impl Drop for CommandEncoder {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("CommandEncoder::drop");
         api_log!("CommandEncoder::drop {:?}", self as *const _);
@@ -893,7 +896,10 @@ pub struct CommandBuffer {
 }
 
 impl Drop for CommandBuffer {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("CommandBuffer::drop");
         api_log!("CommandBuffer::drop {:?}", self as *const _);

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -242,7 +242,10 @@ pub(crate) fn map_buffer(
     };
 
     if !mapping.is_coherent && kind == HostMap::Read {
-        #[allow(clippy::single_range_in_vec_init)]
+        #[allow(
+            clippy::single_range_in_vec_init,
+            reason = "range kept explicit for readability"
+        )]
         unsafe {
             raw_device.invalidate_mapped_ranges(raw_buffer, &[offset..offset + size]);
         }

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -271,7 +271,10 @@ crate::impl_parent_device!(Queue);
 crate::impl_storage_item!(Queue);
 
 impl Drop for Queue {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("Queue::drop");
         api_log!("Queue::drop {:?}", self as *const _);
@@ -1247,7 +1250,10 @@ impl Queue {
         // same way as `HTMLCanvasElement`.
         needs_flag |= source.origin != wgt::Origin2d::ZERO;
         needs_flag |= destination.color_space != wgt::PredefinedColorSpace::Srgb;
-        #[allow(clippy::bool_comparison)]
+        #[allow(
+            clippy::bool_comparison,
+            reason = "kept for explicitness at the guard site"
+        )]
         if matches!(source.source, wgt::ExternalImageSource::ImageBitmap(_)) {
             needs_flag |= source.flip_y != false;
             needs_flag |= destination.premultiplied_alpha != false;
@@ -1988,7 +1994,10 @@ impl Queue {
         self.lock_life().add_work_done_closure(closure)
     }
 
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     pub fn compact_blas(&self, blas: &Arc<Blas>) -> (Arc<Blas>, Option<CompactBlasError>) {
         api_log!(
             "Queue::compact_blas {:?}, {:?}",

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -364,7 +364,10 @@ impl Drop for DeviceResources<'_> {
 }
 
 impl Drop for Device {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("Device::drop");
         api_log!("Device::drop {:?}", self as *const _);
@@ -1339,7 +1342,10 @@ impl Device {
                 // SAFETY: The buffer tail is valid and aligned.
                 mapping.ptr.cast::<u32>().as_ptr().write(0);
                 if !mapping.is_coherent {
-                    #[allow(clippy::single_range_in_vec_init)]
+                    #[allow(
+                        clippy::single_range_in_vec_init,
+                        reason = "range kept explicit for readability"
+                    )]
                     self.raw()
                         .flush_mapped_ranges(raw, &[tail_start..actual_size]);
                 }
@@ -1509,7 +1515,10 @@ impl Device {
         unsafe { core::ptr::copy_nonoverlapping(data.as_ptr(), mapping.ptr.as_ptr(), data.len()) };
 
         if !mapping.is_coherent {
-            #[allow(clippy::single_range_in_vec_init)]
+            #[allow(
+                clippy::single_range_in_vec_init,
+                reason = "range kept explicit for readability"
+            )]
             unsafe {
                 device
                     .raw()

--- a/wgpu-core/src/device/trace.rs
+++ b/wgpu-core/src/device/trace.rs
@@ -112,7 +112,10 @@ impl Data {
     }
 }
 
-#[allow(clippy::large_enum_variant)]
+#[allow(
+    clippy::large_enum_variant,
+    reason = "variant size is inherent to the schema"
+)]
 #[derive(Debug)]
 #[apply(serde_object_reference_struct)]
 pub enum Action<'a, R: ReferenceType> {

--- a/wgpu-core/src/device/trace/record.rs
+++ b/wgpu-core/src/device/trace/record.rs
@@ -178,7 +178,10 @@ impl<T: StorageItem> IntoTrace for Arc<T> {
 /// This will work as expected on heap-allocated types that are not moved around.
 pub(crate) unsafe fn to_trace<T: StorageItem>(t: &T) -> PointerId<T::Marker> {
     PointerId::PointerId(
-        #[expect(trivial_casts)]
+        #[expect(
+            trivial_casts,
+            reason = "casts kept explicit for type clarity across feature gates"
+        )]
         core::num::NonZeroUsize::new(t as *const T as usize).unwrap(),
         PhantomData,
     )

--- a/wgpu-core/src/id.rs
+++ b/wgpu-core/src/id.rs
@@ -12,7 +12,10 @@ pub use wgt::markers::*;
 /// `Arc::as_ptr`. These IDs have the type [`crate::id::PointerId`]. The
 /// trace player uses hash maps to go from `PointerId`s to `Arc`s
 /// when replaying a trace.
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "used by some feature/backend combinations or not yet wired up"
+)]
 #[cfg(feature = "serde")]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum PointerId<T: Marker> {

--- a/wgpu-core/src/indirect_validation/dispatch.rs
+++ b/wgpu-core/src/indirect_validation/dispatch.rs
@@ -89,7 +89,7 @@ impl Dispatch {
             })
         })?;
         #[cfg(not(feature = "wgsl"))]
-        #[allow(clippy::diverging_sub_expression)]
+        #[allow(clippy::diverging_sub_expression, reason = "kept for codegen clarity")]
         let module = panic!("Indirect validation requires the wgsl feature flag to be enabled!");
 
         let info = crate::device::create_validator(

--- a/wgpu-core/src/indirect_validation/draw.rs
+++ b/wgpu-core/src/indirect_validation/draw.rs
@@ -534,7 +534,7 @@ fn create_validation_module(
         })
     })?;
     #[cfg(not(feature = "wgsl"))]
-    #[allow(clippy::diverging_sub_expression)]
+    #[allow(clippy::diverging_sub_expression, reason = "kept for codegen clarity")]
     let module = panic!("Indirect validation requires the wgsl feature flag to be enabled!");
 
     let info = crate::device::create_validator(

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1023,7 +1023,10 @@ impl Surface {
 }
 
 impl Drop for Surface {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("Surface::drop");
 
@@ -1301,7 +1304,10 @@ impl Adapter {
 }
 
 impl Drop for Adapter {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("Adapter::drop");
         api_log!("Adapter::drop {:?}", self as *const _);

--- a/wgpu-core/src/lock/rank.rs
+++ b/wgpu-core/src/lock/rank.rs
@@ -57,7 +57,7 @@ macro_rules! define_lock_ranks {
         )*
     } => {
         // An enum that assigns a unique number to each rank.
-        #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
+        #[allow(non_camel_case_types, clippy::upper_case_acronyms, reason = "kept to mirror spec acronym casing")]
         enum LockRankNumber { $( $name, )* }
 
         bitflags::bitflags! {

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -40,7 +40,10 @@ pub(crate) struct LateSizedBufferGroup {
     pub(crate) shader_sizes: Vec<wgt::BufferAddress>,
 }
 
-#[allow(clippy::large_enum_variant)]
+#[allow(
+    clippy::large_enum_variant,
+    reason = "variant size is inherent to the schema"
+)]
 pub enum ShaderModuleSource<'a> {
     #[cfg(feature = "wgsl")]
     Wgsl(Cow<'a, str>),
@@ -81,7 +84,10 @@ pub struct ShaderModule {
 }
 
 impl Drop for ShaderModule {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("ShaderModule::drop");
         api_log!("ShaderModule::drop {:?}", self as *const _);
@@ -377,7 +383,10 @@ pub struct ComputePipeline {
 }
 
 impl Drop for ComputePipeline {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("ComputePipeline::drop");
         api_log!("ComputePipeline::drop {:?}", self as *const _);
@@ -500,7 +509,10 @@ pub struct PipelineCache {
 }
 
 impl Drop for PipelineCache {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("PipelineCache::drop");
         api_log!("PipelineCache::drop {:?}", self as *const _);
@@ -1044,7 +1056,10 @@ pub struct RenderPipeline {
 }
 
 impl Drop for RenderPipeline {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("RenderPipeline::drop");
         api_log!("RenderPipeline::drop {:?}", self as *const _);

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -464,7 +464,10 @@ pub struct Buffer {
 }
 
 impl Drop for Buffer {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("Buffer::drop");
         api_log!("Buffer::drop {:?}", self as *const _);
@@ -1396,7 +1399,10 @@ impl StagingBuffer {
     pub(crate) fn flush(self) -> FlushedStagingBuffer {
         let device = self.device.raw();
         if !self.is_coherent {
-            #[allow(clippy::single_range_in_vec_init)]
+            #[allow(
+                clippy::single_range_in_vec_init,
+                reason = "range kept explicit for readability"
+            )]
             unsafe {
                 device.flush_mapped_ranges(self.raw.as_ref(), &[0..self.size.get()])
             };
@@ -1585,7 +1591,10 @@ impl Texture {
 }
 
 impl Drop for Texture {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("Texture::drop");
         api_log!("Texture::drop {:?}", self as *const _);
@@ -2470,7 +2479,10 @@ pub struct TextureView {
 }
 
 impl Drop for TextureView {
-    #[expect(trivial_casts)]
+    #[expect(
+        trivial_casts,
+        reason = "casts kept explicit for type clarity across feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("TextureView::drop");
         api_log!("TextureView::drop {:?}", self as *const _);
@@ -2738,7 +2750,10 @@ pub struct ExternalTexture {
 }
 
 impl Drop for ExternalTexture {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("ExternalTexture::drop");
         api_log!("ExternalTexture::drop {:?}", self as *const _);
@@ -2894,7 +2909,10 @@ pub struct Sampler {
 }
 
 impl Drop for Sampler {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("Sampler::drop");
         api_log!("Sampler::drop {:?}", self as *const _);
@@ -3129,7 +3147,10 @@ impl QuerySet {
 }
 
 impl Drop for QuerySet {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("QuerySet::drop");
         api_log!("QuerySet::drop {:?}", self as *const _);
@@ -3252,7 +3273,10 @@ pub struct Blas {
 }
 
 impl Drop for Blas {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("Blas::drop");
         api_log!("Blas::drop {:?}", self as *const _);
@@ -3486,7 +3510,10 @@ pub struct Tlas {
 }
 
 impl Drop for Tlas {
-    #[allow(trivial_casts)]
+    #[allow(
+        trivial_casts,
+        reason = "kept for type-clarity across platform feature gates"
+    )]
     fn drop(&mut self) {
         profiling::scope!("Tlas::drop");
         api_log!("Tlas::drop {:?}", self as *const _);

--- a/wgpu-core/src/snatch.rs
+++ b/wgpu-core/src/snatch.rs
@@ -5,7 +5,13 @@ use crate::lock::{rank, RankData, RwLock, RwLockReadGuard, RwLockWriteGuard};
 /// A guard that provides read access to snatchable data.
 pub struct SnatchGuard<'a>(RwLockReadGuard<'a, ()>);
 /// A guard that allows snatching the snatchable data.
-pub struct ExclusiveSnatchGuard<'a>(#[expect(dead_code)] RwLockWriteGuard<'a, ()>);
+pub struct ExclusiveSnatchGuard<'a>(
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
+    RwLockWriteGuard<'a, ()>,
+);
 
 /// A value that is mostly immutable but can be "snatched" if we need to destroy
 /// it early.
@@ -26,7 +32,10 @@ impl<T> Snatchable<T> {
         }
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub fn empty() -> Self {
         SnatchableInner {
             value: UnsafeCell::new(None),

--- a/wgpu-core/src/timestamp_normalization/mod.rs
+++ b/wgpu-core/src/timestamp_normalization/mod.rs
@@ -146,7 +146,7 @@ impl TimestampNormalizer {
                 })
             })?;
             #[cfg(not(feature = "wgsl"))]
-            #[allow(clippy::diverging_sub_expression)]
+            #[allow(clippy::diverging_sub_expression, reason = "kept for codegen clarity")]
             let module =
                 panic!("Timestamp normalization requires the wgsl feature flag to be enabled!");
 

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -80,7 +80,7 @@ impl From<&BindingType> for BindingTypeName {
 
 #[derive(Debug)]
 struct Resource {
-    #[allow(unused)]
+    #[allow(unused, reason = "kept for tooling/other backends")]
     name: Option<String>,
     bind: naga::ResourceBinding,
     ty: ResourceType,
@@ -406,7 +406,10 @@ pub struct PassthroughInterface {
 // Most shaders will use a standard interface which is very large.
 // Passthrough shaders have a much smaller interface. No reason to
 // box the standard interface though.
-#[expect(clippy::large_enum_variant)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "variant size is inherent to the schema"
+)]
 #[derive(Debug)]
 pub enum ShaderMetaData {
     Interface(Interface),

--- a/wgpu-core/src/validation/shader_io_deductions.rs
+++ b/wgpu-core/src/validation/shader_io_deductions.rs
@@ -1,7 +1,7 @@
 use core::fmt::{self, Debug, Display, Formatter};
 
 #[cfg(doc)]
-#[expect(unused_imports)]
+#[expect(unused_imports, reason = "kept for feature-gated use")]
 use crate::validation::StageError;
 
 /// Max shader I/O variable deductions for vertex shader output. Used by

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -65,7 +65,10 @@ impl<A: hal::Api> ExecutionContext<A> {
     }
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "used by some feature/backend combinations or not yet wired up"
+)]
 struct Example<A: hal::Api> {
     instance: A::Instance,
     adapter: A::Adapter,

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -50,7 +50,10 @@ impl std::fmt::Debug for AccelerationStructureInstance {
     }
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "used by some feature/backend combinations or not yet wired up"
+)]
 impl AccelerationStructureInstance {
     const LOW_24_MASK: u32 = 0x00ff_ffff;
     const MAX_U24: u32 = (1u32 << 24u32) - 1u32;
@@ -194,7 +197,10 @@ impl<A: hal::Api> ExecutionContext<A> {
     }
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "used by some feature/backend combinations or not yet wired up"
+)]
 struct Example<A: hal::Api> {
     instance: A::Instance,
     adapter: A::Adapter,
@@ -321,7 +327,10 @@ impl<A: hal::Api> Example<A> {
             surface.configure(&device, &surface_config).unwrap();
         };
 
-        #[allow(dead_code)]
+        #[allow(
+            dead_code,
+            reason = "used by some feature/backend combinations or not yet wired up"
+        )]
         struct Uniforms {
             view_inverse: glam::Mat4,
             proj_inverse: glam::Mat4,

--- a/wgpu-hal/src/auxil/dxgi/time.rs
+++ b/wgpu-hal/src/auxil/dxgi/time.rs
@@ -12,7 +12,10 @@ pub enum PresentationTimer {
     ///
     /// [`IPresentationManager`]: https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/Graphics/CompositionSwapchain/struct.IPresentationManager.html
     /// [`QueryInterruptTimePrecise()`]: https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/System/WindowsProgramming/fn.QueryInterruptTimePrecise.html
-    #[allow(non_snake_case)]
+    #[allow(
+        non_snake_case,
+        reason = "kept to mirror the source specification naming"
+    )]
     IPresentationManager {
         fnQueryInterruptTimePrecise: unsafe extern "system" fn(*mut u64),
     },

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -61,7 +61,10 @@ impl super::Adapter {
         &self.raw
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub(super) fn expose(
         adapter: DxgiAdapter,
         library: &Arc<D3D12Lib>,

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -38,7 +38,10 @@ use crate::{
 const NAGA_LOCATION_SEMANTIC: &[u8] = c"LOC".to_bytes();
 
 impl super::Device {
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub(super) fn new(
         adapter: auxil::dxgi::factory::DxgiAdapter,
         raw: Direct3D12::ID3D12Device,
@@ -1415,7 +1418,7 @@ impl crate::Device for super::Device {
             // it so if we add more later, the value behaves correctly.
 
             // This is an allow as it doesn't trigger on 1.90, hal's MSRV.
-            #[allow(unused_assignments)]
+            #[allow(unused_assignments, reason = "kept for side effects / uniform shape")]
             {
                 bind_cbv.register += 1;
             }

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -550,7 +550,7 @@ impl Surface {
 #[derive(Debug, Clone, Copy)]
 enum MemoryArchitecture {
     Unified {
-        #[allow(unused)]
+        #[allow(unused, reason = "kept for tooling/other backends")]
         cache_coherent: bool,
     },
     NonUnified,
@@ -560,7 +560,7 @@ enum MemoryArchitecture {
 struct PrivateCapabilities {
     instance_flags: wgt::InstanceFlags,
     workarounds: Workarounds,
-    #[allow(unused)]
+    #[allow(unused, reason = "kept for tooling/other backends")]
     heterogeneous_resource_heaps: bool,
     memory_architecture: MemoryArchitecture,
     heap_create_not_zeroed: bool,

--- a/wgpu-hal/src/dx12/shader_compilation.rs
+++ b/wgpu-hal/src/dx12/shader_compilation.rs
@@ -175,7 +175,10 @@ impl FxcLib {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     fn compile(
         &self,
         source: &str,
@@ -328,7 +331,10 @@ unsafe fn dxc_create_instance<T: DxcObj>(
 }
 
 /// Owned PCWSTR
-#[allow(clippy::upper_case_acronyms)]
+#[allow(
+    clippy::upper_case_acronyms,
+    reason = "kept to match the spec/source acronym casing"
+)]
 struct OPCWSTR {
     inner: Vec<u16>,
 }

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -1852,7 +1852,7 @@ impl crate::Device for super::Device {
             self.render_doc
                 .start_frame_capture(self.shared.context.raw_context(), ptr::null_mut())
         };
-        #[allow(unreachable_code)]
+        #[allow(unreachable_code, reason = "kept behind feature/version gates")]
         false
     }
     unsafe fn stop_graphics_debugger_capture(&self) {

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -30,7 +30,10 @@ type EglInstance = khronos_egl::Instance<khronos_egl::Static>;
 
 type EglLabel = *const ffi::c_void;
 
-#[allow(clippy::upper_case_acronyms)]
+#[allow(
+    clippy::upper_case_acronyms,
+    reason = "kept to match the spec/source acronym casing"
+)]
 type EGLDEBUGPROCKHR = Option<
     unsafe extern "system" fn(
         error: khronos_egl::Enum,
@@ -275,7 +278,10 @@ struct EglContextLock<'a> {
 }
 
 /// A guard containing a lock to an [`AdapterContext`], while the GL context is kept current.
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "kept for the public API surface"
+)]
 pub struct AdapterContextLock<'a> {
     glow: MutexGuard<'a, ManuallyDrop<glow::Context>>,
     egl: Option<EglContextLock<'a>>,
@@ -1115,7 +1121,7 @@ pub struct Swapchain {
     extent: wgt::Extent3d,
     format: wgt::TextureFormat,
     format_desc: super::TextureFormatDesc,
-    #[allow(unused)]
+    #[allow(unused, reason = "kept for tooling/other backends")]
     sample_type: wgt::TextureSampleType,
 }
 

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -975,7 +975,7 @@ enum Command {
     },
     CopyBufferToTexture {
         src: Buffer,
-        #[allow(unused)]
+        #[allow(unused, reason = "kept for tooling/other backends")]
         src_target: BindTarget,
         dst: glow::Texture,
         dst_target: BindTarget,
@@ -987,7 +987,7 @@ enum Command {
         src_target: BindTarget,
         src_format: wgt::TextureFormat,
         dst: Buffer,
-        #[allow(unused)]
+        #[allow(unused, reason = "kept for tooling/other backends")]
         dst_target: BindTarget,
         copy: crate::BufferTextureCopy,
     },

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -667,7 +667,7 @@ pub struct Swapchain {
 
     format: wgt::TextureFormat,
     format_desc: super::TextureFormatDesc,
-    #[allow(unused)]
+    #[allow(unused, reason = "kept for tooling/other backends")]
     sample_type: wgt::TextureSampleType,
 }
 

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -239,7 +239,7 @@
 )]
 
 extern crate alloc;
-#[allow(unused_extern_crates)]
+#[allow(unused_extern_crates, reason = "kept for feature-gated usage")]
 extern crate naga_types as nt;
 extern crate wgpu_types as wgt;
 // Each of these backends needs `std` in some fashion; usually `std::thread` functions.
@@ -293,7 +293,7 @@ pub use dynamic::{
     DynTextureView,
 };
 
-#[allow(unused)]
+#[allow(unused, reason = "kept for tooling/other backends")]
 use alloc::boxed::Box;
 use alloc::{borrow::Cow, string::String, vec::Vec};
 use core::{
@@ -1067,7 +1067,10 @@ pub trait Device: WasmNotSendSync {
     ) -> Result<<Self::A as Api>::PipelineLayout, DeviceError>;
     unsafe fn destroy_pipeline_layout(&self, pipeline_layout: <Self::A as Api>::PipelineLayout);
 
-    #[allow(clippy::type_complexity)]
+    #[allow(
+        clippy::type_complexity,
+        reason = "kept as it reads clearer with the concrete type"
+    )]
     unsafe fn create_bind_group(
         &self,
         desc: &BindGroupDescriptor<
@@ -1087,7 +1090,10 @@ pub trait Device: WasmNotSendSync {
     ) -> Result<<Self::A as Api>::ShaderModule, ShaderError>;
     unsafe fn destroy_shader_module(&self, module: <Self::A as Api>::ShaderModule);
 
-    #[allow(clippy::type_complexity)]
+    #[allow(
+        clippy::type_complexity,
+        reason = "kept as it reads clearer with the concrete type"
+    )]
     unsafe fn create_render_pipeline(
         &self,
         desc: &RenderPipelineDescriptor<
@@ -1098,7 +1104,10 @@ pub trait Device: WasmNotSendSync {
     ) -> Result<<Self::A as Api>::RenderPipeline, PipelineError>;
     unsafe fn destroy_render_pipeline(&self, pipeline: <Self::A as Api>::RenderPipeline);
 
-    #[allow(clippy::type_complexity)]
+    #[allow(
+        clippy::type_complexity,
+        reason = "kept as it reads clearer with the concrete type"
+    )]
     unsafe fn create_compute_pipeline(
         &self,
         desc: &ComputePipelineDescriptor<
@@ -1109,7 +1118,10 @@ pub trait Device: WasmNotSendSync {
     ) -> Result<<Self::A as Api>::ComputePipeline, PipelineError>;
     unsafe fn destroy_compute_pipeline(&self, pipeline: <Self::A as Api>::ComputePipeline);
 
-    #[allow(clippy::type_complexity)]
+    #[allow(
+        clippy::type_complexity,
+        reason = "kept as it reads clearer with the concrete type"
+    )]
     unsafe fn create_ray_tracing_pipeline(
         &self,
         desc: &RayTracingPipelineDescriptor<
@@ -1196,7 +1208,7 @@ pub trait Device: WasmNotSendSync {
     /// [api]: ../wgpu/struct.Device.html#method.stop_graphics_debugger_capture
     unsafe fn stop_graphics_debugger_capture(&self);
 
-    #[allow(unused_variables)]
+    #[allow(unused_variables, reason = "kept for API symmetry across backends")]
     unsafe fn pipeline_cache_get_data(
         &self,
         cache: &<Self::A as Api>::PipelineCache,

--- a/wgpu-hal/src/metal/conv.rs
+++ b/wgpu-hal/src/metal/conv.rs
@@ -359,7 +359,10 @@ pub fn map_render_stages(stage: wgt::ShaderStages) -> MTLRenderStages {
 
 pub fn map_resource_usage(ty: &wgt::BindingType) -> MTLResourceUsage {
     match ty {
-        #[allow(deprecated)]
+        #[allow(
+            deprecated,
+            reason = "kept to support the API through the deprecation cycle"
+        )]
         wgt::BindingType::Texture { .. } => MTLResourceUsage::Sample,
         wgt::BindingType::StorageTexture { access, .. } => match access {
             wgt::StorageTextureAccess::WriteOnly => MTLResourceUsage::Write,

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -190,7 +190,10 @@ impl super::Device {
 
                 let options = naga::back::msl::Options {
                     lang_version: match self.shared.private_caps.msl_version {
-                        #[allow(deprecated)]
+                        #[allow(
+                            deprecated,
+                            reason = "kept to support the API through the deprecation cycle"
+                        )]
                         MTLLanguageVersion::Version1_0 => (1, 0),
                         MTLLanguageVersion::Version1_1 => (1, 1),
                         MTLLanguageVersion::Version1_2 => (1, 2),
@@ -1347,7 +1350,10 @@ impl crate::Device for super::Device {
                     }
                 };
             }
-            #[allow(non_snake_case)]
+            #[allow(
+                non_snake_case,
+                reason = "kept to mirror the source specification naming"
+            )]
             impl MetalGenericRenderPipelineDescriptor {
                 unsafe fn setFragmentFunction(
                     &self,
@@ -1722,7 +1728,10 @@ impl crate::Device for super::Device {
                 //TODO: handle sample mask
                 match descriptor {
                     MetalGenericRenderPipelineDescriptor::Standard(ref inner) => {
-                        #[allow(deprecated)]
+                        #[allow(
+                            deprecated,
+                            reason = "kept to support the API through the deprecation cycle"
+                        )]
                         inner.setSampleCount(desc.multisample.count as _);
                     }
                     MetalGenericRenderPipelineDescriptor::Mesh(ref inner) => {
@@ -2059,7 +2068,10 @@ impl crate::Device for super::Device {
         let shared_capture_manager = unsafe { MTLCaptureManager::sharedCaptureManager() };
         let default_capture_scope = shared_capture_manager.newCaptureScopeWithDevice(device);
         shared_capture_manager.setDefaultCaptureScope(Some(&default_capture_scope));
-        #[allow(deprecated)]
+        #[allow(
+            deprecated,
+            reason = "kept to support the API through the deprecation cycle"
+        )]
         shared_capture_manager.startCaptureWithScope(&default_capture_scope);
         default_capture_scope.beginScope();
         true

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -224,7 +224,10 @@ bitflags!(
     }
 );
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "used by some feature/backend combinations or not yet wired up"
+)]
 struct CapabilitiesQuery {
     msl_version: MTLLanguageVersion,
     fragment_rw_storage: bool,
@@ -374,7 +377,10 @@ struct PrivateDisabilities {
     /// Near depth is not respected properly on some Intel GPUs.
     broken_viewport_near_depth: bool,
     /// Multi-target clears don't appear to work properly on Intel GPUs.
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     broken_layered_clear_image: bool,
 }
 
@@ -1130,7 +1136,10 @@ impl crate::DynShaderModule for ShaderModule {}
 
 #[derive(Debug)]
 struct PipelineStageInfo {
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     library: Option<Retained<ProtocolObject<dyn MTLLibrary>>>,
     immediates: Option<ImmediateDataInfo>,
 

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -19,7 +19,10 @@ const INDEXING_FEATURES: wgt::Features = wgt::Features::TEXTURE_BINDING_ARRAY
     .union(wgt::Features::STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING)
     .union(wgt::Features::UNIFORM_BUFFER_BINDING_ARRAYS)
     .union(wgt::Features::PARTIALLY_BOUND_BINDING_ARRAY);
-#[expect(rustdoc::private_intra_doc_links)]
+#[expect(
+    rustdoc::private_intra_doc_links,
+    reason = "links to private items kept for convenience"
+)]
 /// Features supported by a [`vk::PhysicalDevice`] and its extensions.
 ///
 /// This is used in two phases:
@@ -2609,7 +2612,10 @@ impl super::Adapter {
     /// - `enabled_extensions` must be a superset of `required_device_extensions()`.
     /// - If `drop_callback` is [`None`], wgpu-hal will take ownership of `raw_device`. If
     ///   `drop_callback` is [`Some`], `raw_device` must be valid until the callback is called.
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub unsafe fn device_from_raw(
         &self,
         raw_device: ash::Device,

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -495,7 +495,10 @@ impl super::Device {
             .handle_type(vk::ExternalMemoryHandleTypeFlags::D3D11_TEXTURE)
             .handle(d3d11_shared_handle.0 as _);
         // TODO: We should use `push_next` instead, but currently ash does not provide this method for the `ImportMemoryWin32HandleInfoKHR` type.
-        #[allow(clippy::unnecessary_mut_passed)]
+        #[allow(
+            clippy::unnecessary_mut_passed,
+            reason = "mut kept for uniformity with sibling calls"
+        )]
         {
             import_memory_info.p_next = <*const _>::cast(&mut dedicated_allocate_info);
         }

--- a/wgpu-hal/src/vulkan/drm.rs
+++ b/wgpu-hal/src/vulkan/drm.rs
@@ -22,7 +22,10 @@ impl drm::Device for Card {}
 
 macro_rules! to_u64 {
     ($expr:expr) => {{
-        #[allow(trivial_numeric_casts)]
+        #[allow(
+            trivial_numeric_casts,
+            reason = "casts kept explicit for width clarity"
+        )]
         let expr = $expr as u64;
         assert!(size_of_val(&expr) <= size_of::<u64>());
         expr
@@ -180,7 +183,10 @@ impl super::Instance {
             //   `st_rdev` is `c_ulonglong`. So, we can't just do a `==` comparison.
             // - OpenBSD has `dev_t` on both sides, but is `i32` (N.B., unsigned). Therefore, we
             //   can't just use `u64::from`.
-            #[allow(clippy::useless_conversion)]
+            #[allow(
+                clippy::useless_conversion,
+                reason = "conversion kept explicit for clarity"
+            )]
             if [primary_devid, render_devid]
                 .map(|devid| to_u64!(devid))
                 .contains(&to_u64!(drm_stat.st_rdev))

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -387,7 +387,10 @@ impl super::Instance {
     ///
     /// If `debug_utils_user_data` is `Some`, then the validation layer is
     /// available, so create a [`vk::DebugUtilsMessengerEXT`].
-    #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "kept for API compatibility and readability"
+    )]
     pub unsafe fn from_raw(
         entry: ash::Entry,
         raw_instance: ash::Instance,

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -131,7 +131,10 @@ struct DebugUtils {
     /// `InstanceShared::drop` destroys the debug messenger before
     /// dropping this, so the callback should never receive a dangling
     /// user data pointer.
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     callback_data: Box<DebugUtilsMessengerUserData>,
 }
 
@@ -1729,7 +1732,7 @@ fn get_unexpected_err(_err: vk::Result) -> crate::DeviceError {
     #[cfg(feature = "internal_error_panic")]
     panic!("Unexpected Vulkan error: {_err:?}");
 
-    #[allow(unreachable_code)]
+    #[allow(unreachable_code, reason = "kept behind feature/version gates")]
     crate::DeviceError::Unexpected
 }
 
@@ -1744,7 +1747,7 @@ fn get_lost_err() -> crate::DeviceError {
     #[cfg(feature = "device_lost_panic")]
     panic!("Device lost");
 
-    #[allow(unreachable_code)]
+    #[allow(unreachable_code, reason = "kept behind feature/version gates")]
     crate::DeviceError::Lost
 }
 

--- a/wgpu-types/src/backend.rs
+++ b/wgpu-types/src/backend.rs
@@ -741,7 +741,10 @@ impl Dx12SwapchainKind {
 
 /// DXC shader model.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
-#[allow(missing_docs)]
+#[allow(
+    missing_docs,
+    reason = "kept for internal items not part of the public API"
+)]
 pub enum DxcShaderModel {
     V6_0,
     V6_1,

--- a/wgpu-types/src/counters.rs
+++ b/wgpu-types/src/counters.rs
@@ -103,7 +103,10 @@ impl fmt::Debug for InternalCounter {
 }
 
 /// `wgpu-hal`'s part of [`InternalCounters`].
-#[allow(missing_docs)]
+#[allow(
+    missing_docs,
+    reason = "kept for internal items not part of the public API"
+)]
 #[derive(Clone, Debug, Default)]
 pub struct HalCounters {
     // API objects

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -176,7 +176,7 @@ macro_rules! bitflags_array {
         $(#[$outer])*
         pub struct $name {
             $(
-                #[allow(missing_docs)]
+                #[allow(missing_docs, reason = "kept for internal items not part of the public API")]
                 $vis $lower_inner_name: $inner_name,
             )*
         }

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -347,7 +347,10 @@ pub struct Color {
     pub a: f64,
 }
 
-#[allow(missing_docs)]
+#[allow(
+    missing_docs,
+    reason = "kept for internal items not part of the public API"
+)]
 impl Color {
     pub const TRANSPARENT: Self = Self {
         r: 0.0,

--- a/wgpu-types/src/limits.rs
+++ b/wgpu-types/src/limits.rs
@@ -1043,7 +1043,10 @@ impl Limits {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DownlevelLimits {}
 
-#[allow(clippy::derivable_impls)]
+#[allow(
+    clippy::derivable_impls,
+    reason = "manual impl kept for explicit control"
+)]
 impl Default for DownlevelLimits {
     fn default() -> Self {
         DownlevelLimits {}

--- a/wgpu-types/src/origin_extent.rs
+++ b/wgpu-types/src/origin_extent.rs
@@ -12,9 +12,15 @@ use crate::TextureDimension;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct Origin2d {
-    #[allow(missing_docs)]
+    #[allow(
+        missing_docs,
+        reason = "kept for internal items not part of the public API"
+    )]
     pub x: u32,
-    #[allow(missing_docs)]
+    #[allow(
+        missing_docs,
+        reason = "kept for internal items not part of the public API"
+    )]
     pub y: u32,
 }
 

--- a/wgpu-types/src/texture/external_texture.rs
+++ b/wgpu-types/src/texture/external_texture.rs
@@ -25,7 +25,10 @@ pub enum ExternalTextureFormat {
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, bytemuck::Zeroable, bytemuck::Pod)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[allow(missing_docs)]
+#[allow(
+    missing_docs,
+    reason = "kept for internal items not part of the public API"
+)]
 pub struct ExternalTextureTransferFunction {
     pub a: f32,
     pub b: f32,

--- a/wgpu-types/src/write_only.rs
+++ b/wgpu-types/src/write_only.rs
@@ -1017,7 +1017,10 @@ mod tests {
 
     /// Test that slicing correctly panics on an out-of-bounds range.
     #[test]
-    #[expect(clippy::reversed_empty_ranges)]
+    #[expect(
+        clippy::reversed_empty_ranges,
+        reason = "kept as the range intent is clear here"
+    )]
     fn slice_bounds_check_failures() {
         // RangeBounds isn’t dyn compatible, so we can’t make a list of test cases and have to
         // use a generic function.

--- a/wgpu/src/api/blas.rs
+++ b/wgpu/src/api/blas.rs
@@ -245,28 +245,58 @@ impl Blas {
 }
 
 /// Context version of [BlasTriangleGeometry].
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "kept for the public API surface"
+)]
 pub struct ContextBlasTriangleGeometry<'a> {
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) size: &'a BlasTriangleGeometrySizeDescriptor,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) vertex_buffer: &'a dispatch::DispatchBuffer,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) index_buffer: Option<&'a dispatch::DispatchBuffer>,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) transform_buffer: Option<&'a dispatch::DispatchBuffer>,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) first_vertex: u32,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) vertex_stride: wgt::BufferAddress,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) index_buffer_offset: Option<wgt::BufferAddress>,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) transform_buffer_offset: Option<wgt::BufferAddress>,
 }
 
 /// Context version of [BlasGeometries].
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "kept for the public API surface"
+)]
 pub enum ContextBlasGeometries<'a> {
     /// Triangle geometries.
     TriangleGeometries(Box<dyn Iterator<Item = ContextBlasTriangleGeometry<'a>> + 'a>),
@@ -275,24 +305,48 @@ pub enum ContextBlasGeometries<'a> {
 }
 
 /// Context version of [BlasAabbGeometry].
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "kept for the public API surface"
+)]
 pub struct ContextBlasAabbGeometry<'a> {
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) size: &'a BlasAABBGeometrySizeDescriptor,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) stride: wgt::BufferAddress,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) aabb_buffer: &'a dispatch::DispatchBuffer,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) primitive_offset: u32,
 }
 
 /// Context version see [BlasBuildEntry].
-#[expect(missing_debug_implementations)]
+#[expect(
+    missing_debug_implementations,
+    reason = "kept for the public API surface"
+)]
 pub struct ContextBlasBuildEntry<'a> {
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) blas: &'a dispatch::DispatchBlas,
-    #[expect(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used by some feature/backend combinations or not yet wired up"
+    )]
     pub(crate) geometries: ContextBlasGeometries<'a>,
 }
 

--- a/wgpu/src/api/instance.rs
+++ b/wgpu/src/api/instance.rs
@@ -63,7 +63,11 @@ impl Instance {
     ///
     /// - If no backend feature for the active target platform is enabled,
     ///   this method will panic; see [`Instance::enabled_backend_features()`].
-    #[allow(clippy::allow_attributes, unreachable_code)]
+    #[allow(
+        clippy::allow_attributes,
+        unreachable_code,
+        reason = "allow_attributes not yet enabled workspace-wide"
+    )]
     pub fn new(desc: InstanceDescriptor) -> Self {
         if Self::enabled_backend_features().is_empty() {
             panic!(

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -508,7 +508,10 @@ pub(crate) enum CreateSurfaceErrorKind {
     Hal(wgc::instance::CreateSurfaceError),
 
     /// Error from WebGPU surface creation.
-    #[cfg_attr(not(webgpu), expect(dead_code))]
+    #[cfg_attr(
+        not(webgpu),
+        expect(dead_code, reason = "cfg-gated out of the webgpu build")
+    )]
     Web(String),
 
     /// Error when trying to get a [`RawDisplayHandle`][rdh] or a

--- a/wgpu/src/backend/custom.rs
+++ b/wgpu/src/backend/custom.rs
@@ -1,6 +1,9 @@
 //! Provides wrappers custom backend implementations
 
-#![allow(ambiguous_wide_pointer_comparisons)]
+#![allow(
+    ambiguous_wide_pointer_comparisons,
+    reason = "custom backend is a deprecated shim"
+)]
 
 pub use crate::dispatch::*;
 
@@ -22,7 +25,7 @@ macro_rules! dyn_type {
                 Self(Arc::new(t))
             }
 
-            #[allow(clippy::allow_attributes, dead_code)]
+            #[allow(clippy::allow_attributes, dead_code, reason = "allow_attributes not yet enabled workspace-wide")]
             pub(crate) fn downcast<T: $interface>(&self) -> Option<&T> {
                 self.0.as_ref().as_any().downcast_ref()
             }

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2,7 +2,10 @@
 
 mod defined_non_null_js_value;
 mod ext_bindings;
-#[allow(clippy::allow_attributes)]
+#[allow(
+    clippy::allow_attributes,
+    reason = "needed until allow_attributes is enabled"
+)]
 pub(crate) mod webgpu_sys;
 
 use alloc::{

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBindGroupDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBindGroupDescriptor.rs
@@ -99,7 +99,10 @@ impl GpuBindGroupDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(entries: &[GpuBindGroupEntry], layout: &GpuBindGroupLayout) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_entries(entries);
         ret.set_layout(layout);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBindGroupEntry.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBindGroupEntry.rs
@@ -126,7 +126,10 @@ impl GpuBindGroupEntry {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(binding: u32, resource: &GpuSampler) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_binding(binding);
         ret.set_resource(resource);
@@ -140,7 +143,10 @@ impl GpuBindGroupEntry {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_gpu_texture(binding: u32, resource: &GpuTexture) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_binding(binding);
         ret.set_resource_gpu_texture(resource);
@@ -154,7 +160,10 @@ impl GpuBindGroupEntry {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_gpu_texture_view(binding: u32, resource: &GpuTextureView) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_binding(binding);
         ret.set_resource_gpu_texture_view(resource);
@@ -168,7 +177,10 @@ impl GpuBindGroupEntry {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_gpu_buffer(binding: u32, resource: &GpuBuffer) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_binding(binding);
         ret.set_resource_gpu_buffer(resource);
@@ -182,7 +194,10 @@ impl GpuBindGroupEntry {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_gpu_buffer_binding(binding: u32, resource: &GpuBufferBinding) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_binding(binding);
         ret.set_resource_gpu_buffer_binding(resource);
@@ -196,7 +211,10 @@ impl GpuBindGroupEntry {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_gpu_external_texture(binding: u32, resource: &GpuExternalTexture) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_binding(binding);
         ret.set_resource_gpu_external_texture(resource);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBindGroupLayoutDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBindGroupLayoutDescriptor.rs
@@ -83,7 +83,10 @@ impl GpuBindGroupLayoutDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(entries: &[GpuBindGroupLayoutEntry]) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_entries(entries);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBindGroupLayoutEntry.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBindGroupLayoutEntry.rs
@@ -181,7 +181,10 @@ impl GpuBindGroupLayoutEntry {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(binding: u32, visibility: u32) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_binding(binding);
         ret.set_visibility(visibility);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBlendComponent.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBlendComponent.rs
@@ -99,7 +99,10 @@ impl GpuBlendComponent {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBlendState.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBlendState.rs
@@ -81,7 +81,10 @@ impl GpuBlendState {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(alpha: &GpuBlendComponent, color: &GpuBlendComponent) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_alpha(alpha);
         ret.set_color(color);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBufferBinding.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBufferBinding.rs
@@ -117,7 +117,10 @@ impl GpuBufferBinding {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(buffer: &GpuBuffer) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_buffer(buffer);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBufferBindingLayout.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBufferBindingLayout.rs
@@ -108,7 +108,10 @@ impl GpuBufferBindingLayout {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBufferDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuBufferDescriptor.rs
@@ -126,7 +126,10 @@ impl GpuBufferDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(size: u32, usage: u32) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_size(size);
         ret.set_usage(usage);
@@ -139,7 +142,10 @@ impl GpuBufferDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_f64(size: f64, usage: u32) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_size_f64(size);
         ret.set_usage(usage);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCanvasConfiguration.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCanvasConfiguration.rs
@@ -155,7 +155,10 @@ impl GpuCanvasConfiguration {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(device: &GpuDevice, format: GpuTextureFormat) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_device(device);
         ret.set_format(format);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCanvasToneMapping.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCanvasToneMapping.rs
@@ -63,7 +63,10 @@ impl GpuCanvasToneMapping {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuColorDict.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuColorDict.rs
@@ -117,7 +117,10 @@ impl GpuColorDict {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(a: f64, b: f64, g: f64, r: f64) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_a(a);
         ret.set_b(b);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuColorTargetState.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuColorTargetState.rs
@@ -99,7 +99,10 @@ impl GpuColorTargetState {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(format: GpuTextureFormat) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_format(format);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCommandBufferDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCommandBufferDescriptor.rs
@@ -63,7 +63,10 @@ impl GpuCommandBufferDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCommandEncoderDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCommandEncoderDescriptor.rs
@@ -63,7 +63,10 @@ impl GpuCommandEncoderDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuComputePassDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuComputePassDescriptor.rs
@@ -86,7 +86,10 @@ impl GpuComputePassDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuComputePassTimestampWrites.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuComputePassTimestampWrites.rs
@@ -102,7 +102,10 @@ impl GpuComputePassTimestampWrites {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(query_set: &GpuQuerySet) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_query_set(query_set);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuComputePipelineDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuComputePipelineDescriptor.rs
@@ -111,7 +111,10 @@ impl GpuComputePipelineDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(layout: &GpuPipelineLayout, compute: &GpuProgrammableStage) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_layout(layout);
         ret.set_compute(compute);
@@ -128,7 +131,10 @@ impl GpuComputePipelineDescriptor {
         layout: GpuAutoLayoutMode,
         compute: &GpuProgrammableStage,
     ) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_layout_gpu_auto_layout_mode(layout);
         ret.set_compute(compute);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCopyExternalImageDestInfo.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCopyExternalImageDestInfo.rs
@@ -147,7 +147,10 @@ impl GpuCopyExternalImageDestInfo {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(texture: &GpuTexture) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_texture(texture);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCopyExternalImageSourceInfo.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuCopyExternalImageSourceInfo.rs
@@ -180,7 +180,10 @@ impl GpuCopyExternalImageSourceInfo {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(source: &ImageBitmap) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_source(source);
         ret
@@ -193,7 +196,10 @@ impl GpuCopyExternalImageSourceInfo {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_image_data(source: &ImageData) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_source_image_data(source);
         ret
@@ -206,7 +212,10 @@ impl GpuCopyExternalImageSourceInfo {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_html_image_element(source: &HtmlImageElement) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_source_html_image_element(source);
         ret
@@ -219,7 +228,10 @@ impl GpuCopyExternalImageSourceInfo {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_html_video_element(source: &HtmlVideoElement) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_source_html_video_element(source);
         ret
@@ -232,7 +244,10 @@ impl GpuCopyExternalImageSourceInfo {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_video_frame(source: &VideoFrame) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_source_video_frame(source);
         ret
@@ -245,7 +260,10 @@ impl GpuCopyExternalImageSourceInfo {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_html_canvas_element(source: &HtmlCanvasElement) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_source_html_canvas_element(source);
         ret
@@ -258,7 +276,10 @@ impl GpuCopyExternalImageSourceInfo {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_offscreen_canvas(source: &OffscreenCanvas) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_source_offscreen_canvas(source);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuDepthStencilState.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuDepthStencilState.rs
@@ -225,7 +225,10 @@ impl GpuDepthStencilState {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(format: GpuTextureFormat) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_format(format);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuDeviceDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuDeviceDescriptor.rs
@@ -134,7 +134,10 @@ impl GpuDeviceDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuExtent3dDict.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuExtent3dDict.rs
@@ -99,7 +99,10 @@ impl GpuExtent3dDict {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(width: u32) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_width(width);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuExternalTextureBindingLayout.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuExternalTextureBindingLayout.rs
@@ -48,7 +48,10 @@ impl GpuExternalTextureBindingLayout {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuExternalTextureDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuExternalTextureDescriptor.rs
@@ -90,7 +90,10 @@ impl GpuExternalTextureDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(source: &HtmlVideoElement) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_source(source);
         ret
@@ -103,7 +106,10 @@ impl GpuExternalTextureDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_video_frame(source: &VideoFrame) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_source_video_frame(source);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuFragmentState.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuFragmentState.rs
@@ -122,7 +122,10 @@ impl GpuFragmentState {
         module: &GpuShaderModule,
         targets: &[::js_sys::JsNullable<GpuColorTargetState>],
     ) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_module(module);
         ret.set_targets(targets);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuMultisampleState.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuMultisampleState.rs
@@ -99,7 +99,10 @@ impl GpuMultisampleState {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuObjectDescriptorBase.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuObjectDescriptorBase.rs
@@ -63,7 +63,10 @@ impl GpuObjectDescriptorBase {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuOrigin2dDict.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuOrigin2dDict.rs
@@ -81,7 +81,10 @@ impl GpuOrigin2dDict {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuOrigin3dDict.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuOrigin3dDict.rs
@@ -99,7 +99,10 @@ impl GpuOrigin3dDict {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuPipelineDescriptorBase.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuPipelineDescriptorBase.rs
@@ -93,7 +93,10 @@ impl GpuPipelineDescriptorBase {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(layout: &GpuPipelineLayout) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_layout(layout);
         ret
@@ -106,7 +109,10 @@ impl GpuPipelineDescriptorBase {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_gpu_auto_layout_mode(layout: GpuAutoLayoutMode) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_layout_gpu_auto_layout_mode(layout);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuPipelineLayoutDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuPipelineLayoutDescriptor.rs
@@ -104,7 +104,10 @@ impl GpuPipelineLayoutDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(bind_group_layouts: &[::js_sys::JsNullable<GpuBindGroupLayout>]) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_bind_group_layouts(bind_group_layouts);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuPrimitiveState.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuPrimitiveState.rs
@@ -135,7 +135,10 @@ impl GpuPrimitiveState {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuProgrammableStage.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuProgrammableStage.rs
@@ -100,7 +100,10 @@ impl GpuProgrammableStage {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(module: &GpuShaderModule) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_module(module);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuQuerySetDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuQuerySetDescriptor.rs
@@ -99,7 +99,10 @@ impl GpuQuerySetDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(count: u32, type_: GpuQueryType) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_count(count);
         ret.set_type(type_);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuQueueDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuQueueDescriptor.rs
@@ -63,7 +63,10 @@ impl GpuQueueDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderBundleDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderBundleDescriptor.rs
@@ -63,7 +63,10 @@ impl GpuRenderBundleDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderBundleEncoderDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderBundleEncoderDescriptor.rs
@@ -163,7 +163,10 @@ impl GpuRenderBundleEncoderDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(color_formats: &[::js_sys::JsNullable<::js_sys::JsString>]) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_color_formats(color_formats);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPassColorAttachment.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPassColorAttachment.rs
@@ -183,7 +183,10 @@ impl GpuRenderPassColorAttachment {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(load_op: GpuLoadOp, store_op: GpuStoreOp, view: &GpuTexture) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_load_op(load_op);
         ret.set_store_op(store_op);
@@ -202,7 +205,10 @@ impl GpuRenderPassColorAttachment {
         store_op: GpuStoreOp,
         view: &GpuTextureView,
     ) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_load_op(load_op);
         ret.set_store_op(store_op);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPassDepthStencilAttachment.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPassDepthStencilAttachment.rs
@@ -222,7 +222,10 @@ impl GpuRenderPassDepthStencilAttachment {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(view: &GpuTexture) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_view(view);
         ret
@@ -235,7 +238,10 @@ impl GpuRenderPassDepthStencilAttachment {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_gpu_texture_view(view: &GpuTextureView) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_view_gpu_texture_view(view);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPassDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPassDescriptor.rs
@@ -174,7 +174,10 @@ impl GpuRenderPassDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(color_attachments: &[::js_sys::JsNullable<GpuRenderPassColorAttachment>]) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_color_attachments(color_attachments);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPassTimestampWrites.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPassTimestampWrites.rs
@@ -99,7 +99,10 @@ impl GpuRenderPassTimestampWrites {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(query_set: &GpuQuerySet) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_query_set(query_set);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPipelineDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRenderPipelineDescriptor.rs
@@ -183,7 +183,10 @@ impl GpuRenderPipelineDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(layout: &GpuPipelineLayout, vertex: &GpuVertexState) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_layout(layout);
         ret.set_vertex(vertex);
@@ -200,7 +203,10 @@ impl GpuRenderPipelineDescriptor {
         layout: GpuAutoLayoutMode,
         vertex: &GpuVertexState,
     ) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_layout_gpu_auto_layout_mode(layout);
         ret.set_vertex(vertex);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRequestAdapterOptions.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuRequestAdapterOptions.rs
@@ -117,7 +117,10 @@ impl GpuRequestAdapterOptions {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuSamplerBindingLayout.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuSamplerBindingLayout.rs
@@ -63,7 +63,10 @@ impl GpuSamplerBindingLayout {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuSamplerDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuSamplerDescriptor.rs
@@ -243,7 +243,10 @@ impl GpuSamplerDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuShaderModuleCompilationHint.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuShaderModuleCompilationHint.rs
@@ -96,7 +96,10 @@ impl GpuShaderModuleCompilationHint {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(entry_point: &str) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_entry_point(entry_point);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuShaderModuleDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuShaderModuleDescriptor.rs
@@ -104,7 +104,10 @@ impl GpuShaderModuleDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(code: &str) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_code(code);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuStencilFaceState.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuStencilFaceState.rs
@@ -117,7 +117,10 @@ impl GpuStencilFaceState {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuStorageTextureBindingLayout.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuStorageTextureBindingLayout.rs
@@ -104,7 +104,10 @@ impl GpuStorageTextureBindingLayout {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(format: GpuTextureFormat) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_format(format);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTexelCopyBufferInfo.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTexelCopyBufferInfo.rs
@@ -126,7 +126,10 @@ impl GpuTexelCopyBufferInfo {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(buffer: &GpuBuffer) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_buffer(buffer);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTexelCopyBufferLayout.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTexelCopyBufferLayout.rs
@@ -108,7 +108,10 @@ impl GpuTexelCopyBufferLayout {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTexelCopyTextureInfo.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTexelCopyTextureInfo.rs
@@ -126,7 +126,10 @@ impl GpuTexelCopyTextureInfo {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(texture: &GpuTexture) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_texture(texture);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTextureBindingLayout.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTextureBindingLayout.rs
@@ -99,7 +99,10 @@ impl GpuTextureBindingLayout {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTextureDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTextureDescriptor.rs
@@ -223,7 +223,10 @@ impl GpuTextureDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(format: GpuTextureFormat, size: &[::js_sys::Number], usage: u32) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_format(format);
         ret.set_size(size);
@@ -242,7 +245,10 @@ impl GpuTextureDescriptor {
         size: &GpuExtent3dDict,
         usage: u32,
     ) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_format(format);
         ret.set_size_gpu_extent_3d_dict(size);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTextureViewDescriptor.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuTextureViewDescriptor.rs
@@ -225,7 +225,10 @@ impl GpuTextureViewDescriptor {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuUncapturedErrorEventInit.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuUncapturedErrorEventInit.rs
@@ -117,7 +117,10 @@ impl GpuUncapturedErrorEventInit {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(error: &GpuError) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_error(error);
         ret

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuVertexAttribute.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuVertexAttribute.rs
@@ -108,7 +108,10 @@ impl GpuVertexAttribute {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(format: GpuVertexFormat, offset: u32, shader_location: u32) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_format(format);
         ret.set_offset(offset);
@@ -123,7 +126,10 @@ impl GpuVertexAttribute {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_f64(format: GpuVertexFormat, offset: f64, shader_location: u32) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_format(format);
         ret.set_offset_f64(offset);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuVertexBufferLayout.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuVertexBufferLayout.rs
@@ -108,7 +108,10 @@ impl GpuVertexBufferLayout {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(array_stride: u32, attributes: &[GpuVertexAttribute]) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_array_stride(array_stride);
         ret.set_attributes(attributes);
@@ -122,7 +125,10 @@ impl GpuVertexBufferLayout {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_f64(array_stride: f64, attributes: &[GpuVertexAttribute]) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_array_stride_f64(array_stride);
         ret.set_attributes(attributes);

--- a/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuVertexState.rs
+++ b/wgpu/src/backend/webgpu/webgpu_sys/gen_GpuVertexState.rs
@@ -119,7 +119,10 @@ impl GpuVertexState {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://wasm-bindgen.github.io/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(module: &GpuShaderModule) -> Self {
-        #[allow(unused_mut)]
+        #[allow(
+            unused_mut,
+            reason = "intended by the macro/derived code that requires it"
+        )]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.set_module(module);
         ret

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -276,7 +276,10 @@ fn map_texture_copy_view(
     }
 }
 
-#[cfg_attr(not(webgl), expect(unused))]
+#[cfg_attr(
+    not(webgl),
+    expect(unused, reason = "cfg-gated out of the webgl build")
+)]
 fn map_texture_tagged_copy_view(
     view: crate::CopyExternalImageDestInfo<&api::Texture>,
 ) -> wgt::CopyExternalImageDestInfo<Arc<wgc::resource::Texture>> {

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -75,7 +75,10 @@ pub type BlasCompactCallback = Box<dyn FnOnce(Result<(), crate::BlasAsyncError>)
 pub type BlasCompactCallback = Box<dyn FnOnce(Result<(), crate::BlasAsyncError>) + 'static>;
 
 // remove when rust 1.86
-#[cfg_attr(not(custom), expect(dead_code))]
+#[cfg_attr(
+    not(custom),
+    expect(dead_code, reason = "cfg-gated out of the custom driver build")
+)]
 pub trait AsAny {
     fn as_any(&self) -> &dyn Any;
 }
@@ -750,7 +753,7 @@ macro_rules! dispatch_types {
             Core($core_type),
             #[cfg(webgpu)]
             WebGPU($webgpu_type),
-            #[allow(clippy::allow_attributes, private_interfaces)]
+            #[allow(clippy::allow_attributes, private_interfaces, reason = "allow_attributes not yet enabled workspace-wide")]
             #[cfg(custom)]
             Custom($custom_type),
         }
@@ -758,7 +761,7 @@ macro_rules! dispatch_types {
         impl $name {
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_core(&self) -> &$core_type {
                 match self {
                     Self::Core(value) => value,
@@ -768,7 +771,7 @@ macro_rules! dispatch_types {
 
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_core_opt(&self) -> Option<&$core_type> {
                 match self {
                     Self::Core(value) => Some(value),
@@ -778,7 +781,7 @@ macro_rules! dispatch_types {
 
             #[cfg(custom)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_custom<T: $interface>(&self) -> Option<&T> {
                 match self {
                     Self::Custom(value) => value.downcast(),
@@ -788,7 +791,7 @@ macro_rules! dispatch_types {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_webgpu(&self) -> &$webgpu_type {
                 match self {
                     Self::WebGPU(value) => value,
@@ -798,7 +801,7 @@ macro_rules! dispatch_types {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_webgpu_opt(&self) -> Option<&$webgpu_type> {
                 match self {
                     Self::WebGPU(value) => Some(value),
@@ -856,7 +859,7 @@ macro_rules! dispatch_types {
             Core($core_type),
             #[cfg(webgpu)]
             WebGPU($webgpu_type),
-            #[allow(clippy::allow_attributes, private_interfaces)]
+            #[allow(clippy::allow_attributes, private_interfaces, reason = "allow_attributes not yet enabled workspace-wide")]
             #[cfg(custom)]
             Custom($custom_type),
         }
@@ -864,7 +867,7 @@ macro_rules! dispatch_types {
         impl $name {
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_core(&self) -> &$core_type {
                 match self {
                     Self::Core(value) => value,
@@ -874,7 +877,7 @@ macro_rules! dispatch_types {
 
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_core_mut(&mut self) -> &mut $core_type {
                 match self {
                     Self::Core(value) => value,
@@ -884,7 +887,7 @@ macro_rules! dispatch_types {
 
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_core_opt(&self) -> Option<&$core_type> {
                 match self {
                     Self::Core(value) => Some(value),
@@ -894,7 +897,7 @@ macro_rules! dispatch_types {
 
             #[cfg(wgpu_core)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_core_mut_opt(
                 &mut self,
             ) -> Option<&mut $core_type> {
@@ -906,7 +909,7 @@ macro_rules! dispatch_types {
 
             #[cfg(custom)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_custom<T: $interface>(&self) -> Option<&T> {
                 match self {
                     Self::Custom(value) => value.downcast(),
@@ -916,7 +919,7 @@ macro_rules! dispatch_types {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_webgpu(&self) -> &$webgpu_type {
                 match self {
                     Self::WebGPU(value) => value,
@@ -926,7 +929,7 @@ macro_rules! dispatch_types {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_webgpu_mut(&mut self) -> &mut $webgpu_type {
                 match self {
                     Self::WebGPU(value) => value,
@@ -936,7 +939,7 @@ macro_rules! dispatch_types {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_webgpu_opt(&self) -> Option<&$webgpu_type> {
                 match self {
                     Self::WebGPU(value) => Some(value),
@@ -946,7 +949,7 @@ macro_rules! dispatch_types {
 
             #[cfg(webgpu)]
             #[inline]
-            #[allow(clippy::allow_attributes, unused)]
+            #[allow(clippy::allow_attributes, unused, reason = "allow_attributes not yet enabled workspace-wide")]
             pub fn as_webgpu_mut_opt(
                 &mut self,
             ) -> Option<&mut $webgpu_type> {

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -235,6 +235,7 @@
     // These degrade readability significantly.
     clippy::bool_assert_comparison,
     clippy::bool_comparison,
+    reason = "investigated separately",
 )]
 // NOTE: Keep this in sync with `wgpu-core`.
 #![cfg_attr(not(send_sync), allow(clippy::arc_with_non_send_sync))]
@@ -303,7 +304,10 @@ pub use wgt::{
     QUERY_RESOLVE_BUFFER_ALIGNMENT, QUERY_SET_MAX_QUERIES, QUERY_SIZE, VERTEX_ALIGNMENT,
 };
 
-#[expect(deprecated)]
+#[expect(
+    deprecated,
+    reason = "kept to support the API through the deprecation cycle"
+)]
 pub use wgt::VERTEX_STRIDE_ALIGNMENT;
 
 // wasm-only types, we try to keep as many types non-platform

--- a/wgpu/src/macros/mod.rs
+++ b/wgpu/src/macros/mod.rs
@@ -127,7 +127,10 @@ macro_rules! include_spirv {
 }
 
 #[cfg(all(feature = "spirv", test))]
-#[expect(dead_code)]
+#[expect(
+    dead_code,
+    reason = "used by some feature/backend combinations or not yet wired up"
+)]
 static SPIRV: crate::ShaderModuleDescriptor<'_> = include_spirv!("le-aligned.spv");
 
 /// Macro to load raw SPIR-V data statically, for use with [`Features::PASSTHROUGH_SHADERS`].
@@ -159,7 +162,10 @@ macro_rules! include_spirv_raw {
 }
 
 #[cfg(test)]
-#[expect(dead_code)]
+#[expect(
+    dead_code,
+    reason = "used by some feature/backend combinations or not yet wired up"
+)]
 static SPIRV_RAW: crate::ShaderModuleDescriptorPassthrough<'_> =
     include_spirv_raw!("le-aligned.spv");
 

--- a/wgpu/src/util/spirv.rs
+++ b/wgpu/src/util/spirv.rs
@@ -3,7 +3,10 @@
 use alloc::borrow::Cow;
 use core::mem;
 
-#[cfg_attr(not(any(feature = "spirv", doc)), expect(unused_imports))]
+#[cfg_attr(
+    not(any(feature = "spirv", doc)),
+    expect(unused_imports, reason = "cfg-gated out of the spirv build")
+)]
 use crate::ShaderSource;
 
 #[cfg(doc)]
@@ -75,7 +78,13 @@ const fn assert_has_spirv_magic_number_and_length(bytes: &[u8]) -> bool {
     }
 }
 
-#[cfg_attr(not(feature = "spirv"), expect(rustdoc::broken_intra_doc_links))]
+#[cfg_attr(
+    not(feature = "spirv"),
+    expect(
+        rustdoc::broken_intra_doc_links,
+        reason = "cfg-gated out of the spirv build"
+    )
+)]
 /// Version of [`make_spirv()`] intended for use with
 /// [`Device::create_shader_module_passthrough()`].
 ///

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -63,7 +63,10 @@ pub(crate) fn check_changelog(shell: Shell, mut args: Arguments) -> anyhow::Resu
     if !hunks_in_a_released_section.is_empty() {
         failed = true;
 
-        #[expect(clippy::uninlined_format_args)]
+        #[expect(
+            clippy::uninlined_format_args,
+            reason = "kept for older MSRV readability"
+        )]
         {
             eprintln!(
                 "Found hunk(s) in released sections of `{}`, which we don't want:\n",
@@ -84,7 +87,10 @@ pub(crate) fn check_changelog(shell: Shell, mut args: Arguments) -> anyhow::Resu
     }
 
     if failed {
-        #[expect(clippy::uninlined_format_args)]
+        #[expect(
+            clippy::uninlined_format_args,
+            reason = "kept for older MSRV readability"
+        )]
         let msg = format!(
             "one or more checks against `{}` failed; see above for details",
             CHANGELOG_PATH_RELATIVE,


### PR DESCRIPTION
Closes #9716

Enables the `clippy::allow_attributes` and `clippy::allow_attributes_without_reason` lints in `[workspace.lints.clippy]` and adds a `reason` to every `#[allow]`/`#[expect]` attribute across the workspace.

- 173 files changed, ~1130 insertions
- `cargo check --workspace`, `cargo clippy --workspace --lib --all-targets` and `cargo fmt --check` all pass locally