### PR TITLE
[hlsl-out] Don't panic on a sampler whose group has no sampler index buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ By @sagudev in [#10115](https://github.com/gfx-rs/wgpu/pull/10115).
 - Fix panics when shader `var<immediate>` size is larger than 256 bytes. By @beicause in [#9725](https://github.com/gfx-rs/wgpu/pull/9725).
 - Fix a panic in the SPIR-V frontend when a subgroup collective operation (e.g. `OpGroupNonUniformUMin`) or `OpGroupNonUniformBallot` used an argument whose value needed to be spilled to a temporary variable, such as when the argument was computed inside a loop. By @nazar-pc in [#9957](https://github.com/gfx-rs/wgpu/issues/9957).
 - Lower `@builtin(instance_index)` in `@any_hit` and `@closest_hit` entry points to SPIR-V's `InstanceId` rather than `InstanceIndex`, which Vulkan only permits in the vertex stage. By @JMS55 in [10154](https://github.com/gfx-rs/wgpu/pull/10154).
+- Fix a panic in the HLSL backend when a module declares a sampler whose bind group has no sampler index buffer. The sampler's declaration is now skipped, matching how other globals with unresolvable bindings are handled, and an entry point that actually uses such a sampler reports `EntryPointError::MissingSamplerIndexBuffer` instead of panicking. By @samvallad33 in [#10197](https://github.com/gfx-rs/wgpu/pull/10197).
 
 #### Validation
 

--- a/naga/src/back/hlsl/help.rs
+++ b/naga/src/back/hlsl/help.rs
@@ -2053,16 +2053,16 @@ impl<W: Write> super::Writer<'_, W> {
     }
 
     /// Writes out the sampler index buffer declaration if it hasn't been written yet.
+    ///
+    /// `bind_target` is the register the index buffer is bound to, resolved by
+    /// the caller with [`Options::resolve_sampler_index_buffer_binding`].
+    ///
+    /// [`Options::resolve_sampler_index_buffer_binding`]: super::Options::resolve_sampler_index_buffer_binding
     pub(super) fn write_wrapped_sampler_buffer(
         &mut self,
         key: super::SamplerIndexBufferKey,
+        bind_target: super::BindTarget,
     ) -> BackendResult {
-        // The astute will notice that we do a double hash lookup, but we do this to avoid
-        // holding a mutable reference to `self` while trying to call `write_sampler_heaps`.
-        //
-        // We only pay this double lookup cost when we actually need to write out the sampler
-        // buffer, which should be not be common.
-
         if self.wrapped.sampler_index_buffers.contains_key(&key) {
             return Ok(());
         };
@@ -2074,20 +2074,6 @@ impl<W: Write> super::Writer<'_, W> {
         let sampler_array_name = self
             .namer
             .call(&format!("nagaGroup{}SamplerIndexArray", key.group));
-
-        let bind_target = match self.options.sampler_buffer_binding_map.get(&key) {
-            Some(&bind_target) => bind_target,
-            None if self.options.fake_missing_bindings => super::BindTarget {
-                space: u8::MAX,
-                register: key.group,
-                binding_array_size: None,
-                dynamic_storage_buffer_offsets_index: None,
-                restrict_indexing: false,
-            },
-            None => {
-                unreachable!("Sampler buffer of group {key:?} not bound to a register");
-            }
-        };
 
         writeln!(
             self.out,

--- a/naga/src/back/hlsl/mod.rs
+++ b/naga/src/back/hlsl/mod.rs
@@ -466,6 +466,8 @@ type BackendResult = Result<(), Error>;
 pub enum EntryPointError {
     #[error("mapping of {0:?} is missing")]
     MissingBinding(crate::ResourceBinding),
+    #[error("mapping of the sampler index buffer of group {0} is missing")]
+    MissingSamplerIndexBuffer(u32),
 }
 
 /// Configuration used in the [`Writer`].
@@ -601,6 +603,36 @@ impl Options {
                 restrict_indexing: false,
             }),
             None => Err(EntryPointError::MissingBinding(*res_binding)),
+        }
+    }
+
+    /// Find the [`BindTarget`] for the sampler index buffer of `key`'s group.
+    ///
+    /// A sampler global's own [`BindTarget`] does not name a register: it holds
+    /// an index into its bind group's sampler index buffer, and that buffer
+    /// needs a register of its own. [`sampler_buffer_binding_map`] only has an
+    /// entry for a group whose layout actually contains samplers, so this can
+    /// fail even when [`resolve_resource_binding`] succeeds for the same
+    /// global: [`binding_map`] is keyed on group and binding alone, and carries
+    /// no indication of which kind of resource the layout has in that slot.
+    ///
+    /// [`sampler_buffer_binding_map`]: Options::sampler_buffer_binding_map
+    /// [`resolve_resource_binding`]: Options::resolve_resource_binding
+    /// [`binding_map`]: Options::binding_map
+    fn resolve_sampler_index_buffer_binding(
+        &self,
+        key: SamplerIndexBufferKey,
+    ) -> Result<BindTarget, EntryPointError> {
+        match self.sampler_buffer_binding_map.get(&key) {
+            Some(&target) => Ok(target),
+            None if self.fake_missing_bindings => Ok(BindTarget {
+                space: u8::MAX,
+                register: key.group,
+                binding_array_size: None,
+                dynamic_storage_buffer_offsets_index: None,
+                restrict_indexing: false,
+            }),
+            None => Err(EntryPointError::MissingSamplerIndexBuffer(key.group)),
         }
     }
 

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -465,11 +465,16 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                         .iter()
                         .find(|&(var_handle, var)| match var.binding {
                             Some(ref binding) if !info[var_handle].is_empty() => {
-                                self.options.resolve_resource_binding(binding).is_err()
+                                (self.options.resolve_resource_binding(binding).is_err()
                                     && self
                                         .options
                                         .resolve_external_texture_resource_binding(binding)
-                                        .is_err()
+                                        .is_err())
+                                    || sampler_index_buffer_key(module, var).is_some_and(|key| {
+                                        self.options
+                                            .resolve_sampler_index_buffer_binding(key)
+                                            .is_err()
+                                    })
                             }
                             _ => false,
                         })
@@ -516,6 +521,14 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
                                     .options
                                     .resolve_external_texture_resource_binding(binding)
                                     .is_err()
+                                {
+                                    ep_error = Some(err);
+                                    break;
+                                }
+                            }
+                            if let Some(key) = sampler_index_buffer_key(module, var) {
+                                if let Err(err) =
+                                    self.options.resolve_sampler_index_buffer_binding(key)
                                 {
                                     ep_error = Some(err);
                                     break;
@@ -1064,7 +1077,22 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         let is_sampler = matches!(*handle_ty, TypeInner::Sampler { .. });
 
         if is_sampler {
-            return self.write_global_sampler(module, handle, global);
+            let key = super::SamplerIndexBufferKey {
+                group: global.binding.as_ref().unwrap().group,
+            };
+            let index_buffer_target = match self.options.resolve_sampler_index_buffer_binding(key) {
+                Ok(index_buffer_target) => index_buffer_target,
+                Err(err) => {
+                    log::debug!(
+                        "Skipping global {:?} (name {:?}) for being inaccessible: {}",
+                        handle,
+                        global.name,
+                        err,
+                    );
+                    return Ok(());
+                }
+            };
+            return self.write_global_sampler(module, handle, global, key, index_buffer_target);
         }
 
         // https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-variable-register
@@ -1226,13 +1254,12 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
         module: &Module,
         handle: Handle<crate::GlobalVariable>,
         global: &crate::GlobalVariable,
+        key: super::SamplerIndexBufferKey,
+        index_buffer_target: super::BindTarget,
     ) -> BackendResult {
         let binding = *global.binding.as_ref().unwrap();
 
-        let key = super::SamplerIndexBufferKey {
-            group: binding.group,
-        };
-        self.write_wrapped_sampler_buffer(key)?;
+        self.write_wrapped_sampler_buffer(key, index_buffer_target)?;
 
         // This was already validated, so we can confidently unwrap it.
         let bt = self.options.resolve_resource_binding(&binding).unwrap();
@@ -4961,6 +4988,37 @@ pub(super) fn get_inner_matrix_data(
         TypeInner::Array { base, .. } => get_inner_matrix_data(module, base),
         _ => None,
     }
+}
+
+/// The sampler index buffer that writing `var`'s declaration will require, if
+/// `var` is a sampler global or a binding array of samplers.
+///
+/// A sampler global's own [`BindTarget`] does not name a register. It holds an
+/// index into the sampler index buffer shared by every sampler in its bind
+/// group, and that buffer needs a register of its own, resolved separately from
+/// [`Options::sampler_buffer_binding_map`]. Callers that check whether a global
+/// is accessible must therefore check this second binding too, not just the
+/// global's own [`ResourceBinding`].
+///
+/// [`BindTarget`]: super::BindTarget
+/// [`Options::sampler_buffer_binding_map`]: super::Options::sampler_buffer_binding_map
+/// [`ResourceBinding`]: crate::ResourceBinding
+fn sampler_index_buffer_key(
+    module: &Module,
+    var: &crate::GlobalVariable,
+) -> Option<super::SamplerIndexBufferKey> {
+    let inner = &module.types[var.ty].inner;
+    // Mirrors the unwrapping that `write_global` does to decide `is_sampler`.
+    let handle_ty = match *inner {
+        TypeInner::BindingArray { ref base, .. } => &module.types[*base].inner,
+        _ => inner,
+    };
+    if !matches!(*handle_ty, TypeInner::Sampler { .. }) {
+        return None;
+    }
+    Some(super::SamplerIndexBufferKey {
+        group: var.binding.as_ref()?.group,
+    })
 }
 
 /// If `base` is an access chain of the form `mat`, `mat[col]`, or `mat[col][row]`,

--- a/naga/tests/naga/hlsl.rs
+++ b/naga/tests/naga/hlsl.rs
@@ -1,0 +1,118 @@
+//! Tests of the HLSL backend.
+
+#![cfg(all(feature = "wgsl-in", feature = "hlsl-out"))]
+
+use naga::back::hlsl;
+
+/// Translate `source` for `entry_point`, with a binding map that mimics what
+/// the `dx12` backend builds for a bind group layout holding a single uniform
+/// buffer at `@binding(0)` and a texture at `@binding(1)`, and therefore no
+/// sampler index buffer for group 0.
+fn write_with_texture_at_binding_one(
+    source: &str,
+    entry_point: &str,
+) -> Result<hlsl::ReflectionInfo, hlsl::Error> {
+    let module = naga::front::wgsl::parse_str(source).expect("module should parse");
+    let info = naga::valid::Validator::new(
+        naga::valid::ValidationFlags::all(),
+        naga::valid::Capabilities::all(),
+    )
+    .validate(&module)
+    .expect("module should validate");
+
+    let mut binding_map = hlsl::BindingMap::default();
+    binding_map.insert(
+        naga::ResourceBinding {
+            group: 0,
+            binding: 0,
+        },
+        hlsl::BindTarget {
+            space: 0,
+            register: 0,
+            ..Default::default()
+        },
+    );
+    binding_map.insert(
+        naga::ResourceBinding {
+            group: 0,
+            binding: 1,
+        },
+        hlsl::BindTarget {
+            space: 0,
+            register: 0,
+            ..Default::default()
+        },
+    );
+
+    let options = hlsl::Options {
+        fake_missing_bindings: false,
+        binding_map,
+        sampler_buffer_binding_map: hlsl::SamplerIndexBufferBindingMap::default(),
+        ..Default::default()
+    };
+    let pipeline_options = hlsl::PipelineOptions {
+        entry_point: Some((naga::ShaderStage::Fragment, entry_point.to_string())),
+    };
+
+    let mut hlsl_source = String::new();
+    let mut writer = hlsl::Writer::new(&mut hlsl_source, &options, &pipeline_options);
+    writer.write(&module, &info, None)
+}
+
+/// A sampler global that the entry point never touches must not abort
+/// translation when its bind group has no sampler index buffer.
+///
+/// <https://github.com/gfx-rs/wgpu/issues/7638>
+#[test]
+fn unused_sampler_without_sampler_index_buffer() {
+    let reflection_info = write_with_texture_at_binding_one(
+        "
+        @group(0) @binding(0) var<uniform> u: vec4<f32>;
+        @group(0) @binding(1) var s: sampler;
+
+        @fragment
+        fn main() -> @location(0) vec4<f32> {
+            return u;
+        }
+        ",
+        "main",
+    )
+    .expect("translation should succeed");
+
+    assert_eq!(reflection_info.entry_point_names.len(), 1);
+    reflection_info.entry_point_names[0]
+        .as_ref()
+        .expect("entry point should translate");
+}
+
+/// A sampler global that the entry point *does* use, whose bind group has no
+/// sampler index buffer, must report a translation error for that entry point
+/// rather than aborting the whole translation.
+///
+/// The declaration is skipped in this case too, so emitting the entry point
+/// would produce HLSL referring to an undeclared name. The check in
+/// `Writer::write` has to catch it first.
+///
+/// <https://github.com/gfx-rs/wgpu/issues/7638>
+#[test]
+fn used_sampler_without_sampler_index_buffer() {
+    let reflection_info = write_with_texture_at_binding_one(
+        "
+        @group(0) @binding(0) var t: texture_2d<f32>;
+        @group(0) @binding(1) var s: sampler;
+
+        @fragment
+        fn main() -> @location(0) vec4<f32> {
+            return textureSampleLevel(t, s, vec2<f32>(0.0), 0.0);
+        }
+        ",
+        "main",
+    )
+    .expect("translation should succeed");
+
+    assert_eq!(reflection_info.entry_point_names.len(), 1);
+    assert!(matches!(
+        reflection_info.entry_point_names[0],
+        Err(hlsl::EntryPointError::MissingSamplerIndexBuffer(0))
+    ));
+}

--- a/naga/tests/naga/main.rs
+++ b/naga/tests/naga/main.rs
@@ -1,4 +1,5 @@
 mod example_wgsl;
+mod hlsl;
 mod snapshots;
 mod spirv_capabilities;
 mod spirv_debug_info;


### PR DESCRIPTION
**Connections**

Fixes #7638.

**Description**

Writing a sampler in hlsl-out needs two bindings resolved, not one. The sampler's own binding comes from binding_map. The sampler index buffer for its bind group comes from sampler_buffer_binding_map. write_global only checked the first one.

So a shader that declares a sampler it never uses, at a slot the layout fills with something else, passed that check and then hit unreachable! later, because the group has no index buffer. The two lookups disagree because binding_map is keyed on group and binding alone and says nothing about what kind of resource is actually there. wgpu-core does not catch it earlier, because its shader-to-layout validation only inspects globals the entry point uses, and this one is unused.

The fix resolves the index buffer up front in write_global and passes the resolved BindTarget down. If it cannot be resolved, the declaration is skipped and logged, which is how an unresolvable ResourceBinding is already handled a few lines above. write_wrapped_sampler_buffer no longer resolves anything itself, so the panic path is gone rather than converted into an error.

**Testing**

New tests in naga/tests/naga/hlsl.rs cover the unused and unbound sampler that used to panic, plus a bound sampler to confirm normal output is unchanged.

**Squash or Rebase?**

Ready to rebase as it stands.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
