### PR TITLE
Fix WebGL build after external texture API changes

### DIFF
--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -493,9 +493,10 @@ impl Device {
         };
 
         // SAFETY: `hal_texture` was created on this device's raw handle
-        // respecting `desc` just above, and carries no initial state.
+        // respecting `desc` just above, carries no initial state, and WebGL
+        // guarantees that observable texture contents are initialized.
         Ok(unsafe {
-            self.create_texture_from_hal::<Gles>(hal_texture, desc, wgt::TextureUses::empty())
+            self.create_texture_from_hal::<Gles>(hal_texture, desc, wgt::TextureUses::empty(), true)
         })
     }
 


### PR DESCRIPTION
**Connections**

#9834 and #10076 both passed CI before merge. Their combined changes broke WebAssembly CI.

**Description**

#9834 added a WebGL call to `create_texture_from_hal`. #10076 added the `cleared` argument. Pass `true` at the new call site to preserve the imported texture contents.

**Testing**

- `cargo --locked clippy --target wasm32-unknown-unknown --tests --features glsl,spirv,fragile-send-sync-non-atomic-wasm`
- `cargo build --target wasm32-unknown-unknown -p wgpu-examples --no-default-features --features webgl`
- `cargo clippy --tests`
- `cargo nextest run -p wgpu --lib`

**Squash or Rebase?**

Ready to rebase.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and does not make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.