### PR TITLE
Move erroring of create_texture_view into wgc and implement

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -77,6 +77,7 @@ webgpu:api,validation,capability_checks,features,texture_component_swizzle:*
 webgpu:api,validation,capability_checks,features,texture_formats:render_bundle_encoder_descriptor_depth_stencil_format:*
 webgpu:api,validation,capability_checks,features,texture_formats:texture_descriptor_view_formats:*
 webgpu:api,validation,capability_checks,features,texture_formats:texture_descriptor:*
+webgpu:api,validation,capability_checks,features,texture_formats:texture_view_descriptor:*
 webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,*
 webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:validate,*
 webgpu:api,validation,capability_checks,limits,maxBufferSize:*

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -250,7 +250,6 @@ impl GPUDevice {
     let wgpu_texture = self.wgpu_device.create_texture(&wgpu_descriptor);
 
     Ok(GPUTexture {
-      error_handler: self.error_handler.clone(),
       wgpu_texture,
       default_view: Default::default(),
       label: descriptor.label,

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -147,7 +147,6 @@ impl GPUCanvasContext {
     match output.status {
       SurfaceStatus::Good | SurfaceStatus::Suboptimal => {
         let texture = GPUTexture {
-          error_handler: config.device.error_handler.clone(),
           wgpu_texture: output.texture.unwrap(),
           default_view: Default::default(),
           label: "".to_string(),

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -8,6 +8,7 @@ use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use deno_error::JsErrorBox;
+use wgpu_core::resource::ParentDevice;
 use wgpu_types::AstcBlock;
 use wgpu_types::AstcChannel;
 use wgpu_types::Extent3d;
@@ -16,6 +17,7 @@ use wgpu_types::TextureDimension;
 use wgpu_types::TextureFormat;
 use wgpu_types::TextureViewDimension;
 
+use crate::error::fmt_err;
 use crate::error::GPUGenericError;
 use crate::webidl::GPUTextureUsageFlags;
 
@@ -41,8 +43,6 @@ pub(crate) struct GPUTextureDescriptor {
 }
 
 pub struct GPUTexture {
-  pub error_handler: super::error::ErrorHandler,
-
   pub wgpu_texture: Arc<wgpu_core::resource::Texture>,
   pub default_view: OnceLock<Arc<wgpu_core::resource::TextureView>>,
 
@@ -60,23 +60,7 @@ impl GPUTexture {
   pub(crate) fn default_view(&self) -> Arc<wgpu_core::resource::TextureView> {
     self
       .default_view
-      .get_or_init(|| {
-        let (wgpu_texture_view, err) =
-          self.wgpu_texture.create_view(&Default::default());
-        if let Some(err) = err {
-          use wgpu_types::error::WebGpuError;
-          assert_ne!(
-            err.webgpu_error_type(),
-            wgpu_types::error::ErrorType::Validation,
-            concat!(
-              "getting default view for a texture ",
-              "caused a validation error (!?)"
-            )
-          );
-          self.error_handler.push_error(Some(err));
-        }
-        wgpu_texture_view
-      })
+      .get_or_init(|| self.wgpu_texture.create_view(&Default::default()))
       .clone()
   }
 }
@@ -170,10 +154,18 @@ impl GPUTexture {
       swizzle: crate::map_texture_component_swizzle(&descriptor.swizzle)?,
     };
 
-    let (wgpu_texture_view, err) =
-      self.wgpu_texture.create_view(&wgpu_descriptor);
+    if let Some(format) = wgpu_descriptor.format {
+      self
+        .wgpu_texture
+        .device()
+        .require_features(format.required_features())
+        .map_err(|err| {
+          let err = fmt_err(&err);
+          JsErrorBox::type_error(err)
+        })?;
+    }
 
-    self.error_handler.push_error(err);
+    let wgpu_texture_view = self.wgpu_texture.create_view(&wgpu_descriptor);
 
     Ok(GPUTextureView {
       wgpu_texture_view,

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -147,7 +147,7 @@ impl Player {
             }
             Action::CreateTextureView { id, parent, desc } => {
                 let parent_texture = self.resolve_texture_id(parent);
-                let (texture_view, _error) = parent_texture.create_view(&desc);
+                let texture_view = parent_texture.create_view(&desc);
                 self.texture_views.insert(id, texture_view);
             }
             Action::DropTextureView(id) => {

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -325,7 +325,7 @@ impl Global {
         texture_id: id::TextureId,
         desc: &TextureViewDescriptor,
         id_in: id::TextureViewId,
-    ) -> (id::TextureViewId, Option<resource::CreateTextureViewError>) {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             textures,
@@ -344,11 +344,9 @@ impl Global {
             swizzle: desc.swizzle,
         };
 
-        let (view, error) = texture.create_view(&desc);
+        let view = texture.create_view(&desc);
 
-        let id = texture_views.assign(id_in, view);
-
-        (id, error)
+        texture_views.assign(id_in, view);
     }
 
     pub fn texture_view_remove(

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -2164,16 +2164,14 @@ impl Texture {
         Ok(view)
     }
 
-    pub fn create_view(
-        self: &Arc<Self>,
-        desc: &TextureViewDescriptor,
-    ) -> (Arc<TextureView>, Option<CreateTextureViewError>) {
+    pub fn create_view(self: &Arc<Self>, desc: &TextureViewDescriptor) -> Arc<TextureView> {
         profiling::scope!("Texture::create_view");
 
-        let (view, error) = match self.create_view_inner(desc) {
-            Ok(view) => (view, None),
-            Err(e) => (TextureView::invalid(&self.device, self, desc), Some(e)),
-        };
+        let view = self.create_view_inner(desc).unwrap_or_else(|err| {
+            self.device
+                .handle_error(err, desc.label.as_deref(), "Texture::create_view failed");
+            TextureView::invalid(&self.device, self, desc)
+        });
 
         api_log!(
             "Texture::create_view({:?}) -> {:?}",
@@ -2192,7 +2190,7 @@ impl Texture {
             });
         }
 
-        (view, error)
+        view
     }
 
     pub fn descriptor(&self) -> &wgt::TextureDescriptor<String, Vec<wgt::TextureFormat>> {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1788,12 +1788,7 @@ impl dispatch::TextureInterface for CoreTexture {
             },
             swizzle: desc.swizzle,
         };
-        let (wgpu_texture_view, error) = self.wgpu_texture.create_view(&descriptor);
-        if let Some(cause) = error {
-            self.wgpu_texture
-                .device()
-                .handle_error(cause, desc.label, "Texture::create_view");
-        }
+        let wgpu_texture_view = self.wgpu_texture.create_view(&descriptor);
         CoreTextureView { wgpu_texture_view }.into()
     }
 


### PR DESCRIPTION
**Connections**
Part of https://github.com/gfx-rs/wgpu/issues/8911
Towards https://github.com/gfx-rs/wgpu/issues/10073
Continuation of #10165

**Description**
As always we move erroring into wgc. No missing content validation wgc, but we add this content timeline validation in deno as in #10179.

**Testing**
Covered by CTS tests

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [x] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
