### PR TITLE
Record a pass's first use of a texture subresource, not its last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Fix initialization tracking for some cases of array textures, 3d textures, and depth/stencil textures with divergent usage in a render pass. By @andyleiserson in [#10002](https://github.com/gfx-rs/wgpu/pull/10002) and [#10060](https://github.com/gfx-rs/wgpu/pull/10060).
 - Fixed a deadlock between `Queue::compact_blas` and `Queue::submit`, which acquired `Device::command_indices` and `Queue::pending_writes` in opposite orders. By @mstampfli in [#10118](https://github.com/gfx-rs/wgpu/pull/10118).
 - Fixed some cases of passing object labels to platform APIs despite `InstanceFlags::DISCARD_HAL_LABELS` being set. By @andyleiserson in [#10121](https://github.com/gfx-rs/wgpu/pull/10121) and [#10123](https://github.com/gfx-rs/wgpu/pull/10123).
+- Fix the barriers inserted at submission when a pass is the first user of a texture subresource and uses that subresource two different ways. The command buffer recorded the last use as the first use, so the subresource started the submission in the wrong state. By @cwfitzgerald in [#10212](https://github.com/gfx-rs/wgpu/pull/10212).
 
 #### naga
 

--- a/tests/tests/wgpu-gpu/main.rs
+++ b/tests/tests/wgpu-gpu/main.rs
@@ -1,4 +1,5 @@
 mod regression {
+    pub mod issue_10199;
     pub mod issue_3349;
     pub mod issue_3457;
     pub mod issue_4024;
@@ -134,6 +135,7 @@ fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     resolve_query_set_init::all_tests(&mut tests);
     queue_transfer::all_tests(&mut tests);
     ray_tracing::all_tests(&mut tests);
+    regression::issue_10199::all_tests(&mut tests);
     regression::issue_3349::all_tests(&mut tests);
     regression::issue_3457::all_tests(&mut tests);
     regression::issue_4024::all_tests(&mut tests);

--- a/tests/tests/wgpu-gpu/regression/issue_10199.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_10199.rs
@@ -1,0 +1,161 @@
+//! Tests that the command buffer records the *first* use of a texture
+//! subresource, not its last use, when a pass teaches the command buffer about
+//! a subresource it did not know about before.
+//!
+//! If the first use is wrong, the barriers inserted at submission put the
+//! subresource in the wrong layout and the backend reports a validation error.
+
+use wgpu_test::{apply, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters};
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.push(MIP_FIRST_USE);
+}
+
+#[apply(gpu_test!)]
+static MIP_FIRST_USE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().limits(wgpu::Limits {
+        max_storage_textures_per_shader_stage: 1,
+        ..Default::default()
+    }))
+    .run_sync(|ctx| {
+        const MIP_LEVELS: u32 = 4;
+
+        let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("test image"),
+            size: wgpu::Extent3d {
+                width: 16,
+                height: 16,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: MIP_LEVELS,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::STORAGE_BINDING,
+            view_formats: &[],
+        });
+
+        let shader = ctx
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: None,
+                source: wgpu::ShaderSource::Wgsl(
+                    "
+                    @group(0) @binding(0) var input: texture_2d<f32>;
+                    @group(0) @binding(1) var output: texture_storage_2d<rgba8unorm, write>;
+                    @compute @workgroup_size(1)
+                    fn main() {
+                        textureStore(output, vec2u(0u), textureLoad(input, vec2u(0u), 0));
+                    }
+                    "
+                    .into(),
+                ),
+            });
+
+        let bind_group_layout =
+            ctx.device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: None,
+                    entries: &[
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::Texture {
+                                sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                                view_dimension: wgpu::TextureViewDimension::D2,
+                                multisampled: false,
+                            },
+                            count: None,
+                        },
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 1,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::StorageTexture {
+                                access: wgpu::StorageTextureAccess::WriteOnly,
+                                format: wgpu::TextureFormat::Rgba8Unorm,
+                                view_dimension: wgpu::TextureViewDimension::D2,
+                            },
+                            count: None,
+                        },
+                    ],
+                });
+
+        let pipeline_layout = ctx
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: None,
+                bind_group_layouts: &[Some(&bind_group_layout)],
+                immediate_size: 0,
+            });
+
+        let pipeline = ctx
+            .device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: None,
+                layout: Some(&pipeline_layout),
+                module: &shader,
+                entry_point: None,
+                cache: None,
+                compilation_options: Default::default(),
+            });
+
+        let views: Vec<_> = (0..MIP_LEVELS)
+            .map(|mip| {
+                texture.create_view(&wgpu::TextureViewDescriptor {
+                    label: Some(&format!("mip {mip}")),
+                    base_mip_level: mip,
+                    mip_level_count: Some(1),
+                    ..Default::default()
+                })
+            })
+            .collect();
+
+        let bind_group = |read: usize, write: usize| {
+            ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: None,
+                layout: &bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&views[read]),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::TextureView(&views[write]),
+                    },
+                ],
+            })
+        };
+
+        let read_1_write_0 = bind_group(1, 0);
+        let read_1_write_2 = bind_group(1, 2);
+        let read_2_write_3 = bind_group(2, 3);
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+
+        // The first pass leaves mip 2 and mip 3 unknown to the command buffer.
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &read_1_write_0, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+
+        // The second pass uses mip 2 as a storage target and then as a sampled
+        // texture, so its first and last use of mip 2 differ.
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &read_1_write_2, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+            pass.set_bind_group(0, &read_2_write_3, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+
+        ctx.queue.submit(Some(encoder.finish()));
+        ctx.device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .unwrap();
+    });

--- a/wgpu-core/src/track/texture.rs
+++ b/wgpu-core/src/track/texture.rs
@@ -809,7 +809,6 @@ impl DeviceTextureTracker {
         unsafe {
             update(
                 &texture.full_range,
-                None,
                 &mut self.current_state_set,
                 index,
                 start_state_provider,
@@ -849,7 +848,6 @@ impl DeviceTextureTracker {
                 );
                 update(
                     texture_selector,
-                    None,
                     &mut self.current_state_set,
                     index,
                     end_state_provider,
@@ -889,7 +887,6 @@ impl DeviceTextureTracker {
                 );
                 update(
                     texture_selector,
-                    None,
                     &mut self.current_state_set,
                     index,
                     start_state_provider,
@@ -1066,6 +1063,8 @@ unsafe fn insert_or_merge(
 /// If the resource is tracked
 /// - Inserts barriers from the state in `current_states`
 ///   to the state provided by `start_state_provider`.
+/// - Uses the `start_state_provider` to populate `start_states`
+///   for the subresources that `current_states` does not know yet.
 /// - Updates the `current_states` with either the state from
 ///   `end_state_provider` or `start_state_provider`.
 ///
@@ -1112,20 +1111,112 @@ unsafe fn insert_or_barrier_update(
             texture_selector,
             current_state_set,
             index,
-            start_state_provider,
+            start_state_provider.clone(),
             barriers,
             ordered_uses_mask,
         )
     };
+    if let Some(start_state) = start_state {
+        unsafe {
+            backfill_start_state(
+                texture_selector,
+                start_state,
+                current_state_set,
+                index,
+                start_state_provider,
+            )
+        };
+    }
     unsafe {
         update(
             texture_selector,
-            start_state,
             current_state_set,
             index,
             update_state_provider,
         )
     };
+}
+
+/// Records the first use of the subresources that the tracker learns about in
+/// this operation.
+///
+/// A subresource is new to the tracker if `current_state_set` holds `UNKNOWN`
+/// for it. The state to record comes from `start_state_provider`, which must be
+/// the first use of the incoming operation, not its last use.
+///
+/// Must run before [`update`], because `current_state_set` must still hold the
+/// state from before the incoming operation.
+///
+/// # Safety
+///
+/// The `index` must be in bounds of every set passed in, either directly or via
+/// the provider struct.
+#[inline(always)]
+unsafe fn backfill_start_state(
+    texture_selector: &TextureSelector,
+    start_state_set: &mut TextureStateSet,
+    current_state_set: &TextureStateSet,
+    index: usize,
+    start_state_provider: TextureStateProvider<'_>,
+) {
+    // Only a complex state can hold UNKNOWN. A simple state means the tracker
+    // already knows a state for every subresource.
+    let SingleOrManyStates::Many(current_complex) =
+        (unsafe { current_state_set.get_unchecked(index) })
+    else {
+        return;
+    };
+    let SingleOrManyStates::Many(start_complex) =
+        (unsafe { start_state_set.get_mut_unchecked(index) })
+    else {
+        return;
+    };
+
+    let mut record = |mip_id: usize, layers: &core::ops::Range<u32>, state: TextureUses| {
+        strict_assert!(mip_id < start_complex.mips.len());
+
+        let start_mip = unsafe { start_complex.mips.get_unchecked_mut(mip_id) };
+
+        for &mut (_, ref mut start_state) in start_mip.isolate(layers, TextureUses::UNKNOWN) {
+            strict_assert_eq!(*start_state, TextureUses::UNKNOWN);
+            *start_state = state;
+        }
+
+        start_mip.coalesce();
+    };
+
+    match unsafe { start_state_provider.get_state(Some(texture_selector), index) } {
+        SingleOrManyStates::Single(new_state) => {
+            for (mip_id, mip) in current_complex.mips.iter().enumerate() {
+                for &(ref layers, current_layer_state) in mip.iter() {
+                    if current_layer_state == TextureUses::UNKNOWN {
+                        record(mip_id, layers, new_state);
+                    }
+                }
+            }
+        }
+        SingleOrManyStates::Many(state_iter) => {
+            for (selector, new_state) in state_iter {
+                if new_state == TextureUses::UNKNOWN {
+                    // We know nothing new.
+                    continue;
+                }
+
+                for mip_id in selector.mips {
+                    let mip_id = mip_id as usize;
+                    strict_assert!(mip_id < current_complex.mips.len());
+
+                    let mip = unsafe { current_complex.mips.get_unchecked(mip_id) };
+
+                    for (layers, &current_layer_state) in mip.iter_filter(&selector.layers) {
+                        if current_layer_state == TextureUses::UNKNOWN {
+                            record(mip_id, &layers, new_state);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[inline(always)]
@@ -1459,21 +1550,10 @@ unsafe fn barrier(
 #[inline(always)]
 unsafe fn update(
     texture_selector: &TextureSelector,
-    start_state_set: Option<&mut TextureStateSet>,
     current_state_set: &mut TextureStateSet,
     index: usize,
     state_provider: TextureStateProvider<'_>,
 ) {
-    // We only ever need to update the start state here if the state is complex.
-    //
-    // If the state is simple, the first insert to the tracker would cover it.
-    let mut start_complex = start_state_set.and_then(|start_state_set| {
-        match unsafe { start_state_set.get_mut_unchecked(index) } {
-            SingleOrManyStates::Single(_) => None,
-            SingleOrManyStates::Many(complex) => Some(complex),
-        }
-    });
-
     let current_state = unsafe { current_state_set.get_mut_unchecked(index) };
 
     let new_state = unsafe { state_provider.get_state(Some(texture_selector), index) };
@@ -1512,29 +1592,7 @@ unsafe fn update(
 
             unsafe { current_state_set.make_complex_unchecked(index, new_complex) };
         }
-        (SingleOrManyStates::Many(current_complex), SingleOrManyStates::Single(new_single)) => {
-            for (mip_id, mip) in current_complex.mips.iter().enumerate() {
-                for &(ref layers, current_layer_state) in mip.iter() {
-                    // If this state is unknown, that means that the start is _also_ unknown.
-                    if current_layer_state == TextureUses::UNKNOWN {
-                        if let Some(&mut ref mut start_complex) = start_complex {
-                            strict_assert!(mip_id < start_complex.mips.len());
-
-                            let start_mip = unsafe { start_complex.mips.get_unchecked_mut(mip_id) };
-
-                            for &mut (_, ref mut current_start_state) in
-                                start_mip.isolate(layers, TextureUses::UNKNOWN)
-                            {
-                                strict_assert_eq!(*current_start_state, TextureUses::UNKNOWN);
-                                *current_start_state = new_single;
-                            }
-
-                            start_mip.coalesce();
-                        }
-                    }
-                }
-            }
-
+        (SingleOrManyStates::Many(_), SingleOrManyStates::Single(new_single)) => {
             unsafe { current_state_set.make_simple_unchecked(index, new_single) };
         }
         (SingleOrManyStates::Many(current_complex), SingleOrManyStates::Many(new_many)) => {
@@ -1550,37 +1608,9 @@ unsafe fn update(
 
                     let mip = unsafe { current_complex.mips.get_unchecked_mut(mip_id) };
 
-                    for &mut (ref layers, ref mut current_layer_state) in
+                    for &mut (_, ref mut current_layer_state) in
                         mip.isolate(&selector.layers, TextureUses::UNKNOWN)
                     {
-                        if *current_layer_state == TextureUses::UNKNOWN
-                            && new_state != TextureUses::UNKNOWN
-                        {
-                            // We now know something about this subresource that
-                            // we didn't before so we should go back and update
-                            // the start state.
-                            //
-                            // We know we must have starter state be complex,
-                            // otherwise we would know about this state.
-                            strict_assert!(start_complex.is_some());
-
-                            let start_complex =
-                                unsafe { start_complex.as_deref_mut().unwrap_unchecked() };
-
-                            strict_assert!(mip_id < start_complex.mips.len());
-
-                            let start_mip = unsafe { start_complex.mips.get_unchecked_mut(mip_id) };
-
-                            for &mut (_, ref mut current_start_state) in
-                                start_mip.isolate(layers, TextureUses::UNKNOWN)
-                            {
-                                strict_assert_eq!(*current_start_state, TextureUses::UNKNOWN);
-                                *current_start_state = new_state;
-                            }
-
-                            start_mip.coalesce();
-                        }
-
                         *current_layer_state = new_state;
                     }
 


### PR DESCRIPTION
**Connections**

Fixes #10199.

**Description**

## This is all LLM bunk

A command buffer keeps two states for each texture it tracks: the start state, which is the first use of the texture in the command buffer, and the end state, which is the last use. At submission, `wgpu-core` inserts barriers that bring each subresource to its start state.

A pass can tell the command buffer about a subresource that the command buffer does not know yet. The command buffer must then record the pass's first use of that subresource as the start state. It recorded the pass's last use instead.

The two uses are the same in most cases, so the bug was not visible. They differ when a pass uses one subresource two different ways. In the reproduction in #10199, the second compute pass writes mip 2 as a storage texture and then reads mip 2 as a sampled texture. The command buffer recorded `RESOURCE` as the start state of mip 2. Submission put mip 2 in `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`, but the first dispatch needs `VK_IMAGE_LAYOUT_GENERAL`. The Vulkan validation layers report `VUID-vkCmdDraw-None-09600`.

The cause is the state provider that `update()` receives. `insert_or_barrier_update()` gives `update()` the end state provider, and `update()` used that same provider to record the start state. Only `TextureTracker::set_from_tracker()` passes an end state provider that differs from the start state provider, so only the merge of a pass tracker into a command buffer tracker was wrong.

This PR moves the start state code out of `update()` into a new function, `backfill_start_state()`. The new function reads the start state provider. It runs before `update()`, because it must read the current state from before the update to find the subresources that the command buffer does not know yet.

The fix is in `wgpu-core`, so it applies to all backends and to Firefox, Servo, and Deno. Only Vulkan reports an error today, because Vulkan is the only backend that uses image layouts.

**Testing**

New GPU test: `regression::issue_10199::mip_first_use`. It records the two compute passes from the issue. The test harness fails the test when the Vulkan validation layers report an error.

Without the fix, the test fails on both Vulkan adapters on my machine. With the fix, it passes on all three adapters.

I ran the full `cargo xtask test` suite on KosmicKrisp, MoltenVK, and Metal. 1859 tests ran and 29 failed. I re-ran each failure with the fix reverted, and all 29 also fail without it. I also ran the whole `wgpu-gpu` test binary with `wgpu-core/strict_asserts` on. No assertion in the new code fires.

**Squash or Rebase?**

One commit. Ready to rebase.

**LLM Use?**

Found and bisected by LLM, validated manually.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [x] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [x] (If applicable) Tests demonstrate the validation and altered logic works.
