### PR TITLE
ci: Update Vulkan SDK to 1.4.357

### DIFF
--- a/.github/actions/install-vulkan-sdk/action.yml
+++ b/.github/actions/install-vulkan-sdk/action.yml
@@ -3,9 +3,9 @@ description: "Install Vulkan SDK"
 inputs:
   # Sourced from https://vulkan.lunarg.com/sdk/home#linux
   version:
-    default: "1.4.328"
+    default: "1.4.357"
   full-version:
-    default: "1.4.328.1"
+    default: "1.4.357.0"
 runs:
   using: "composite"
   steps:

--- a/naga/tests/out/spv/wgsl-functions-optimized-by-capability.spvasm.glsl
+++ b/naga/tests/out/spv/wgsl-functions-optimized-by-capability.spvasm.glsl
@@ -1,2 +1,20 @@
-// spirv-cross error:
-// SPIRV-Cross threw an exception: Cannot resolve expression type.
+#version 460
+#extension GL_EXT_spirv_intrinsics : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+spirv_instruction (extensions = ["SPV_KHR_integer_dot_product"], capabilities = [6019, 6018], id = 4450)
+int spvSDot_int_uint_uint(uint arg0, uint arg1, spirv_literal uint packedFormat);
+
+spirv_instruction (extensions = ["SPV_KHR_integer_dot_product"], capabilities = [6019, 6018], id = 4451)
+uint spvUDot_uint_uint_uint(uint arg0, uint arg1, spirv_literal uint packedFormat);
+
+uint _5()
+{
+    uint _18 = spvUDot_uint_uint_uint(3u, 4u, 0);
+    return spvUDot_uint_uint_uint(7u + _18, 8u + _18, 0);
+}
+
+void main()
+{
+}
+

--- a/naga/tests/out/spv/wgsl-functions-optimized-by-version.spvasm.glsl
+++ b/naga/tests/out/spv/wgsl-functions-optimized-by-version.spvasm.glsl
@@ -1,2 +1,20 @@
-// spirv-cross error:
-// SPIRV-Cross threw an exception: Cannot resolve expression type.
+#version 460
+#extension GL_EXT_spirv_intrinsics : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+spirv_instruction (extensions = ["SPV_KHR_integer_dot_product"], capabilities = [6019, 6018], id = 4450)
+int spvSDot_int_uint_uint(uint arg0, uint arg1, spirv_literal uint packedFormat);
+
+spirv_instruction (extensions = ["SPV_KHR_integer_dot_product"], capabilities = [6019, 6018], id = 4451)
+uint spvUDot_uint_uint_uint(uint arg0, uint arg1, spirv_literal uint packedFormat);
+
+uint _5()
+{
+    uint _18 = spvUDot_uint_uint_uint(3u, 4u, 0);
+    return spvUDot_uint_uint_uint(7u + _18, 8u + _18, 0);
+}
+
+void main()
+{
+}
+

--- a/naga/tests/out/spv/wgsl-functions-unoptimized.spvasm.glsl
+++ b/naga/tests/out/spv/wgsl-functions-unoptimized.spvasm.glsl
@@ -5,7 +5,15 @@ uint _5()
 {
     int _18 = int(1u);
     int _19 = int(2u);
-    uint _39 = (((0u + (bitfieldExtract(3u, int(0u), int(8u)) * bitfieldExtract(4u, int(0u), int(8u)))) + (bitfieldExtract(3u, int(8u), int(8u)) * bitfieldExtract(4u, int(8u), int(8u)))) + (bitfieldExtract(3u, int(16u), int(8u)) * bitfieldExtract(4u, int(16u), int(8u)))) + (bitfieldExtract(3u, int(24u), int(8u)) * bitfieldExtract(4u, int(24u), int(8u)));
+    uint _41 = bitfieldExtract(3u, int(0u), int(8u));
+    uint _42 = bitfieldExtract(4u, int(0u), int(8u));
+    uint _45 = bitfieldExtract(3u, int(8u), int(8u));
+    uint _46 = bitfieldExtract(4u, int(8u), int(8u));
+    uint _49 = bitfieldExtract(3u, int(16u), int(8u));
+    uint _50 = bitfieldExtract(4u, int(16u), int(8u));
+    uint _53 = bitfieldExtract(3u, int(24u), int(8u));
+    uint _54 = bitfieldExtract(4u, int(24u), int(8u));
+    uint _39 = (((0u + (_41 * _42)) + (_45 * _46)) + (_49 * _50)) + (_53 * _54);
     int _59 = int(5u + _39);
     int _60 = int(6u + _39);
     uint _76 = 7u + _39;

--- a/naga/tests/out/spv/wgsl-functions.spvasm.glsl
+++ b/naga/tests/out/spv/wgsl-functions.spvasm.glsl
@@ -1,2 +1,31 @@
-// spirv-cross error:
-// SPIRV-Cross threw an exception: Cannot resolve expression type.
+#version 460
+#extension GL_EXT_spirv_intrinsics : require
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+spirv_instruction (extensions = ["SPV_KHR_integer_dot_product"], capabilities = [6019, 6018], id = 4450)
+int spvSDot_int_uint_uint(uint arg0, uint arg1, spirv_literal uint packedFormat);
+
+spirv_instruction (extensions = ["SPV_KHR_integer_dot_product"], capabilities = [6019, 6018], id = 4451)
+uint spvUDot_uint_uint_uint(uint arg0, uint arg1, spirv_literal uint packedFormat);
+
+vec2 _8()
+{
+    vec2 _15 = fma(vec2(2.0), vec2(0.5), vec2(0.5));
+    return _15;
+}
+
+int _17()
+{
+    return 32;
+}
+
+uint _50()
+{
+    uint _61 = spvUDot_uint_uint_uint(3u, 4u, 0);
+    return spvUDot_uint_uint_uint(7u + _61, 8u + _61, 0);
+}
+
+void main()
+{
+}
+

--- a/naga/tests/out/spv/wgsl-operators.spvasm.glsl
+++ b/naga/tests/out/spv/wgsl-operators.spvasm.glsl
@@ -239,6 +239,30 @@ void _309()
 
 void _403()
 {
+    int _405 = ~1;
+    uint _406 = ~1u;
+    ivec2 _407 = ~ivec2(1);
+    uvec3 _408 = ~uvec3(1u);
+    int _409 = 2 | 1;
+    uint _410 = 2u | 1u;
+    ivec2 _411 = ivec2(2) | ivec2(1);
+    uvec3 _412 = uvec3(2u) | uvec3(1u);
+    int _413 = 2 & 1;
+    uint _414 = 2u & 1u;
+    ivec2 _415 = ivec2(2) & ivec2(1);
+    uvec3 _416 = uvec3(2u) & uvec3(1u);
+    int _417 = 2 ^ 1;
+    uint _418 = 2u ^ 1u;
+    ivec2 _419 = ivec2(2) ^ ivec2(1);
+    uvec3 _420 = uvec3(2u) ^ uvec3(1u);
+    int _421 = 2 << int(1u);
+    uint _422 = 2u << 1u;
+    ivec2 _423 = ivec2(2) << ivec2(uvec2(1u));
+    uvec3 _424 = uvec3(2u) << uvec3(1u);
+    int _425 = 2 >> int(1u);
+    uint _426 = 2u >> 1u;
+    ivec2 _427 = ivec2(2) >> ivec2(uvec2(1u));
+    uvec3 _428 = uvec3(2u) >> uvec3(1u);
 }
 
 void _430()


### PR DESCRIPTION
**Description**

Updates the CI Vulkan SDK from 1.4.328.1 to 1.4.357.0. The newer `spirv-cross` now succeeds in translating more outputs.

**Testing**

Regenerated the snapshots from a clean `trunk` tree with SDK 1.4.357 installed. `cargo nextest run -p naga` passes, and no snapshot files other than the five here change.

**Squash or Rebase?**

Squash

**LLM Use**

Yes.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. --> (N/A: CI and snapshot outputs only.)
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
