### PR TITLE
Move erroring of create_buffer into wgc

### DIFF
--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -187,9 +187,7 @@ impl GPUDevice {
       mapped_at_creation: descriptor.mapped_at_creation,
     };
 
-    let (wgpu_buffer, err) = self.wgpu_device.create_buffer(&wgpu_descriptor);
-
-    self.error_handler.push_error(err);
+    let wgpu_buffer = self.wgpu_device.create_buffer(&wgpu_descriptor);
 
     Ok(GPUBuffer {
       error_handler: self.error_handler.clone(),

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -117,7 +117,7 @@ impl Player {
                 panic!("Unexpected Surface action: winit feature is not enabled")
             }
             Action::CreateBuffer(id, desc) => {
-                let (buffer, _error) = device.create_buffer(&desc);
+                let buffer = device.create_buffer(&desc);
                 self.buffers.insert(id, buffer);
             }
             Action::DestroyBuffer(id) => {

--- a/tests/tests/wgpu_trace.rs
+++ b/tests/tests/wgpu_trace.rs
@@ -37,13 +37,14 @@ fn trace_test(test_type: TestType) {
         })
         .unwrap();
 
-    let (buffer, error) = device.create_buffer(&wgt::BufferDescriptor {
+    device.push_error_scope(wgpu::ErrorFilter::Validation);
+    let buffer = device.create_buffer(&wgt::BufferDescriptor {
         label: None,
         size: 1024,
         usage: wgt::BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });
-    assert!(error.is_none());
+    assert!(matches!(device.pop_error_scope(), Ok(None)));
 
     device.push_error_scope(wgpu::ErrorFilter::Validation);
     let encoder = device.create_command_encoder(&wgt::CommandEncoderDescriptor::default());

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -64,7 +64,7 @@ impl Global {
         device_id: DeviceId,
         desc: &BufferDescriptor,
         id_in: id::BufferId,
-    ) -> (id::BufferId, Option<CreateBufferError>) {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             buffers, devices, ..
@@ -72,11 +72,9 @@ impl Global {
 
         let device = devices.get(device_id);
 
-        let (buffer, error) = device.create_buffer(desc);
+        let buffer = device.create_buffer(desc);
 
-        let id = buffers.assign(id_in, buffer);
-
-        (id, error)
+        buffers.assign(id_in, buffer);
     }
 
     /// Assign `id_in` an error with the given `label`.

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -1429,16 +1429,13 @@ impl Device {
         Ok(buffer)
     }
 
-    pub fn create_buffer(
-        self: &Arc<Self>,
-        desc: &resource::BufferDescriptor,
-    ) -> (Arc<Buffer>, Option<resource::CreateBufferError>) {
+    pub fn create_buffer(self: &Arc<Self>, desc: &resource::BufferDescriptor) -> Arc<Buffer> {
         profiling::scope!("Device::create_buffer");
 
-        let (buffer, error) = match self.create_buffer_inner(desc) {
-            Ok(buffer) => (buffer, None),
-            Err(e) => (Buffer::invalid(Arc::clone(self), desc), Some(e)),
-        };
+        let buffer = self.create_buffer_inner(desc).unwrap_or_else(|err| {
+            self.handle_error(err, desc.label.as_deref(), "Device::create_buffer");
+            Buffer::invalid(Arc::clone(self), desc)
+        });
         #[cfg(feature = "trace")]
         if let Some(ref mut trace) = *self.trace.lock() {
             use trace::IntoTrace;
@@ -1459,7 +1456,7 @@ impl Device {
             },
             Arc::as_ptr(&buffer)
         );
-        (buffer, error)
+        buffer
     }
 
     #[cfg(feature = "replay")]

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1320,13 +1320,9 @@ impl dispatch::DeviceInterface for CoreDevice {
     }
 
     fn create_buffer(&self, desc: &crate::BufferDescriptor<'_>) -> dispatch::DispatchBuffer {
-        let (wgpu_buffer, error) = self
+        let wgpu_buffer = self
             .wgpu_device
             .create_buffer(&desc.map_label(|l| l.map(Borrowed)));
-        if let Some(cause) = error {
-            self.wgpu_device
-                .handle_error(cause, desc.label, "Device::create_buffer");
-        }
 
         CoreBuffer { wgpu_buffer }.into()
     }


### PR DESCRIPTION
**Connections**
Part of https://github.com/gfx-rs/wgpu/issues/8911
Towards https://github.com/gfx-rs/wgpu/issues/10073
Continuation of #10208

**Description**
As always we move erroring into wgc. All content timeline validation is already done \o/.

**Testing**
Just refactor, but should be covered.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
