### PR TITLE
Move erroring from create_bind_group_layout into wgc

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -75,6 +75,7 @@ webgpu:api,validation,buffer,destroy:*
 webgpu:api,validation,capability_checks,features,clip_distances:*
 webgpu:api,validation,capability_checks,features,texture_component_swizzle:*
 webgpu:api,validation,capability_checks,features,texture_formats:render_bundle_encoder_descriptor_depth_stencil_format:*
+webgpu:api,validation,capability_checks,features,texture_formats:storage_texture_binding_layout:*
 webgpu:api,validation,capability_checks,features,texture_formats:texture_descriptor_view_formats:*
 webgpu:api,validation,capability_checks,features,texture_formats:texture_descriptor:*
 webgpu:api,validation,capability_checks,features,texture_formats:texture_view_descriptor:*

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -332,9 +332,11 @@ impl GPUDevice {
           multisampled: texture.multisampled,
         }
       } else if let Some(storage_texture) = entry.storage_texture {
+        let format = storage_texture.format.into();
+        self.validate_texture_format_required_feature(format)?;
         BindingType::StorageTexture {
           access: storage_texture.access.into(),
-          format: storage_texture.format.into(),
+          format,
           view_dimension: storage_texture.view_dimension.into(),
         }
       } else if entry.external_texture.is_some() {
@@ -356,10 +358,8 @@ impl GPUDevice {
       entries: Cow::Owned(entries),
     };
 
-    let (wgpu_bind_group_layout, err) =
+    let wgpu_bind_group_layout =
       self.wgpu_device.create_bind_group_layout(&wgpu_descriptor);
-
-    self.error_handler.push_error(err);
 
     Ok(GPUBindGroupLayout {
       wgpu_bind_group_layout,

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -186,7 +186,7 @@ impl Player {
                 unimplemented!()
             }
             Action::CreateBindGroupLayout(id, desc) => {
-                let (bind_group_layout, _error) = device.create_bind_group_layout(&desc);
+                let bind_group_layout = device.create_bind_group_layout(&desc);
                 self.bind_group_layouts.insert(id, bind_group_layout);
             }
             Action::GetRenderPipelineBindGroupLayout {

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -453,9 +453,6 @@ impl Global {
         device_id: DeviceId,
         desc: &BindGroupLayoutDescriptor,
         id_in: id::BindGroupLayoutId,
-    ) -> (
-        id::BindGroupLayoutId,
-        Option<binding_model::CreateBindGroupLayoutError>,
     ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
@@ -471,11 +468,9 @@ impl Global {
             entries: Cow::Borrowed(&desc.entries),
         };
 
-        let (bgl, error) = device.create_bind_group_layout(&desc);
+        let bgl = device.create_bind_group_layout(&desc);
 
-        let id = bind_group_layouts.assign(id_in, bgl);
-
-        (id, error)
+        bind_group_layouts.assign(id_in, bgl);
     }
 
     pub fn bind_group_layout_remove(

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -2920,16 +2920,20 @@ impl Device {
     pub fn create_bind_group_layout(
         self: &Arc<Self>,
         desc: &binding_model::BindGroupLayoutDescriptor,
-    ) -> (Arc<BindGroupLayout>, Option<CreateBindGroupLayoutError>) {
+    ) -> Arc<BindGroupLayout> {
         profiling::scope!("Device::create_bind_group_layout");
 
-        let (bgl, error) = match self.create_bind_group_layout_inner(desc) {
-            Ok(layout) => (layout, None),
-            Err(e) => (
-                BindGroupLayout::invalid(self, desc.label.to_string()),
-                Some(e),
-            ),
-        };
+        let bgl = self
+            .create_bind_group_layout_inner(desc)
+            .unwrap_or_else(|err| {
+                self.handle_error(
+                    err,
+                    desc.label.as_deref(),
+                    "Device::create_bind_group_layout",
+                );
+                BindGroupLayout::invalid(self, desc.label.to_string())
+            });
+
         #[cfg(feature = "trace")]
         if let Some(ref mut trace) = *self.trace.lock() {
             use crate::device::trace::IntoTrace;
@@ -2943,7 +2947,7 @@ impl Device {
             "Device::create_bind_group_layout -> {:?}",
             Arc::as_ptr(&bgl)
         );
-        (bgl, error)
+        bgl
     }
 
     fn create_bind_group_layout_inner(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -883,12 +883,7 @@ impl dispatch::DeviceInterface for CoreDevice {
             label: desc.label.map(Borrowed),
             entries: Borrowed(desc.entries),
         };
-        let (wgpu_bind_group_layout, error) =
-            self.wgpu_device.create_bind_group_layout(&descriptor);
-        if let Some(cause) = error {
-            self.wgpu_device
-                .handle_error(cause, desc.label, "Device::create_bind_group_layout");
-        }
+        let wgpu_bind_group_layout = self.wgpu_device.create_bind_group_layout(&descriptor);
         CoreBindGroupLayout {
             wgpu_bind_group_layout,
         }


### PR DESCRIPTION
**Connections**
Part of https://github.com/gfx-rs/wgpu/issues/8911
Towards https://github.com/gfx-rs/wgpu/issues/10073
Continuation of #10208

**Description**
As always we move erroring into wgc. Only deno was mising contant timeline validation.

**Testing**
Just refactor, but should be covered.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
