### PR TITLE
Move erroring of `create_query_set` into wgc

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -73,6 +73,7 @@ webgpu:api,validation,buffer,create:size,*
 webgpu:api,validation,buffer,create:usage,*
 webgpu:api,validation,buffer,destroy:*
 webgpu:api,validation,capability_checks,features,clip_distances:*
+webgpu:api,validation,capability_checks,features,query_types:createQuerySet:*
 webgpu:api,validation,capability_checks,features,texture_component_swizzle:*
 webgpu:api,validation,capability_checks,features,texture_formats:render_bundle_encoder_descriptor_depth_stencil_format:*
 webgpu:api,validation,capability_checks,features,texture_formats:texture_descriptor_view_formats:*

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -694,24 +694,31 @@ impl GPUDevice {
   fn create_query_set(
     &self,
     #[webidl] descriptor: crate::query_set::GPUQuerySetDescriptor,
-  ) -> GPUQuerySet {
+  ) -> Result<GPUQuerySet, JsErrorBox> {
     let wgpu_descriptor = wgpu_core::resource::QuerySetDescriptor {
       label: crate::transform_label(descriptor.label.clone()),
       ty: descriptor.r#type.clone().into(),
       count: descriptor.count,
     };
 
-    let (wgpu_query_set, err) =
-      self.wgpu_device.create_query_set(&wgpu_descriptor);
+    if matches!(wgpu_descriptor.ty, wgpu_types::QueryType::Timestamp) {
+      self
+        .wgpu_device
+        .require_features(wgpu_types::Features::TIMESTAMP_QUERY)
+        .map_err(|err| {
+          let err = fmt_err(&err);
+          JsErrorBox::type_error(err)
+        })?;
+    }
 
-    self.error_handler.push_error(err);
+    let wgpu_query_set = self.wgpu_device.create_query_set(&wgpu_descriptor);
 
-    GPUQuerySet {
+    Ok(GPUQuerySet {
       wgpu_query_set,
       r#type: descriptor.r#type,
       count: descriptor.count,
       label: descriptor.label,
-    }
+    })
   }
 
   #[getter]

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -365,7 +365,7 @@ impl Player {
                     .expect("invalid render bundle");
             }
             Action::CreateQuerySet { id, desc } => {
-                let (query_set, _error) = device.create_query_set(&desc);
+                let query_set = device.create_query_set(&desc);
                 self.query_sets.insert(id, query_set);
             }
             Action::DestroyQuerySet(id) => {

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -777,7 +777,7 @@ impl Global {
         device_id: DeviceId,
         desc: &QuerySetDescriptor,
         id_in: id::QuerySetId,
-    ) -> (id::QuerySetId, Option<resource::CreateQuerySetError>) {
+    ) {
         let mut hub = self.hub.borrow_mut();
         let Hub {
             query_sets,
@@ -787,11 +787,9 @@ impl Global {
 
         let device = devices.get(device_id);
 
-        let (query_set, error) = device.create_query_set(desc);
+        let query_set = device.create_query_set(desc);
 
-        let id = query_sets.assign(id_in, query_set);
-
-        (id, error)
+        query_sets.assign(id_in, query_set);
     }
 
     pub fn query_set_destroy(&self, query_set_id: id::QuerySetId) {

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -5619,12 +5619,12 @@ impl Device {
     pub fn create_query_set(
         self: &Arc<Self>,
         desc: &resource::QuerySetDescriptor,
-    ) -> (Arc<QuerySet>, Option<resource::CreateQuerySetError>) {
+    ) -> Arc<QuerySet> {
         profiling::scope!("Device::create_query_set");
-        let (query_set, error) = match self.create_query_set_inner(desc) {
-            Ok(query_set) => (query_set, None),
-            Err(e) => (QuerySet::invalid(Arc::clone(self), desc), Some(e)),
-        };
+        let query_set = self.create_query_set_inner(desc).unwrap_or_else(|err| {
+            self.handle_error(err, desc.label.as_deref(), "Device::create_query_set");
+            QuerySet::invalid(Arc::clone(self), desc)
+        });
         #[cfg(feature = "trace")]
         if let Some(ref mut trace) = *self.trace.lock() {
             use trace::IntoTrace;
@@ -5634,7 +5634,7 @@ impl Device {
             });
         }
         api_log!("Device::create_query_set -> {:?}", Arc::as_ptr(&query_set));
-        (query_set, error)
+        query_set
     }
 
     pub(crate) fn create_query_set_inner(

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1401,13 +1401,9 @@ impl dispatch::DeviceInterface for CoreDevice {
     }
 
     fn create_query_set(&self, desc: &crate::QuerySetDescriptor<'_>) -> dispatch::DispatchQuerySet {
-        let (wgpu_query_set, error) = self
+        let wgpu_query_set = self
             .wgpu_device
             .create_query_set(&desc.map_label(|l| l.map(Borrowed)));
-        if let Some(cause) = error {
-            self.wgpu_device
-                .handle_error_nolabel(cause, "Device::create_query_set");
-        }
         CoreQuerySet { wgpu_query_set }.into()
     }
 


### PR DESCRIPTION
**Connections**
Part of https://github.com/gfx-rs/wgpu/issues/8911
Towards https://github.com/gfx-rs/wgpu/issues/10073
Continuation of #10208

**Description**
As always we move erroring into wgc. Only deno was missing contant timeline validation.

**Testing**
Just refactor, but should be covered.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
