### PR TITLE
Return `SubmissionIndex` only if submissions succeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Remove the never-constructed `CreateBlasError::InvalidAabbStride` variant. `create_blas` takes no stride, so it could never be produced; AABB stride is validated at build time as `BuildAccelerationStructureError::InvalidAabbStride`. By @mstampfli in [#9935](https://github.com/gfx-rs/wgpu/pull/9935).
 
 - Added `DownlevelFlags::LINEAR_INTERPOLATION`, indicating that the adapter supports `@interpolate(linear)`. It is absent on GLES/WebGL2, since GLSL ES has no `noperspective` qualifier. By @emilk in [#9972](https://github.com/gfx-rs/wgpu/pull/9972).
+- `Queue::submit` now returns `Option<SubmissionIndex>`, and returns `None` if the submission failed. A `None` result means the submission never reached the driver, so fences/events/semaphores attached to HAL queues will never be signalled. By @teoxoy in [#10218](https://github.com/gfx-rs/wgpu/pull/10218).
 
 #### naga
 

--- a/examples/standalone/custom_backend/src/custom.rs
+++ b/examples/standalone/custom_backend/src/custom.rs
@@ -355,7 +355,7 @@ impl QueueInterface for CustomQueue {
     fn submit(
         &self,
         _command_buffers: &mut dyn Iterator<Item = wgpu::custom::DispatchCommandBuffer>,
-    ) -> u64 {
+    ) -> Option<u64> {
         unimplemented!()
     }
 

--- a/tests/tests/wgpu-gpu/poll.rs
+++ b/tests/tests/wgpu-gpu/poll.rs
@@ -251,7 +251,7 @@ static WAIT_ON_SUBMISSION: GpuTestConfiguration = GpuTestConfiguration::new()
 
         let index = ctx.queue.submit(Some(cmd_buf));
         ctx.async_poll(PollType::Wait {
-            submission_index: Some(index),
+            submission_index: index,
             timeout: None,
         })
         .await
@@ -266,7 +266,7 @@ static WAIT_ON_SUBMISSION_WITH_TIMEOUT: GpuTestConfiguration = GpuTestConfigurat
 
         let index = ctx.queue.submit(Some(cmd_buf));
         ctx.async_poll(PollType::Wait {
-            submission_index: Some(index),
+            submission_index: index,
             timeout: Some(Duration::from_secs(1)),
         })
         .await
@@ -281,7 +281,7 @@ static WAIT_ON_SUBMISSION_WITH_TIMEOUT_MAX: GpuTestConfiguration = GpuTestConfig
 
         let index = ctx.queue.submit(Some(cmd_buf));
         ctx.async_poll(PollType::Wait {
-            submission_index: Some(index),
+            submission_index: index,
             timeout: Some(Duration::MAX),
         })
         .await
@@ -296,13 +296,13 @@ static DOUBLE_WAIT_ON_SUBMISSION: GpuTestConfiguration = GpuTestConfiguration::n
 
         let index = ctx.queue.submit(Some(cmd_buf));
         ctx.async_poll(PollType::Wait {
-            submission_index: Some(index.clone()),
+            submission_index: index.clone(),
             timeout: None,
         })
         .await
         .unwrap();
         ctx.async_poll(PollType::Wait {
-            submission_index: Some(index),
+            submission_index: index,
             timeout: None,
         })
         .await
@@ -319,13 +319,13 @@ static WAIT_OUT_OF_ORDER: GpuTestConfiguration = GpuTestConfiguration::new()
         let index1 = ctx.queue.submit(Some(cmd_buf1));
         let index2 = ctx.queue.submit(Some(cmd_buf2));
         ctx.async_poll(PollType::Wait {
-            submission_index: Some(index2),
+            submission_index: index2,
             timeout: None,
         })
         .await
         .unwrap();
         ctx.async_poll(PollType::Wait {
-            submission_index: Some(index1),
+            submission_index: index1,
             timeout: None,
         })
         .await
@@ -383,34 +383,73 @@ async fn wait_after_bad_submission(ctx: TestingContext) {
 /// > operation you have already presented to the device is going to store in
 /// > `fence`.
 ///
+/// `wgpu::Queue::submit` returns `None` for a failed submission, so the hole
+/// index cannot be observed through the `wgpu` API. This test therefore drives
+/// wgpu-core directly, where a submission index is a plain `u64` we can
+/// construct ourselves.
+///
 /// Regression test for <https://github.com/gfx-rs/wgpu/issues/9498>.
+///
+/// Skipped under WebGL, where an adapter is a view onto a canvas's WebGL2
+/// context and so cannot be enumerated without a surface, leaving this test no
+/// way to build its own `wgpu-core` instance.
 #[apply(gpu_test!)]
 static WAIT_ON_FAILED_SUBMISSION: GpuTestConfiguration = GpuTestConfiguration::new()
-    .parameters(wgpu_test::TestParameters::default())
-    .run_async(wait_on_failed_submission);
+    .parameters(TestParameters::default().skip(FailureCase::webgl2()))
+    .run_sync(wait_on_failed_submission);
 
-async fn wait_on_failed_submission(ctx: TestingContext) {
-    // Create an alternate device; we will produce a failed submission by
-    // submitting a command buffer to the wrong device.
-    let (device2, queue2) =
-        wgpu_test::initialize_device(&ctx.adapter, ctx.device_features, ctx.device_limits.clone())
-            .await;
+fn wait_on_failed_submission(ctx: TestingContext) {
+    use wgpu_core as wgc;
+    use wgpu_types as wgt;
+
+    let backends = Backends::from(ctx.adapter_info.backend);
+    let instance = wgc::instance::Instance::new(
+        "wait_on_failed_submission",
+        wgt::InstanceDescriptor {
+            backends,
+            ..wgt::InstanceDescriptor::new_without_display_handle()
+        },
+        None,
+    );
+    // Pick out the same adapter the harness selected, so that this test covers
+    // every adapter it is run against rather than just the preferred one.
+    let wanted = &ctx.adapter_info;
+    let adapter = instance
+        .enumerate_adapters(backends, false)
+        .into_iter()
+        .find(|adapter| {
+            let info = adapter.get_info();
+            (info.name, info.vendor, info.device)
+                == (wanted.name.clone(), wanted.vendor, wanted.device)
+        })
+        .expect("could not find the adapter under test");
+
+    let device_desc = wgc::device::DeviceDescriptor {
+        label: None,
+        required_limits: adapter.limits(),
+        ..Default::default()
+    };
+    // A second device, used only to produce a command buffer that `queue`
+    // must reject.
+    let (other_device, _other_queue) = adapter.request_device(&device_desc).unwrap();
+    let (device, queue) = adapter.request_device(&device_desc).unwrap();
 
     // 1. Successful empty submit. Advances `last_successful_submission_index`.
-    let _idx_before = queue2.submit([]);
+    let idx_before = queue.submit(&[]).expect("empty submission should succeed");
 
     // 2. Failed submit (cross-device cmd buffer). Burns an index but does not
-    //    advance `last_successful_submission_index`. Capture the returned
-    //    index using an error scope so the validation error is not fatal.
-    let command_buffer_wrong_device = ctx
-        .device
-        .create_command_encoder(&CommandEncoderDescriptor::default())
-        .finish();
-    let scope = device2.push_error_scope(wgpu::ErrorFilter::Validation);
-    let bad_index = queue2.submit([command_buffer_wrong_device]);
-    let scope_error = scope.pop().await;
+    //    advance `last_successful_submission_index`. The error scope keeps the
+    //    validation error from being fatal.
+    let command_buffer_wrong_device = other_device
+        .create_command_encoder(&wgt::CommandEncoderDescriptor { label: None })
+        .finish(&wgt::CommandBufferDescriptor { label: None });
+    device.push_error_scope(wgt::error::ErrorFilter::Validation);
     assert!(
-        scope_error.is_some(),
+        queue.submit(&[command_buffer_wrong_device]).is_none(),
+        "expected the cross-device submission to fail"
+    );
+    assert!(
+        device.pop_error_scope().unwrap().is_some(),
         "expected the cross-device submission to produce a validation error"
     );
 
@@ -425,31 +464,38 @@ async fn wait_on_failed_submission(ctx: TestingContext) {
     //    want to exercise — the pending-fence search where the only
     //    candidate fence has a value strictly greater than `wait_value`.
     let big_size = 64 * 1024 * 1024;
-    let src = device2.create_buffer(&BufferDescriptor {
-        label: Some("src"),
+    let src = device.create_buffer(&wgt::BufferDescriptor {
+        label: Some("src".into()),
         size: big_size,
-        usage: BufferUsages::COPY_SRC | BufferUsages::COPY_DST,
+        usage: wgt::BufferUsages::COPY_SRC | wgt::BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });
-    let dst = device2.create_buffer(&BufferDescriptor {
-        label: Some("dst"),
+    let dst = device.create_buffer(&wgt::BufferDescriptor {
+        label: Some("dst".into()),
         size: big_size,
-        usage: BufferUsages::COPY_DST,
+        usage: wgt::BufferUsages::COPY_DST,
         mapped_at_creation: false,
     });
-    let mut encoder = device2.create_command_encoder(&CommandEncoderDescriptor::default());
+    let encoder = device.create_command_encoder(&wgt::CommandEncoderDescriptor { label: None });
     // Stack several copies to extend the GPU work duration.
     for _ in 0..16 {
-        encoder.copy_buffer_to_buffer(&src, 0, &dst, 0, Some(big_size));
+        encoder.copy_buffer_to_buffer(src.clone(), 0, dst.clone(), 0, Some(big_size));
     }
-    let _idx_after = queue2.submit([encoder.finish()]);
+    let idx_after = queue
+        .submit(&[encoder.finish(&wgt::CommandBufferDescriptor { label: None })])
+        .expect("submission should succeed");
+
+    // Each submission attempt consumes exactly one index, so the failed one
+    // sits between the two successful ones.
+    let bad_index = idx_after - 1;
+    assert!(idx_before < bad_index);
 
     // 4. The interesting wait: pass the hole index to `poll(Wait)`. The
     //    wgpu-core guard sees `bad_index <= last_successful_submission_index`
     //    and lets it through to the HAL `wait`, which is being asked to wait
     //    on a fence value no operation actually presented. Must not panic or
     //    hang.
-    let result = device2.poll(wgpu::PollType::Wait {
+    let result = device.poll(wgt::PollType::Wait {
         submission_index: Some(bad_index),
         timeout: Some(Duration::from_secs(5)),
     });

--- a/wgpu-core-remote/src/global/queue.rs
+++ b/wgpu-core-remote/src/global/queue.rs
@@ -44,7 +44,7 @@ impl Global {
         &self,
         queue_id: QueueId,
         command_buffer_ids: &[CommandBufferId],
-    ) -> SubmissionIndex {
+    ) -> Option<SubmissionIndex> {
         let hub = self.hub.borrow();
         let queue = hub.queues.get(queue_id);
         let command_buffers = command_buffer_ids

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -129,9 +129,7 @@ impl Queue {
         texture: &Arc<Texture>,
     ) -> Result<(), DeviceError> {
         let snatch_guard = self.device.snatchable_lock.read();
-        let submission = self
-            .allocate_submission(snatch_guard)
-            .map_err(|(_index, e)| e)?;
+        let submission = self.allocate_submission(snatch_guard)?;
         let device = &self.device;
 
         // If the texture is uninitialized it needs to be cleared before presenting
@@ -1451,9 +1449,7 @@ impl Queue {
         buffer: &Arc<Buffer>,
         snatch_guard: SnatchGuard,
     ) -> Result<(), BufferAccessError> {
-        let submission = self
-            .allocate_submission(snatch_guard)
-            .map_err(|(_index, e)| e)?;
+        let submission = self.allocate_submission(snatch_guard)?;
 
         let pending_writes = self.pending_writes.lock();
         if !pending_writes.contains_buffer(buffer) {
@@ -1467,9 +1463,7 @@ impl Queue {
 
     fn flush_pending_writes(&self) -> Result<Option<SubmissionIndex>, DeviceError> {
         let snatch_guard = self.device.snatchable_lock.read();
-        let submission = self
-            .allocate_submission(snatch_guard)
-            .map_err(|(_index, e)| e)?;
+        let submission = self.allocate_submission(snatch_guard)?;
         let submit_index = submission.index;
         let pending_writes = self.pending_writes.lock();
         if pending_writes.is_recording {
@@ -1510,20 +1504,21 @@ impl Queue {
     fn submit_inner(
         &self,
         command_buffers: &[Arc<CommandBuffer>],
-    ) -> Result<SubmissionIndex, (SubmissionIndex, QueueSubmitError)> {
+    ) -> Result<SubmissionIndex, Box<(Option<SubmissionIndex>, QueueSubmitError)>> {
         profiling::scope!("Queue::submit");
         api_log!("Queue::submit");
 
         let snatch_guard = self.device.snatchable_lock.read();
         let mut submission = self
             .allocate_submission(snatch_guard)
-            .map_err(|(index, e)| (index, e.into()))?;
+            .map_err(|e| (None, e.into()))?;
         let submit_index = submission.index;
 
         // If we encounter an error after we have started updating global state and before
         // successful submission, we must lose the device to avoid continuing with
         // potentially inaccurate resource state.
         let mut lose_device_on_error = false;
+        let mut successfully_submitted = false;
 
         let res = 'error: {
             let mut used_surface_textures = track::TextureUsageScope::default();
@@ -1730,6 +1725,7 @@ impl Queue {
                 Ok(result) => result,
                 Err(e) => break 'error Err(e.into()),
             };
+            successfully_submitted = true;
 
             profiling::scope!("cleanup");
 
@@ -1765,7 +1761,10 @@ impl Queue {
                 if lose_device_on_error {
                     self.device.lose("submission failed");
                 }
-                return Err((submit_index, e));
+                return Err(Box::new((
+                    successfully_submitted.then_some(submit_index),
+                    e,
+                )));
             }
         };
 
@@ -1779,10 +1778,11 @@ impl Queue {
         Ok(submit_index)
     }
 
-    pub fn submit(&self, command_buffers: &[Arc<CommandBuffer>]) -> SubmissionIndex {
+    pub fn submit(&self, command_buffers: &[Arc<CommandBuffer>]) -> Option<SubmissionIndex> {
         match self.submit_inner(command_buffers) {
-            Ok(submit_index) => submit_index,
-            Err((submit_index, e)) => {
+            Ok(submit_index) => Some(submit_index),
+            Err(e) => {
+                let (submit_index, e) = *e;
                 self.device
                     .handle_error(e, Some(self.label()), "Queue::submit");
                 submit_index
@@ -1815,14 +1815,12 @@ impl Queue {
     fn allocate_submission<'a>(
         &'a self,
         snatch_guard: SnatchGuard<'a>,
-    ) -> Result<PendingSubmission<'a>, (SubmissionIndex, DeviceError)> {
+    ) -> Result<PendingSubmission<'a>, DeviceError> {
         let mut command_index_guard = self.device.command_indices.write();
         command_index_guard.active_submission_index += 1;
         let index = command_index_guard.active_submission_index;
 
-        if let Err(e) = self.device.check_is_valid() {
-            return Err((index, e));
-        }
+        self.device.check_is_valid()?;
 
         let submission = PendingSubmission {
             queue: self,

--- a/wgpu/src/api/queue.rs
+++ b/wgpu/src/api/queue.rs
@@ -280,7 +280,7 @@ impl Queue {
     pub fn submit<I: IntoIterator<Item = CommandBuffer>>(
         &self,
         command_buffers: I,
-    ) -> SubmissionIndex {
+    ) -> Option<SubmissionIndex> {
         // As submit drains the iterator (even on error), collect deferred actions
         // from each CommandBuffer along the way.
         let mut actions = DeferredCommandBufferActions::default();
@@ -294,7 +294,7 @@ impl Queue {
         // Execute all deferred actions after submit.
         actions.execute(&self.inner);
 
-        SubmissionIndex { index }
+        index.map(|index| SubmissionIndex { index })
     }
 
     /// Gets the amount of nanoseconds each tick of a timestamp query represents.

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -2946,7 +2946,7 @@ impl dispatch::QueueInterface for WebQueue {
     fn submit(
         &self,
         command_buffers: &mut dyn Iterator<Item = dispatch::DispatchCommandBuffer>,
-    ) -> u64 {
+    ) -> Option<u64> {
         let temp_command_buffers = command_buffers.collect::<Vec<_>>();
 
         let array = temp_command_buffers
@@ -2956,7 +2956,7 @@ impl dispatch::QueueInterface for WebQueue {
 
         self.inner.submit(&array);
 
-        0
+        Some(0)
     }
 
     fn get_timestamp_period(&self) -> f32 {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1629,7 +1629,7 @@ impl dispatch::QueueInterface for CoreQueue {
     fn submit(
         &self,
         command_buffers: &mut dyn Iterator<Item = dispatch::DispatchCommandBuffer>,
-    ) -> u64 {
+    ) -> Option<u64> {
         let temp_command_buffers = command_buffers.collect::<SmallVec<[_; 4]>>();
         let command_buffers = temp_command_buffers
             .iter()

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -255,7 +255,10 @@ pub trait QueueInterface: CommonTraits {
     );
 
     /// Submit must always drain the iterator, even in the case of error.
-    fn submit(&self, command_buffers: &mut dyn Iterator<Item = DispatchCommandBuffer>) -> u64;
+    fn submit(
+        &self,
+        command_buffers: &mut dyn Iterator<Item = DispatchCommandBuffer>,
+    ) -> Option<u64>;
 
     fn get_timestamp_period(&self) -> f32;
     fn on_submitted_work_done(&self, callback: BoxSubmittedWorkDoneCallback);


### PR DESCRIPTION
**Connections**
Firefox's wgpu update ([Bug 2066780](https://bugzilla.mozilla.org/show_bug.cgi?id=2066780)) needs this since `queue_submit` only returns the submission index now and we have no way to tell if the submission succeeded (we can't use an error scope since validation errors should still be surfaced to users).

Firefox was also incorrectly using the presence of `Result::Err` to mean the submission failed but that's not correct since the inner call to `maintain` (below the call to HAL `submit`) could error. The error would be propagated but the submission did reach the driver and our lifetime tracking. This PR also enables us to fix this issue.

**Description**
If submissions were not successful, a subsequent call to `poll` with the returned `SubmissionIndex` would have raised a validation error anyway.

Making the result type `Option<SubmissionIndex>` hints to users that the submission has not reached the driver so fences/events/semaphores that were attached to HAL queues will never be signalled.

**Testing**
Existing tests.

**Squash or Rebase?**
Squash

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [x] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
