### PR TITLE
Fix missing SUBGROUP feature mapping on WebGPU backend

### DIFF
--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -794,7 +794,7 @@ fn map_map_mode(mode: crate::MapMode) -> u32 {
     }
 }
 
-static FEATURES_MAPPING: &'static [(wgt::Features, webgpu_sys::GpuFeatureName)] = &[
+static FEATURES_MAPPING: &[(wgt::Features, webgpu_sys::GpuFeatureName)] = &[
     (
         wgt::Features::DEPTH_CLIP_CONTROL,
         webgpu_sys::GpuFeatureName::DepthClipControl,

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -794,7 +794,7 @@ fn map_map_mode(mode: crate::MapMode) -> u32 {
     }
 }
 
-const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 17] = [
+static FEATURES_MAPPING: &'static [(wgt::Features, webgpu_sys::GpuFeatureName)] = &[
     (
         wgt::Features::DEPTH_CLIP_CONTROL,
         webgpu_sys::GpuFeatureName::DepthClipControl,
@@ -868,8 +868,8 @@ const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 17] = [
 fn map_wgt_features(supported_features: webgpu_sys::GpuSupportedFeatures) -> wgt::Features {
     let mut features = wgt::Features::empty();
     for (wgpu_feat, web_feat) in FEATURES_MAPPING {
-        match wasm_bindgen::JsValue::from(web_feat).as_string() {
-            Some(value) if supported_features.has(&value) => features |= wgpu_feat,
+        match wasm_bindgen::JsValue::from(*web_feat).as_string() {
+            Some(value) if supported_features.has(&value) => features |= *wgpu_feat,
             _ => {}
         }
     }

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -794,7 +794,7 @@ fn map_map_mode(mode: crate::MapMode) -> u32 {
     }
 }
 
-const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 16] = [
+const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 17] = [
     (
         wgt::Features::DEPTH_CLIP_CONTROL,
         webgpu_sys::GpuFeatureName::DepthClipControl,
@@ -858,6 +858,10 @@ const FEATURES_MAPPING: [(wgt::Features, webgpu_sys::GpuFeatureName); 16] = [
     (
         wgt::Features::CLIP_DISTANCES,
         webgpu_sys::GpuFeatureName::ClipDistances,
+    ),
+    (
+        wgt::Features::SUBGROUP,
+        webgpu_sys::GpuFeatureName::Subgroups,
     ),
 ];
 


### PR DESCRIPTION
Closes #10146

## Summary

The WebGPU backend's `FEATURES_MAPPING` table was missing the entry for `wgt::Features::SUBGROUP`, so the feature was never propagated even when the browser/host reports support for `subgroups`. This made subgroup operations unusable on the WebGPU backend.

## Changes

- Add the `wgt::Features::SUBGROUP` -> `webgpu_sys::GpuFeatureName::Subgroups` entry to `FEATURES_MAPPING`.
- Bump the table length from 16 to 17.

This single table already drives both directions: `map_wgt_features` (exposing supported features) and required-features validation when creating a device.

## Why this is safe

- Both symbols exist (`wgpu-types::Features::SUBGROUP`, `webgpu_sys::GpuFeatureName::Subgroups`).
- The backend already exposes `subgroup_min_size` / `subgroup_max_size` from adapter info, so propagating the feature flag is consistent.

## Testing

- `cargo check -p wgpu --target wasm32-unknown-unknown --no-default-features --features webgpu,wgsl,std` passes.