### PR TITLE
fix(dx12): actually use NONE comparison function when it is None

### DIFF
--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -822,8 +822,7 @@ impl crate::Device for super::Device {
 
             ComparisonFunc: desc
                 .compare
-                .map(conv::map_comparison)
-                .unwrap_or(Direct3D12::D3D12_COMPARISON_FUNC_NONE),
+                .map_or(Direct3D12::D3D12_COMPARISON_FUNC_NONE, conv::map_comparison),
             BorderColor: border_color,
             MinLOD: desc.lod_clamp.start,
             MaxLOD: desc.lod_clamp.end,

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -820,7 +820,10 @@ impl crate::Device for super::Device {
             MipLODBias: 0f32,
             MaxAnisotropy: desc.anisotropy_clamp as u32,
 
-            ComparisonFunc: conv::map_comparison(desc.compare.unwrap_or_default()),
+            ComparisonFunc: desc
+                .compare
+                .map(conv::map_comparison)
+                .unwrap_or(Direct3D12::D3D12_COMPARISON_FUNC_NONE),
             BorderColor: border_color,
             MinLOD: desc.lod_clamp.start,
             MaxLOD: desc.lod_clamp.end,


### PR DESCRIPTION
**Connections**
fix #10150

**Description**
make the warning disappear, as explained in #10150 
```
D3D12 WARNING: ID3D12Device::CreateSampler2: ComparisonFunc is D3D12_COMPARISON_FUNC_ALWAYS, but D3D12_FILTER_MIN_MAG_MIP_POINT is not a comparison filter. This is OK, as the ComparisonFunc will simply be ignored, but is was likely not the intent. [ STATE_CREATION WARNING #1361: CREATE_SAMPLER_COMPARISON_FUNC_IGNORED]
```

**Testing**
code compiles. should be no breaking change

**Squash or Rebase?**
squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [X] Commits are logically scoped and individually reviewable.
- [X] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
