### PR TITLE
[v30] Manual `Send` and `Sync` for `Hub` and `Command{Encoder,Buffer}`

### DIFF
--- a/wgpu-core/src/command/mod.rs
+++ b/wgpu-core/src/command/mod.rs
@@ -534,6 +534,26 @@ crate::impl_labeled!(CommandEncoder);
 crate::impl_parent_device!(CommandEncoder);
 crate::impl_storage_item!(CommandEncoder);
 
+#[cfg(send_sync)]
+const _: () = {
+    // SAFETY: Bounds checked below
+    unsafe impl Send for CommandEncoder {}
+    // SAFETY: Bounds checked below
+    unsafe impl Sync for CommandEncoder {}
+
+    fn _command_encoder_fields_are_send_sync(obj: &CommandEncoder) {
+        fn _check_bound<T: Send + Sync>(_: &T) {}
+        let CommandEncoder {
+            device,
+            label,
+            data,
+        } = obj;
+        _check_bound(device);
+        _check_bound(label);
+        _check_bound(data);
+    }
+};
+
 impl Drop for CommandEncoder {
     fn drop(&mut self) {
         resource_log!("Drop {}", self.error_ident());
@@ -901,6 +921,26 @@ pub struct CommandBuffer {
     /// The mutable state of this command buffer.
     pub(crate) data: Mutex<CommandEncoderStatus>,
 }
+
+#[cfg(send_sync)]
+const _: () = {
+    // SAFETY: Bounds checked below
+    unsafe impl Send for CommandBuffer {}
+    // SAFETY: Bounds checked below
+    unsafe impl Sync for CommandBuffer {}
+
+    fn _command_buffer_fields_are_send_sync(obj: &CommandBuffer) {
+        fn _check_bound<T: Send + Sync>(_: &T) {}
+        let CommandBuffer {
+            device,
+            label,
+            data,
+        } = obj;
+        _check_bound(device);
+        _check_bound(label);
+        _check_bound(data);
+    }
+};
 
 impl Drop for CommandBuffer {
     fn drop(&mut self) {

--- a/wgpu-core/src/hub.rs
+++ b/wgpu-core/src/hub.rs
@@ -283,3 +283,67 @@ impl Hub {
         }
     }
 }
+
+#[cfg(send_sync)]
+const _: () = {
+    // SAFETY: Bounds checked below
+    unsafe impl Send for Hub {}
+    // SAFETY: Bounds checked below
+    unsafe impl Sync for Hub {}
+
+    fn _hub_fields_are_send_sync(hub: &Hub) {
+        fn _check_bound<T: Send + Sync>(_: &T) {}
+        let Hub {
+            adapters,
+            devices,
+            queues,
+            pipeline_layouts,
+            shader_modules,
+            bind_group_layouts,
+            bind_groups,
+            command_encoders,
+            command_buffers,
+            render_bundles,
+            render_pipelines,
+            compute_pipelines,
+            pipeline_caches,
+            query_sets,
+            buffers,
+            staging_buffers,
+            textures,
+            texture_views,
+            external_textures,
+            samplers,
+            blas_s,
+            tlas_s,
+            render_passes,
+            compute_passes,
+            render_bundle_encoders,
+        } = hub;
+        _check_bound(adapters);
+        _check_bound(devices);
+        _check_bound(queues);
+        _check_bound(pipeline_layouts);
+        _check_bound(shader_modules);
+        _check_bound(bind_group_layouts);
+        _check_bound(bind_groups);
+        _check_bound(command_encoders);
+        _check_bound(command_buffers);
+        _check_bound(render_bundles);
+        _check_bound(render_pipelines);
+        _check_bound(compute_pipelines);
+        _check_bound(pipeline_caches);
+        _check_bound(query_sets);
+        _check_bound(buffers);
+        _check_bound(staging_buffers);
+        _check_bound(textures);
+        _check_bound(texture_views);
+        _check_bound(external_textures);
+        _check_bound(samplers);
+        _check_bound(blas_s);
+        _check_bound(tlas_s);
+        _check_bound(render_passes);
+        _check_bound(compute_passes);
+        _check_bound(render_bundle_encoders);
+    }
+};


### PR DESCRIPTION
Note: This PR targets the `v30` branch.

Fix recursion limit error on nightly (CI miri job) with unsafe direct `Send`/`Sync` plus manual checks on struct members, like we've had before for `Global`. Mostly the same as the `firefox-153` version in #10170, but with a few additional fields in `Hub`. 

**Testing**
CI

**Squash or Rebase?** Squash