### PR TITLE
Partial `snorm10-10-10-2` vertex format support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,10 +103,12 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
   By @ErichDonGubler in [#8764](https://github.com/gfx-rs/wgpu/pull/8764)
 
+- Zero-size vertex and index buffer bindings are now accepted by `set_vertex_buffer` and `set_index_buffer`. By @andyleiserson in [#9848](https://github.com/gfx-rs/wgpu/pull/9848).
+- Added the `snorm10-10-10-2` vertex format on Metal and Vulkan. Not yet supported on DX12. By @andyleiserson in [#10226](https://github.com/gfx-rs/wgpu/pull/10226).
+
 #### Naga
 
 - Add `@builtin(hit_barycentrics)`, a `vec2<f32>` readable in `@any_hit` and `@closest_hit` ray tracing pipeline shaders, holding two of the barycentric coordinates of the hit point on the triangle (the third is `1.0 - x - y`). Currently only supported with the SPIR-V backend. By @JMS55 in [#10193](https://github.com/gfx-rs/wgpu/pull/10193).
-- Zero-size vertex and index buffer bindings are now accepted by `set_vertex_buffer` and `set_index_buffer`. By @andyleiserson in [#9848](https://github.com/gfx-rs/wgpu/pull/9848).
 
 #### Hal
 

--- a/cts_runner/fail.lst
+++ b/cts_runner/fail.lst
@@ -17,6 +17,7 @@ webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_t
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=false;stencilReadOnly=true // https://github.com/gfx-rs/wgpu/issues/8705
 webgpu:api,operation,memory_sync,texture,readonly_depth_stencil:sampling_while_testing:format="depth32float-stencil8";depthReadOnly=true;stencilReadOnly=false // https://github.com/gfx-rs/wgpu/issues/8705
 webgpu:api,operation,rendering,3d_texture_slices:* // https://github.com/gfx-rs/wgpu/issues/9455
+webgpu:api,operation,vertex_state,correctness:* // Vulkan (https://github.com/gfx-rs/wgpu/issues/1105) and dx12 (https://github.com/gfx-rs/wgpu/issues/10216)
 
 webgpu:api,validation,buffer,create:new_usages,* // 0%, deno_webgpu declares the GPU*Usage constants as static getters, which are non-enumerable, so the test sees no legal usage bits, https://github.com/denoland/deno/issues/33846
 webgpu:api,validation,buffer,mapping:* // crash
@@ -51,7 +52,7 @@ webgpu:api,validation,render_pipeline,inter_stage:* // 15%, inter-stage type val
 webgpu:api,validation,render_pipeline,misc:external_texture:* // 0%, no external texture in deno
 webgpu:api,validation,render_pipeline,multisample_state:* // 60%, https://github.com/gfx-rs/wgpu/issues/8779
 webgpu:api,validation,render_pipeline,overrides:* // 17%, missing validation: invalid pipeline constant identifiers silently ignored
-webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:* // fails on metal in CI https://github.com/gfx-rs/wgpu/issues/8312
+webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:* // metal (CI only, https://github.com/gfx-rs/wgpu/issues/8312), dx12 (https://github.com/gfx-rs/wgpu/issues/10216)
 webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_offset_alignment:* // fails on metal in CI
 webgpu:api,validation,resource_usages,texture,in_pass_encoder:subresources_and_binding_types_combination_for_color:* // 92%, https://github.com/gfx-rs/wgpu/issues/3126
 webgpu:api,validation,state,device_lost,destroy:* // crash

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -64,9 +64,9 @@ fails-if(dx12) webgpu:api,operation,texture_view,texture_component_swizzle:*
 webgpu:api,operation,uncapturederror:iff_uncaptured:*
 //FAIL: webgpu:api,operation,uncapturederror:onuncapturederror_order_wrt_addEventListener
 // There are also two unimplemented SKIPs in uncapturederror not enumerated here.
-fails-if(vulkan) webgpu:api,operation,vertex_state,correctness:array_stride_zero:*
-webgpu:api,operation,vertex_state,correctness:non_zero_array_stride_and_attribute_offset:*
-webgpu:api,operation,vertex_state,correctness:setVertexBuffer_offset_and_attribute_offset:*
+fails-if(vulkan,dx12) webgpu:api,operation,vertex_state,correctness:array_stride_zero:*
+fails-if(dx12) webgpu:api,operation,vertex_state,correctness:non_zero_array_stride_and_attribute_offset:*
+fails-if(dx12) webgpu:api,operation,vertex_state,correctness:setVertexBuffer_offset_and_attribute_offset:*
 
 webgpu:api,validation,buffer,create:createBuffer_invalid_and_oom,*
 webgpu:api,validation,buffer,create:limit,*
@@ -299,7 +299,7 @@ webgpu:api,validation,render_pipeline,vertex_state:many_attributes_overlapping:*
 webgpu:api,validation,render_pipeline,vertex_state:max_vertex_attribute_limit:*
 webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_array_stride_limit:*
 webgpu:api,validation,render_pipeline,vertex_state:max_vertex_buffer_limit:*
-fails-if(metal) webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:*
+fails-if(dx12,metal) webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_contained_in_stride:*
 fails-if(metal) webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_offset_alignment:*
 webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_shaderLocation_limit:*
 webgpu:api,validation,render_pipeline,vertex_state:vertex_attribute_shaderLocation_unique:*

--- a/deno_webgpu/render_pipeline.rs
+++ b/deno_webgpu/render_pipeline.rs
@@ -496,6 +496,8 @@ pub(crate) enum GPUVertexFormat {
   Unorm1010102,
   #[webidl(rename = "unorm8x4-bgra")]
   Unorm8x4Bgra,
+  #[webidl(rename = "snorm10-10-10-2")]
+  Snorm1010102,
 }
 
 impl From<GPUVertexFormat> for wgpu_types::VertexFormat {
@@ -542,6 +544,7 @@ impl From<GPUVertexFormat> for wgpu_types::VertexFormat {
       GPUVertexFormat::Sint32x4 => Self::Sint32x4,
       GPUVertexFormat::Unorm1010102 => Self::Unorm10_10_10_2,
       GPUVertexFormat::Unorm8x4Bgra => Self::Unorm8x4Bgra,
+      GPUVertexFormat::Snorm1010102 => Self::Snorm10_10_10_2,
     }
   }
 }

--- a/naga-types/src/lib.rs
+++ b/naga-types/src/lib.rs
@@ -316,6 +316,12 @@ pub enum VertexFormat {
         serde(rename = "unorm8x4-bgra")
     )]
     Unorm8x4Bgra = 44,
+    /// Three signed 10-bit integers and one 2-bit integer, packed into a 32-bit integer (u32). [&minus;511, 511] and [&minus;1, 1] converted to float [&minus;1, 1] `vec4<f32>` in shaders.
+    #[cfg_attr(
+        any(feature = "serialize", feature = "deserialize"),
+        serde(rename = "snorm10-10-10-2")
+    )]
+    Snorm10_10_10_2 = 45,
 }
 
 impl VertexFormat {
@@ -346,7 +352,8 @@ impl VertexFormat {
             | Self::Uint32
             | Self::Sint32
             | Self::Unorm10_10_10_2
-            | Self::Unorm8x4Bgra => 4,
+            | Self::Unorm8x4Bgra
+            | Self::Snorm10_10_10_2 => 4,
             Self::Uint16x4
             | Self::Sint16x4
             | Self::Unorm16x4

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -5824,6 +5824,29 @@ template <typename A>
                 writeln!(self.out, "}}")?;
                 Ok((name, 4, Some(VectorSize::Quad), Scalar::F32))
             }
+            Snorm10_10_10_2 => {
+                let name = self.namer.call("unpackSnorm10_10_10_2");
+                writeln!(
+                    self.out,
+                    "metal::float4 {name}(uint b0, \
+                                          uint b1, \
+                                          uint b2, \
+                                          uint b3) {{"
+                )?;
+                writeln!(
+                    self.out,
+                    // Sign-extend by shifting to the top of the word and back.
+                    "{}uint v = (b3 << 24 | b2 << 16 | b1 << 8 | b0); \
+                       return metal::max(metal::float4(float(as_type<int>(v << 22) >> 22) / 511.0f, \
+                                                       float(as_type<int>(v << 12) >> 22) / 511.0f, \
+                                                       float(as_type<int>(v << 2) >> 22) / 511.0f, \
+                                                       float(as_type<int>(v) >> 30)), \
+                                         metal::float4(-1.0f));",
+                    back::INDENT
+                )?;
+                writeln!(self.out, "}}")?;
+                Ok((name, 4, Some(VectorSize::Quad), Scalar::F32))
+            }
             Unorm8x4Bgra => {
                 let name = self.namer.call("unpackUnorm8x4Bgra");
                 writeln!(

--- a/naga/tests/in/wgsl/msl-vpt-formats-x1.toml
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x1.toml
@@ -51,7 +51,8 @@ attributes = [
     { offset = 656, shader_location = 41, format = "float16" },
     { offset = 672, shader_location = 42, format = "float16x2" },
     { offset = 688, shader_location = 43, format = "float16x4" },
+    { offset = 704, shader_location = 44, format = "snorm10-10-10-2" },
 ]
 id = 1
 step_mode = "ByVertex"
-stride = 704
+stride = 720

--- a/naga/tests/in/wgsl/msl-vpt-formats-x1.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x1.wgsl
@@ -57,6 +57,8 @@ struct VertexInput {
   @location(41) v_float16_as_f16   : f16,
   @location(42) v_float16x2_as_f16 : f16,
   @location(43) v_float16x4_as_f16 : f16,
+
+  @location(44) v_snorm10_10_10_2: f32,
 }
 
 @vertex

--- a/naga/tests/in/wgsl/msl-vpt-formats-x2.toml
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x2.toml
@@ -51,7 +51,8 @@ attributes = [
     { offset = 656, shader_location = 41, format = "float16" },
     { offset = 672, shader_location = 42, format = "float16x2" },
     { offset = 688, shader_location = 43, format = "float16x4" },
+    { offset = 704, shader_location = 44, format = "snorm10-10-10-2" },
 ]
 id = 1
 step_mode = "ByVertex"
-stride = 704
+stride = 720

--- a/naga/tests/in/wgsl/msl-vpt-formats-x2.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x2.wgsl
@@ -57,6 +57,8 @@ struct VertexInput {
   @location(41) v_float16_as_f16   : vec2<f16>,
   @location(42) v_float16x2_as_f16 : vec2<f16>,
   @location(43) v_float16x4_as_f16 : vec2<f16>,
+
+  @location(44) v_snorm10_10_10_2: vec2<f32>,
 }
 
 @vertex

--- a/naga/tests/in/wgsl/msl-vpt-formats-x3.toml
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x3.toml
@@ -51,7 +51,8 @@ attributes = [
     { offset = 656, shader_location = 41, format = "float16" },
     { offset = 672, shader_location = 42, format = "float16x2" },
     { offset = 688, shader_location = 43, format = "float16x4" },
+    { offset = 704, shader_location = 44, format = "snorm10-10-10-2" },
 ]
 id = 1
 step_mode = "ByVertex"
-stride = 704
+stride = 720

--- a/naga/tests/in/wgsl/msl-vpt-formats-x3.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x3.wgsl
@@ -57,6 +57,8 @@ struct VertexInput {
   @location(41) v_float16_as_f16   : vec3<f16>,
   @location(42) v_float16x2_as_f16 : vec3<f16>,
   @location(43) v_float16x4_as_f16 : vec3<f16>,
+
+  @location(44) v_snorm10_10_10_2: vec3<f32>,
 }
 
 @vertex

--- a/naga/tests/in/wgsl/msl-vpt-formats-x4.toml
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x4.toml
@@ -51,7 +51,8 @@ attributes = [
     { offset = 656, shader_location = 41, format = "float16" },
     { offset = 672, shader_location = 42, format = "float16x2" },
     { offset = 688, shader_location = 43, format = "float16x4" },
+    { offset = 704, shader_location = 44, format = "snorm10-10-10-2" },
 ]
 id = 1
 step_mode = "ByVertex"
-stride = 704
+stride = 720

--- a/naga/tests/in/wgsl/msl-vpt-formats-x4.wgsl
+++ b/naga/tests/in/wgsl/msl-vpt-formats-x4.wgsl
@@ -57,6 +57,8 @@ struct VertexInput {
   @location(41) v_float16_as_f16   : vec4<f16>,
   @location(42) v_float16x2_as_f16 : vec4<f16>,
   @location(43) v_float16x4_as_f16 : vec4<f16>,
+
+  @location(44) v_snorm10_10_10_2: vec4<f32>,
 }
 
 @vertex

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x1.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x1.metal
@@ -57,6 +57,7 @@ struct VertexInput {
     half v_float16x2_as_f16_;
     half v_float16x4_as_f16_;
     char _pad44[2];
+    float v_snorm10_10_10_2_;
 };
 uint unpackUint8_(metal::uchar b0) {
     return uint(b0);
@@ -181,11 +182,14 @@ metal::float4 unpackUnorm10_10_10_2_(uint b0, uint b1, uint b2, uint b3) {
 metal::float4 unpackUnorm8x4Bgra(metal::uchar b0, metal::uchar b1, metal::uchar b2, metal::uchar b3) {
     return metal::float4(float(b2) / 255.0f, float(b1) / 255.0f, float(b0) / 255.0f, float(b3) / 255.0f);
 }
+metal::float4 unpackSnorm10_10_10_2_(uint b0, uint b1, uint b2, uint b3) {
+    uint v = (b3 << 24 | b2 << 16 | b1 << 8 | b0); return metal::max(metal::float4(float(as_type<int>(v << 22) >> 22) / 511.0f, float(as_type<int>(v << 12) >> 22) / 511.0f, float(as_type<int>(v << 2) >> 22) / 511.0f, float(as_type<int>(v) >> 30)), metal::float4(-1.0f));
+}
 
 struct render_vertexOutput {
     metal::float4 position [[position]];
 };
-struct vb_1_type { metal::uchar data[704]; };
+struct vb_1_type { metal::uchar data[720]; };
 vertex render_vertexOutput render_vertex(
   uint v_id [[vertex_id]]
 , const device vb_1_type* vb_1_in [[buffer(1)]]
@@ -235,7 +239,8 @@ vertex render_vertexOutput render_vertex(
     half v_float16_as_f16_ = {};
     half v_float16x2_as_f16_ = {};
     half v_float16x4_as_f16_ = {};
-    if (v_id < (_buffer_sizes.buffer_size1 / 704)) {
+    float v_snorm10_10_10_2_ = {};
+    if (v_id < (_buffer_sizes.buffer_size1 / 720)) {
         const vb_1_type vb_1_elem = vb_1_in[v_id];
         v_uint8_ = unpackUint8_(vb_1_elem.data[0]);
         // uint <- Uint8x2
@@ -312,8 +317,10 @@ vertex render_vertexOutput render_vertex(
         v_float16x2_as_f16_ = metal::half2(unpackFloat16x2_(vb_1_elem.data[672], vb_1_elem.data[673], vb_1_elem.data[674], vb_1_elem.data[675])).x;
         // half <- Float16x4
         v_float16x4_as_f16_ = metal::half4(unpackFloat16x4_(vb_1_elem.data[688], vb_1_elem.data[689], vb_1_elem.data[690], vb_1_elem.data[691], vb_1_elem.data[692], vb_1_elem.data[693], vb_1_elem.data[694], vb_1_elem.data[695])).x;
+        // float <- Snorm10_10_10_2
+        v_snorm10_10_10_2_ = unpackSnorm10_10_10_2_(vb_1_elem.data[704], vb_1_elem.data[705], vb_1_elem.data[706], vb_1_elem.data[707]).x;
     }
-    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_ };
+    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_, {}, v_snorm10_10_10_2_ };
     const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_)};
     return render_vertexOutput { _tmp.position };
 }

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x2.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x2.metal
@@ -57,6 +57,7 @@ struct VertexInput {
     metal::half2 v_float16x2_as_f16_;
     metal::half2 v_float16x4_as_f16_;
     char _pad44[4];
+    metal::float2 v_snorm10_10_10_2_;
 };
 uint unpackUint8_(metal::uchar b0) {
     return uint(b0);
@@ -181,11 +182,14 @@ metal::float4 unpackUnorm10_10_10_2_(uint b0, uint b1, uint b2, uint b3) {
 metal::float4 unpackUnorm8x4Bgra(metal::uchar b0, metal::uchar b1, metal::uchar b2, metal::uchar b3) {
     return metal::float4(float(b2) / 255.0f, float(b1) / 255.0f, float(b0) / 255.0f, float(b3) / 255.0f);
 }
+metal::float4 unpackSnorm10_10_10_2_(uint b0, uint b1, uint b2, uint b3) {
+    uint v = (b3 << 24 | b2 << 16 | b1 << 8 | b0); return metal::max(metal::float4(float(as_type<int>(v << 22) >> 22) / 511.0f, float(as_type<int>(v << 12) >> 22) / 511.0f, float(as_type<int>(v << 2) >> 22) / 511.0f, float(as_type<int>(v) >> 30)), metal::float4(-1.0f));
+}
 
 struct render_vertexOutput {
     metal::float4 position [[position]];
 };
-struct vb_1_type { metal::uchar data[704]; };
+struct vb_1_type { metal::uchar data[720]; };
 vertex render_vertexOutput render_vertex(
   uint v_id [[vertex_id]]
 , const device vb_1_type* vb_1_in [[buffer(1)]]
@@ -235,7 +239,8 @@ vertex render_vertexOutput render_vertex(
     metal::half2 v_float16_as_f16_ = {};
     metal::half2 v_float16x2_as_f16_ = {};
     metal::half2 v_float16x4_as_f16_ = {};
-    if (v_id < (_buffer_sizes.buffer_size1 / 704)) {
+    metal::float2 v_snorm10_10_10_2_ = {};
+    if (v_id < (_buffer_sizes.buffer_size1 / 720)) {
         const vb_1_type vb_1_elem = vb_1_in[v_id];
         // metal::uint2 <- Uint8
         v_uint8_ = metal::uint2(unpackUint8_(vb_1_elem.data[0]), 0);
@@ -312,8 +317,10 @@ vertex render_vertexOutput render_vertex(
         v_float16x2_as_f16_ = metal::half2(unpackFloat16x2_(vb_1_elem.data[672], vb_1_elem.data[673], vb_1_elem.data[674], vb_1_elem.data[675]));
         // metal::half2 <- Float16x4
         v_float16x4_as_f16_ = metal::half4(unpackFloat16x4_(vb_1_elem.data[688], vb_1_elem.data[689], vb_1_elem.data[690], vb_1_elem.data[691], vb_1_elem.data[692], vb_1_elem.data[693], vb_1_elem.data[694], vb_1_elem.data[695])).xy;
+        // metal::float2 <- Snorm10_10_10_2
+        v_snorm10_10_10_2_ = unpackSnorm10_10_10_2_(vb_1_elem.data[704], vb_1_elem.data[705], vb_1_elem.data[706], vb_1_elem.data[707]).xy;
     }
-    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_ };
+    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_, {}, v_snorm10_10_10_2_ };
     const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_.x)};
     return render_vertexOutput { _tmp.position };
 }

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x3.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x3.metal
@@ -57,6 +57,7 @@ struct VertexInput {
     metal::half3 v_float16x2_as_f16_;
     metal::half3 v_float16x4_as_f16_;
     char _pad44[8];
+    metal::float3 v_snorm10_10_10_2_;
 };
 uint unpackUint8_(metal::uchar b0) {
     return uint(b0);
@@ -181,11 +182,14 @@ metal::float4 unpackUnorm10_10_10_2_(uint b0, uint b1, uint b2, uint b3) {
 metal::float4 unpackUnorm8x4Bgra(metal::uchar b0, metal::uchar b1, metal::uchar b2, metal::uchar b3) {
     return metal::float4(float(b2) / 255.0f, float(b1) / 255.0f, float(b0) / 255.0f, float(b3) / 255.0f);
 }
+metal::float4 unpackSnorm10_10_10_2_(uint b0, uint b1, uint b2, uint b3) {
+    uint v = (b3 << 24 | b2 << 16 | b1 << 8 | b0); return metal::max(metal::float4(float(as_type<int>(v << 22) >> 22) / 511.0f, float(as_type<int>(v << 12) >> 22) / 511.0f, float(as_type<int>(v << 2) >> 22) / 511.0f, float(as_type<int>(v) >> 30)), metal::float4(-1.0f));
+}
 
 struct render_vertexOutput {
     metal::float4 position [[position]];
 };
-struct vb_1_type { metal::uchar data[704]; };
+struct vb_1_type { metal::uchar data[720]; };
 vertex render_vertexOutput render_vertex(
   uint v_id [[vertex_id]]
 , const device vb_1_type* vb_1_in [[buffer(1)]]
@@ -235,7 +239,8 @@ vertex render_vertexOutput render_vertex(
     metal::half3 v_float16_as_f16_ = {};
     metal::half3 v_float16x2_as_f16_ = {};
     metal::half3 v_float16x4_as_f16_ = {};
-    if (v_id < (_buffer_sizes.buffer_size1 / 704)) {
+    metal::float3 v_snorm10_10_10_2_ = {};
+    if (v_id < (_buffer_sizes.buffer_size1 / 720)) {
         const vb_1_type vb_1_elem = vb_1_in[v_id];
         // metal::uint3 <- Uint8
         v_uint8_ = metal::uint3(unpackUint8_(vb_1_elem.data[0]), 0, 0);
@@ -322,8 +327,10 @@ vertex render_vertexOutput render_vertex(
         v_float16x2_as_f16_ = metal::half3(metal::half2(unpackFloat16x2_(vb_1_elem.data[672], vb_1_elem.data[673], vb_1_elem.data[674], vb_1_elem.data[675])), 0.0);
         // metal::half3 <- Float16x4
         v_float16x4_as_f16_ = metal::half4(unpackFloat16x4_(vb_1_elem.data[688], vb_1_elem.data[689], vb_1_elem.data[690], vb_1_elem.data[691], vb_1_elem.data[692], vb_1_elem.data[693], vb_1_elem.data[694], vb_1_elem.data[695])).xyz;
+        // metal::float3 <- Snorm10_10_10_2
+        v_snorm10_10_10_2_ = unpackSnorm10_10_10_2_(vb_1_elem.data[704], vb_1_elem.data[705], vb_1_elem.data[706], vb_1_elem.data[707]).xyz;
     }
-    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_ };
+    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_, {}, v_snorm10_10_10_2_ };
     const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_.x)};
     return render_vertexOutput { _tmp.position };
 }

--- a/naga/tests/out/msl/wgsl-msl-vpt-formats-x4.metal
+++ b/naga/tests/out/msl/wgsl-msl-vpt-formats-x4.metal
@@ -57,6 +57,7 @@ struct VertexInput {
     metal::half4 v_float16x2_as_f16_;
     metal::half4 v_float16x4_as_f16_;
     char _pad44[8];
+    metal::float4 v_snorm10_10_10_2_;
 };
 uint unpackUint8_(metal::uchar b0) {
     return uint(b0);
@@ -181,11 +182,14 @@ metal::float4 unpackUnorm10_10_10_2_(uint b0, uint b1, uint b2, uint b3) {
 metal::float4 unpackUnorm8x4Bgra(metal::uchar b0, metal::uchar b1, metal::uchar b2, metal::uchar b3) {
     return metal::float4(float(b2) / 255.0f, float(b1) / 255.0f, float(b0) / 255.0f, float(b3) / 255.0f);
 }
+metal::float4 unpackSnorm10_10_10_2_(uint b0, uint b1, uint b2, uint b3) {
+    uint v = (b3 << 24 | b2 << 16 | b1 << 8 | b0); return metal::max(metal::float4(float(as_type<int>(v << 22) >> 22) / 511.0f, float(as_type<int>(v << 12) >> 22) / 511.0f, float(as_type<int>(v << 2) >> 22) / 511.0f, float(as_type<int>(v) >> 30)), metal::float4(-1.0f));
+}
 
 struct render_vertexOutput {
     metal::float4 position [[position]];
 };
-struct vb_1_type { metal::uchar data[704]; };
+struct vb_1_type { metal::uchar data[720]; };
 vertex render_vertexOutput render_vertex(
   uint v_id [[vertex_id]]
 , const device vb_1_type* vb_1_in [[buffer(1)]]
@@ -235,7 +239,8 @@ vertex render_vertexOutput render_vertex(
     metal::half4 v_float16_as_f16_ = {};
     metal::half4 v_float16x2_as_f16_ = {};
     metal::half4 v_float16x4_as_f16_ = {};
-    if (v_id < (_buffer_sizes.buffer_size1 / 704)) {
+    metal::float4 v_snorm10_10_10_2_ = {};
+    if (v_id < (_buffer_sizes.buffer_size1 / 720)) {
         const vb_1_type vb_1_elem = vb_1_in[v_id];
         // metal::uint4 <- Uint8
         v_uint8_ = metal::uint4(unpackUint8_(vb_1_elem.data[0]), 0, 0, 1);
@@ -310,8 +315,9 @@ vertex render_vertexOutput render_vertex(
         // metal::half4 <- Float16x2
         v_float16x2_as_f16_ = metal::half4(metal::half2(unpackFloat16x2_(vb_1_elem.data[672], vb_1_elem.data[673], vb_1_elem.data[674], vb_1_elem.data[675])), 0.0, 1.0);
         v_float16x4_as_f16_ = metal::half4(unpackFloat16x4_(vb_1_elem.data[688], vb_1_elem.data[689], vb_1_elem.data[690], vb_1_elem.data[691], vb_1_elem.data[692], vb_1_elem.data[693], vb_1_elem.data[694], vb_1_elem.data[695]));
+        v_snorm10_10_10_2_ = unpackSnorm10_10_10_2_(vb_1_elem.data[704], vb_1_elem.data[705], vb_1_elem.data[706], vb_1_elem.data[707]);
     }
-    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_ };
+    const VertexInput v_in = { v_uint8_, v_uint8x2_, v_uint8x4_, v_sint8_, v_sint8x2_, v_sint8x4_, v_unorm8_, v_unorm8x2_, v_unorm8x4_, v_snorm8_, v_snorm8x2_, v_snorm8x4_, v_uint16_, v_uint16x2_, v_uint16x4_, v_sint16_, v_sint16x2_, v_sint16x4_, v_unorm16_, v_unorm16x2_, v_unorm16x4_, v_snorm16_, v_snorm16x2_, v_snorm16x4_, v_float16_, v_float16x2_, v_float16x4_, v_float32_, v_float32x2_, v_float32x3_, v_float32x4_, v_uint32_, v_uint32x2_, v_uint32x3_, v_uint32x4_, v_sint32_, v_sint32x2_, v_sint32x3_, v_sint32x4_, v_unorm10_10_10_2_, v_unorm8x4_bgra, v_float16_as_f16_, v_float16x2_as_f16_, v_float16x4_as_f16_, {}, v_snorm10_10_10_2_ };
     const auto _tmp = VertexOutput {metal::float4(v_in.v_float32_.x)};
     return render_vertexOutput { _tmp.position };
 }

--- a/tests/src/expectations.rs
+++ b/tests/src/expectations.rs
@@ -355,7 +355,10 @@ impl FailureReason {
         message: None,
     };
 
-    /// Match a validation error.
+    /// Match an error caught by [`wgpu_hal::VALIDATION_CANARY`].
+    ///
+    /// These are errors from platform debug/validation layers, _not_
+    /// WebGPU validation errors.
     #[allow(dead_code, reason = "Not constructed on wasm")]
     pub fn validation_error() -> Self {
         Self {
@@ -365,6 +368,9 @@ impl FailureReason {
     }
 
     /// Match a panic.
+    ///
+    /// This includes WebGPU validation errors caught by the default (panicking)
+    /// error handler.
     pub fn panic() -> Self {
         Self {
             kind: Some(FailureResultKind::Panic),

--- a/tests/tests/wgpu-gpu/vertex_formats/draw.vert.wgsl
+++ b/tests/tests/wgpu-gpu/vertex_formats/draw.vert.wgsl
@@ -353,6 +353,27 @@ fn vertex_block_7(v_in: AttributeBlock7) -> @builtin(position) vec4<f32>
   return vec4(0.0);
 }
 
+struct AttributeBlock8 {
+  @location(0) snorm10_10_10_2: vec4<f32>,
+}
+
+@vertex
+fn vertex_block_8(v_in: AttributeBlock8) -> @builtin(position) vec4<f32>
+{
+  init_checksums();
+
+  // Accumulate all snorm into one checksum value.
+  var all_snorm: f32 = 0.0;
+  all_snorm = accumulate_snorm(all_snorm, v_in.snorm10_10_10_2.x);
+  all_snorm = accumulate_snorm(all_snorm, v_in.snorm10_10_10_2.y);
+  all_snorm = accumulate_snorm(all_snorm, v_in.snorm10_10_10_2.z);
+  all_snorm = accumulate_snorm(all_snorm, v_in.snorm10_10_10_2.w);
+
+  checksums[index_snorm] = f32(all_snorm);
+
+  return vec4(0.0);
+}
+
 fn accumulate_uint(accum: u32, val: u32) -> u32 {
   return accum + val;
 }

--- a/tests/tests/wgpu-gpu/vertex_formats/mod.rs
+++ b/tests/tests/wgpu-gpu/vertex_formats/mod.rs
@@ -7,7 +7,7 @@ use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu_test::{apply, gpu_test, GpuTestConfiguration, TestParameters, TestingContext};
 
 pub fn all_tests(vec: &mut Vec<wgpu_test::GpuTestInitializer>) {
-    vec.extend([VERTEX_FORMATS_ALL, VERTEX_FORMATS_10_10_10_2]);
+    vec.extend([VERTEX_FORMATS_ALL, VERTEX_FORMATS_SNORM10_10_10_2]);
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -18,6 +18,7 @@ enum TestCase {
     SintsBig,
     Floats,
     Unorm1010102,
+    Snorm1010102,
     SingleSmallNormsAndInts,
     Unorm8x4Bgra,
 }
@@ -75,6 +76,10 @@ async fn vertex_formats_all(ctx: TestingContext) {
         4 => Float16x2,
         5 => Float16x4,
         6 => Float16,
+    ];
+
+    let attributes_block_5 = &wgpu::vertex_attr_array![
+        0 => Unorm10_10_10_2,
     ];
 
     let attributes_block_6 = &wgpu::vertex_attr_array![
@@ -175,6 +180,21 @@ async fn vertex_formats_all(ctx: TestingContext) {
             checksums: &[0.0, 0.0, 0.0, 0.0, 2.5, 16.0],
         },
         Test {
+            case: TestCase::Unorm1010102,
+            entry_point: "vertex_block_5",
+            attributes: attributes_block_5,
+            input: &[
+                // We are aiming for rgba of (0.5, 0.5, 0.5, 0.66)
+                // Packing   AA BB BBBB BBBB GGGG GGGG GG RR RRRR RRRR
+                // Binary    10 10 0000 0000 1000 0000 00 10 0000 0000
+                // Hex               A0        08         02        00
+                // Decimal          160         8          2         0
+                // unorm   0.66          0.5          0.5          0.5 = 2.16
+                0u8, 2u8, 8u8, 160u8, // Unorm10_10_10_2
+            ],
+            checksums: &[0.0, 0.0, 2.16, 0.0, 0.0, 0.0],
+        },
+        Test {
             case: TestCase::SingleSmallNormsAndInts,
             entry_point: "vertex_block_6",
             attributes: attributes_block_6,
@@ -204,25 +224,25 @@ async fn vertex_formats_all(ctx: TestingContext) {
     vertex_formats_common(ctx, &tests).await;
 }
 
-async fn vertex_formats_10_10_10_2(ctx: TestingContext) {
-    let attributes_block_5 = &wgpu::vertex_attr_array![
-        0 => Unorm10_10_10_2,
+async fn vertex_formats_snorm10_10_10_2(ctx: TestingContext) {
+    let attributes_block_8 = &wgpu::vertex_attr_array![
+        0 => Snorm10_10_10_2,
     ];
 
     let tests = vec![Test {
-        case: TestCase::Unorm1010102,
-        entry_point: "vertex_block_5",
-        attributes: attributes_block_5,
+        case: TestCase::Snorm1010102,
+        entry_point: "vertex_block_8",
+        attributes: attributes_block_8,
         input: &[
-            // We are aiming for rgba of (0.5, 0.5, 0.5, 0.66)
-            // Packing   AA BB BBBB BBBB GGGG GGGG GG RR RRRR RRRR
-            // Binary    10 10 0000 0000 1000 0000 00 10 0000 0000
-            // Hex               A0        08         02        00
-            // Decimal          160         8          2         0
-            // unorm   0.66          0.5          0.5          0.5 = 2.16
-            0u8, 2u8, 8u8, 160u8, // Unorm10_10_10_2
+            // Signed components (r, g, b, a) of (243, -123, 342, -2), packed as
+            // AA BBBBBBBBBB GGGGGGGGGG RRRRRRRRRR = 0x956e14f3.
+            //
+            // Each 10-bit component divided by 511 gives (0.4755, -0.2407, 0.6693).
+            // The 2-bit alpha divided by 1 gives -2.0, which is clamped to -1.0, so
+            // the sum is -0.0959 rather than -1.0959.
+            243u8, 20u8, 110u8, 149u8, // Snorm10_10_10_2
         ],
-        checksums: &[0.0, 0.0, 2.16, 0.0, 0.0, 0.0],
+        checksums: &[0.0, 0.0, 0.0, -0.0959, 0.0, 0.0],
     }];
 
     vertex_formats_common(ctx, &tests).await;
@@ -427,10 +447,8 @@ static VERTEX_FORMATS_ALL: GpuTestConfiguration = GpuTestConfiguration::new()
     )
     .run_async(vertex_formats_all);
 
-// Some backends can handle Unorm-10-10-2, but GL backends seem to throw this error:
-// Validation Error: GL_INVALID_ENUM in glVertexAttribFormat(type = GL_UNSIGNED_INT_10_10_10_2)
 #[apply(gpu_test!)]
-static VERTEX_FORMATS_10_10_10_2: GpuTestConfiguration = GpuTestConfiguration::new()
+static VERTEX_FORMATS_SNORM10_10_10_2: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
             .test_features_limits()
@@ -439,6 +457,13 @@ static VERTEX_FORMATS_10_10_10_2: GpuTestConfiguration = GpuTestConfiguration::n
             .expect_fail(
                 wgpu_test::FailureCase::molten_vk()
                     .validation_error("vertexAttributeAccessBeyondStride"),
-            ),
+            )
+            // https://github.com/gfx-rs/wgpu/issues/10216
+            .expect_fail(wgpu_test::FailureCase {
+                backends: Some(wgpu::Backends::DX12),
+                reasons: vec![wgpu_test::FailureReason::panic()
+                    .with_message("HLSL: snorm-10-10-10-2 vertex format is not supported")],
+                ..Default::default()
+            }),
     )
-    .run_async(vertex_formats_10_10_10_2);
+    .run_async(vertex_formats_snorm10_10_10_2);

--- a/wgpu-core/src/validation.rs
+++ b/wgpu-core/src/validation.rs
@@ -1006,7 +1006,8 @@ impl NumericType {
             | Vf::Float16x4
             | Vf::Float32x4
             | Vf::Unorm10_10_10_2
-            | Vf::Unorm8x4Bgra => (NumericDimension::Vector(Vs::Quad), Scalar::F32),
+            | Vf::Unorm8x4Bgra
+            | Vf::Snorm10_10_10_2 => (NumericDimension::Vector(Vs::Quad), Scalar::F32),
             Vf::Float64 => (NumericDimension::Scalar, Scalar::F64),
             Vf::Float64x2 => (NumericDimension::Vector(Vs::Bi), Scalar::F64),
             Vf::Float64x3 => (NumericDimension::Vector(Vs::Tri), Scalar::F64),

--- a/wgpu-hal/src/auxil/dxgi/conv.rs
+++ b/wgpu-hal/src/auxil/dxgi/conv.rs
@@ -284,6 +284,10 @@ pub fn map_vertex_format(format: wgt::VertexFormat) -> Dxgi::Common::DXGI_FORMAT
         Vf::Sint32x4 => DXGI_FORMAT_R32G32B32A32_SINT,
         Vf::Float32x4 => DXGI_FORMAT_R32G32B32A32_FLOAT,
         Vf::Unorm10_10_10_2 => DXGI_FORMAT_R10G10B10A2_UNORM,
+        // https://github.com/gfx-rs/wgpu/issues/10216
+        Vf::Snorm10_10_10_2 => {
+            unimplemented!("VertexFormat::Snorm10_10_10_2 requires a polyfill in HLSL")
+        }
         Vf::Unorm8x4Bgra => DXGI_FORMAT_B8G8R8A8_UNORM,
         Vf::Float64 | Vf::Float64x2 | Vf::Float64x3 | Vf::Float64x4 => unimplemented!(),
     }

--- a/wgpu-hal/src/dx12/device.rs
+++ b/wgpu-hal/src/dx12/device.rs
@@ -2144,6 +2144,14 @@ impl crate::Device for super::Device {
                         }
                     };
                     for attribute in vbuf.attributes {
+                        if attribute.format == nt::VertexFormat::Snorm10_10_10_2 {
+                            // Avoid `map_vertex_format` panic.
+                            // https://github.com/gfx-rs/wgpu/issues/10216
+                            return Err(crate::PipelineError::Linkage(
+                                wgt::ShaderStages::VERTEX,
+                                "HLSL: snorm-10-10-10-2 vertex format is not supported".into(),
+                            ));
+                        }
                         input_element_descs.push(Direct3D12::D3D12_INPUT_ELEMENT_DESC {
                             SemanticName: windows::core::PCSTR(NAGA_LOCATION_SEMANTIC.as_ptr()),
                             SemanticIndex: attribute.shader_location,

--- a/wgpu-hal/src/gles/conv.rs
+++ b/wgpu-hal/src/gles/conv.rs
@@ -224,6 +224,7 @@ pub(super) fn describe_vertex_format(vertex_format: wgt::VertexFormat) -> super:
         Vf::Sint32x4 => (4, glow::INT, Vak::Integer),
         Vf::Float32x4 => (4, glow::FLOAT, Vak::Float),
         Vf::Unorm10_10_10_2 => (4, glow::UNSIGNED_INT_2_10_10_10_REV, Vak::Float),
+        Vf::Snorm10_10_10_2 => (4, glow::INT_2_10_10_10_REV, Vak::Float),
         Vf::Unorm8x4Bgra => (glow::BGRA as i32, glow::UNSIGNED_BYTE, Vak::Float),
         Vf::Float64 | Vf::Float64x2 | Vf::Float64x3 | Vf::Float64x4 => unimplemented!(),
     };

--- a/wgpu-hal/src/metal/conv.rs
+++ b/wgpu-hal/src/metal/conv.rs
@@ -241,6 +241,7 @@ pub fn map_vertex_format(format: wgt::VertexFormat) -> MTLVertexFormat {
         Vf::Sint32x4 => MTL::Int4,
         Vf::Float32x4 => MTL::Float4,
         Vf::Unorm10_10_10_2 => MTL::UInt1010102Normalized,
+        Vf::Snorm10_10_10_2 => MTL::Int1010102Normalized,
         Vf::Unorm8x4Bgra => MTL::UChar4Normalized_BGRA,
         Vf::Float64 | Vf::Float64x2 | Vf::Float64x3 | Vf::Float64x4 => unimplemented!(),
     }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -147,6 +147,7 @@ const fn convert_vertex_format_to_naga(format: wgt::VertexFormat) -> nt::VertexF
         wgt::VertexFormat::Sint32x3 => nt::VertexFormat::Sint32x3,
         wgt::VertexFormat::Sint32x4 => nt::VertexFormat::Sint32x4,
         wgt::VertexFormat::Unorm10_10_10_2 => nt::VertexFormat::Unorm10_10_10_2,
+        wgt::VertexFormat::Snorm10_10_10_2 => nt::VertexFormat::Snorm10_10_10_2,
         wgt::VertexFormat::Unorm8x4Bgra => nt::VertexFormat::Unorm8x4Bgra,
 
         wgt::VertexFormat::Float64

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -473,6 +473,9 @@ pub fn map_vertex_format(vertex_format: wgt::VertexFormat) -> vk::Format {
         Vf::Float64x3 => vk::Format::R64G64B64_SFLOAT,
         Vf::Float64x4 => vk::Format::R64G64B64A64_SFLOAT,
         Vf::Unorm10_10_10_2 => vk::Format::A2B10G10R10_UNORM_PACK32,
+        // Note that, unlike the unorm variant, this format has no mandatory format
+        // features in Vulkan, so vertex buffer support is not guaranteed.
+        Vf::Snorm10_10_10_2 => vk::Format::A2B10G10R10_SNORM_PACK32,
         Vf::Unorm8x4Bgra => vk::Format::B8G8R8A8_UNORM,
     }
 }

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -584,6 +584,10 @@ fn map_vertex_format(format: wgt::VertexFormat) -> webgpu_sys::GpuVertexFormat {
         VertexFormat::Sint32x4 => vf::Sint32x4,
         VertexFormat::Unorm10_10_10_2 => vf::Unorm1010102,
         VertexFormat::Unorm8x4Bgra => vf::Unorm8x4Bgra,
+        VertexFormat::Snorm10_10_10_2 => {
+            // https://github.com/gfx-rs/wgpu/issues/10216
+            panic!("snorm10-10-10-2 is not yet available on the WebGPU backend")
+        }
         VertexFormat::Float64
         | VertexFormat::Float64x2
         | VertexFormat::Float64x3


### PR DESCRIPTION
Adds support for the `snorm10-10-10-2` vertex format on Metal and Vulkan. Does not implement the required polyfill on DX12, nor support in the WebGPU backend, which requires an updated `web-sys`. These remaining items are tracked in #10216.

This PR should unblock the CTS update in #10206. Note that the CTS now exercises the new `snorm10` format unconditionally.

**Testing**
Enables CTS tests and adds a directed GPU test.

Rather than enumerate all ~40 working vertex formats in the CTS test list, temporarily gives up some CTS coverage on dx12. Firefox CTS runs have case-level expectations and will still catch regressions here.

**Squash or Rebase?** Squash

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [x] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [x] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
