### PR TITLE
Move erroring of create_render_pipeline into wgc

### DIFF
--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -75,6 +75,8 @@ webgpu:api,validation,buffer,destroy:*
 webgpu:api,validation,capability_checks,features,clip_distances:*
 webgpu:api,validation,capability_checks,features,query_types:createQuerySet:*
 webgpu:api,validation,capability_checks,features,texture_component_swizzle:*
+webgpu:api,validation,capability_checks,features,texture_formats:color_target_state:*
+webgpu:api,validation,capability_checks,features,texture_formats:depth_stencil_state:*
 webgpu:api,validation,capability_checks,features,texture_formats:render_bundle_encoder_descriptor_depth_stencil_format:*
 webgpu:api,validation,capability_checks,features,texture_formats:storage_texture_binding_layout:*
 webgpu:api,validation,capability_checks,features,texture_formats:texture_descriptor_view_formats:*

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -509,10 +509,16 @@ impl GPUDevice {
   fn create_render_pipeline(
     &self,
     #[webidl] descriptor: super::render_pipeline::GPURenderPipelineDescriptor,
-  ) -> GPURenderPipeline {
-    let (pipeline, err) = self.new_render_pipeline(descriptor);
-    self.error_handler.push_error(err);
-    pipeline
+  ) -> Result<GPURenderPipeline, JsErrorBox> {
+    let label = descriptor.label.clone();
+    let wgpu_descriptor =
+      self.transform_render_pipeline_descriptor(descriptor)?;
+    let wgpu_render_pipeline =
+      self.wgpu_device.create_render_pipeline(wgpu_descriptor);
+    Ok(GPURenderPipeline {
+      wgpu_render_pipeline,
+      label,
+    })
   }
 
   #[async_method(fake)]
@@ -562,23 +568,37 @@ impl GPUDevice {
     &self,
     scope: &mut v8::HandleScope,
     #[webidl] descriptor: super::render_pipeline::GPURenderPipelineDescriptor,
-  ) -> v8::Global<v8::Promise> {
+  ) -> Result<v8::Global<v8::Promise>, JsErrorBox> {
+    let label = descriptor.label.clone();
+
+    let wgpu_descriptor =
+      self.transform_render_pipeline_descriptor(descriptor)?;
+
     let resolver = v8::PromiseResolver::new(scope).unwrap();
     let promise = resolver.get_promise(scope);
 
-    let (pipeline, err) = self.new_render_pipeline(descriptor);
-    if let Some(err) = err {
-      let err = make_pipeline_error(
-        scope,
-        GPUPipelineErrorReason::Validation,
-        &fmt_err(&err),
-      );
-      resolver.reject(scope, err.into());
-    } else {
-      let val = make_cppgc_object(scope, pipeline).into();
-      resolver.resolve(scope, val);
+    match self
+      .wgpu_device
+      .create_render_pipeline_or_error(wgpu_descriptor)
+    {
+      Ok(wgpu_render_pipeline) => {
+        let render_pipeline = GPURenderPipeline {
+          wgpu_render_pipeline,
+          label,
+        };
+        let val = make_cppgc_object(scope, render_pipeline).into();
+        resolver.resolve(scope, val);
+      }
+      Err(err) => {
+        let err = make_pipeline_error(
+          scope,
+          GPUPipelineErrorReason::Validation,
+          &fmt_err(&err),
+        );
+        resolver.reject(scope, err.into());
+      }
     }
-    v8::Global::new(scope, promise)
+    Ok(v8::Global::new(scope, promise))
   }
 
   fn create_command_encoder<'a>(
@@ -787,13 +807,13 @@ fn transform_compute_pipeline_descriptor(
 }
 
 impl GPUDevice {
-  fn new_render_pipeline(
+  fn transform_render_pipeline_descriptor(
     &self,
     descriptor: super::render_pipeline::GPURenderPipelineDescriptor,
-  ) -> (
-    GPURenderPipeline,
-    Option<wgpu_core::pipeline::CreateRenderPipelineError>,
-  ) {
+  ) -> Result<
+    wgpu_core::pipeline::ResolvedGeneralRenderPipelineDescriptor<'static>,
+    JsErrorBox,
+  > {
     let vertex = wgpu_core::pipeline::VertexState {
       stage: ProgrammableStageDescriptor {
         module: descriptor.vertex.module.wgpu_shader_module.clone(),
@@ -842,37 +862,42 @@ impl GPUDevice {
       conservative: false,
     };
 
-    let depth_stencil = descriptor.depth_stencil.map(|depth_stencil| {
-      let front = wgpu_types::StencilFaceState {
-        compare: depth_stencil.stencil_front.compare.into(),
-        fail_op: depth_stencil.stencil_front.fail_op.into(),
-        depth_fail_op: depth_stencil.stencil_front.depth_fail_op.into(),
-        pass_op: depth_stencil.stencil_front.pass_op.into(),
-      };
-      let back = wgpu_types::StencilFaceState {
-        compare: depth_stencil.stencil_back.compare.into(),
-        fail_op: depth_stencil.stencil_back.fail_op.into(),
-        depth_fail_op: depth_stencil.stencil_back.depth_fail_op.into(),
-        pass_op: depth_stencil.stencil_back.pass_op.into(),
-      };
+    let depth_stencil = descriptor
+      .depth_stencil
+      .map(|depth_stencil| -> Result<_, JsErrorBox> {
+        let front = wgpu_types::StencilFaceState {
+          compare: depth_stencil.stencil_front.compare.into(),
+          fail_op: depth_stencil.stencil_front.fail_op.into(),
+          depth_fail_op: depth_stencil.stencil_front.depth_fail_op.into(),
+          pass_op: depth_stencil.stencil_front.pass_op.into(),
+        };
+        let back = wgpu_types::StencilFaceState {
+          compare: depth_stencil.stencil_back.compare.into(),
+          fail_op: depth_stencil.stencil_back.fail_op.into(),
+          depth_fail_op: depth_stencil.stencil_back.depth_fail_op.into(),
+          pass_op: depth_stencil.stencil_back.pass_op.into(),
+        };
 
-      wgpu_types::DepthStencilState {
-        format: depth_stencil.format.into(),
-        depth_write_enabled: depth_stencil.depth_write_enabled,
-        depth_compare: depth_stencil.depth_compare.map(Into::into),
-        stencil: wgpu_types::StencilState {
-          front,
-          back,
-          read_mask: depth_stencil.stencil_read_mask,
-          write_mask: depth_stencil.stencil_write_mask,
-        },
-        bias: wgpu_types::DepthBiasState {
-          constant: depth_stencil.depth_bias,
-          slope_scale: depth_stencil.depth_bias_slope_scale,
-          clamp: depth_stencil.depth_bias_clamp,
-        },
-      }
-    });
+        let format = depth_stencil.format.into();
+        self.validate_texture_format_required_feature(format)?;
+        Ok(wgpu_types::DepthStencilState {
+          format,
+          depth_write_enabled: depth_stencil.depth_write_enabled,
+          depth_compare: depth_stencil.depth_compare.map(Into::into),
+          stencil: wgpu_types::StencilState {
+            front,
+            back,
+            read_mask: depth_stencil.stencil_read_mask,
+            write_mask: depth_stencil.stencil_write_mask,
+          },
+          bias: wgpu_types::DepthBiasState {
+            constant: depth_stencil.depth_bias,
+            slope_scale: depth_stencil.depth_bias_slope_scale,
+            clamp: depth_stencil.depth_bias_clamp,
+          },
+        })
+      })
+      .transpose()?;
 
     let multisample = wgpu_types::MultisampleState {
       count: descriptor.multisample.count,
@@ -882,10 +907,10 @@ impl GPUDevice {
         .alpha_to_coverage_enabled,
     };
 
-    let fragment =
-      descriptor
-        .fragment
-        .map(|fragment| wgpu_core::pipeline::FragmentState {
+    let fragment = descriptor
+      .fragment
+      .map(|fragment| -> Result<_, JsErrorBox> {
+        Ok(wgpu_core::pipeline::FragmentState {
           stage: ProgrammableStageDescriptor {
             module: fragment.module.wgpu_shader_module.clone(),
             entry_point: fragment.entry_point.map(Into::into),
@@ -896,31 +921,38 @@ impl GPUDevice {
             fragment
               .targets
               .into_iter()
-              .map(|target| {
-                target.into_option().map(|target| {
-                  wgpu_types::ColorTargetState {
-                    format: target.format.into(),
-                    blend: target.blend.map(|blend| wgpu_types::BlendState {
-                      color: wgpu_types::BlendComponent {
-                        src_factor: blend.color.src_factor.into(),
-                        dst_factor: blend.color.dst_factor.into(),
-                        operation: blend.color.operation.into(),
-                      },
-                      alpha: wgpu_types::BlendComponent {
-                        src_factor: blend.alpha.src_factor.into(),
-                        dst_factor: blend.alpha.dst_factor.into(),
-                        operation: blend.alpha.operation.into(),
-                      },
-                    }),
-                    write_mask: target.write_mask.into(),
-                  }
-                })
+              .map(|target| -> Result<_, JsErrorBox> {
+                target
+                  .into_option()
+                  .map(|target| -> Result<_, JsErrorBox> {
+                    let format = target.format.into();
+                    self.validate_texture_format_required_feature(format)?;
+                    Ok(wgpu_types::ColorTargetState {
+                      format,
+                      blend: target.blend.map(|blend| wgpu_types::BlendState {
+                        color: wgpu_types::BlendComponent {
+                          src_factor: blend.color.src_factor.into(),
+                          dst_factor: blend.color.dst_factor.into(),
+                          operation: blend.color.operation.into(),
+                        },
+                        alpha: wgpu_types::BlendComponent {
+                          src_factor: blend.alpha.src_factor.into(),
+                          dst_factor: blend.alpha.dst_factor.into(),
+                          operation: blend.alpha.operation.into(),
+                        },
+                      }),
+                      write_mask: target.write_mask.into(),
+                    })
+                  })
+                  .transpose()
               })
-              .collect(),
+              .collect::<Result<Vec<_>, JsErrorBox>>()?,
           ),
-        });
+        })
+      })
+      .transpose()?;
 
-    let wgpu_descriptor =
+    Ok(
       wgpu_core::pipeline::ResolvedGeneralRenderPipelineDescriptor {
         label: crate::transform_label(descriptor.label.clone()),
         layout: descriptor.layout.into(),
@@ -933,17 +965,7 @@ impl GPUDevice {
         fragment,
         cache: None,
         multiview_mask: None,
-      };
-
-    let (wgpu_render_pipeline, err) =
-      self.wgpu_device.create_render_pipeline(wgpu_descriptor);
-
-    (
-      GPURenderPipeline {
-        wgpu_render_pipeline,
-        label: descriptor.label,
       },
-      err,
     )
   }
 }

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -339,7 +339,7 @@ impl Player {
                 // pipeline descriptor that can represent either a conventional
                 // pipeline or a mesh shading pipeline.
                 let resolved_desc = self.resolve_render_pipeline_descriptor(desc);
-                let (pipeline, _error) = device.create_render_pipeline(resolved_desc);
+                let pipeline = device.create_render_pipeline(resolved_desc);
                 self.render_pipelines.insert(id, pipeline);
             }
             Action::DropRenderPipeline(id) => {

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -801,26 +801,11 @@ impl Global {
         hub.query_sets.remove(query_set_id)
     }
 
-    pub fn device_create_render_pipeline(
-        &self,
-        device_id: DeviceId,
-        desc: &RenderPipelineDescriptor,
-        id_in: id::RenderPipelineId,
-    ) -> (
-        id::RenderPipelineId,
-        Option<pipeline::CreateRenderPipelineError>,
-    ) {
-        let mut hub = self.hub.borrow_mut();
-        let Hub {
-            render_pipelines,
-            devices,
-            shader_modules,
-            pipeline_layouts,
-            ..
-        } = &mut *hub;
-
-        let device = devices.get(device_id);
-
+    fn resolve_render_pipeline_descriptor<'a>(
+        shader_modules: &mut Registry<Arc<pipeline::ShaderModule>>,
+        pipeline_layouts: &mut Registry<Arc<binding_model::PipelineLayout>>,
+        desc: &'a RenderPipelineDescriptor,
+    ) -> ResolvedGeneralRenderPipelineDescriptor<'a> {
         let layout = desc.layout.map(|layout| pipeline_layouts.get(layout));
 
         let vertex = {
@@ -865,7 +850,7 @@ impl Global {
             None
         };
 
-        let desc = ResolvedGeneralRenderPipelineDescriptor {
+        ResolvedGeneralRenderPipelineDescriptor {
             label: desc.label.clone(),
             layout,
             vertex,
@@ -875,13 +860,65 @@ impl Global {
             fragment,
             multiview_mask: None,
             cache: None,
-        };
+        }
+    }
 
-        let (pipeline, error) = device.create_render_pipeline(desc);
+    pub fn device_create_render_pipeline(
+        &self,
+        device_id: DeviceId,
+        desc: &RenderPipelineDescriptor,
+        id_in: id::RenderPipelineId,
+    ) {
+        let mut hub = self.hub.borrow_mut();
 
-        let id = render_pipelines.assign(id_in, pipeline);
+        let Hub {
+            shader_modules,
+            pipeline_layouts,
+            render_pipelines,
+            devices,
+            ..
+        } = &mut *hub;
 
-        (id, error)
+        let device = devices.get(device_id);
+
+        let desc = Self::resolve_render_pipeline_descriptor(shader_modules, pipeline_layouts, desc);
+
+        let pipeline = device.create_render_pipeline(desc);
+
+        render_pipelines.assign(id_in, pipeline);
+    }
+
+    /// Error-returning version of `device_create_render_pipeline` to implement
+    /// [GPUDevice.createRenderPipelineAsync](https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipelineasync).
+    /// Returns an error if the pipeline creation fails instead of handling error in device.
+    ///
+    /// Id is assigned to the pipeline only if the creation succeeds.
+    pub fn create_render_pipeline_or_error(
+        &self,
+        device_id: DeviceId,
+        desc: &RenderPipelineDescriptor,
+        id_in: id::RenderPipelineId,
+    ) -> Result<(), pipeline::CreateRenderPipelineError> {
+        let mut hub = self.hub.borrow_mut();
+        let Hub {
+            render_pipelines,
+            devices,
+            shader_modules,
+            pipeline_layouts,
+            ..
+        } = &mut *hub;
+
+        let device = devices.get(device_id);
+
+        let desc = Self::resolve_render_pipeline_descriptor(shader_modules, pipeline_layouts, desc);
+
+        match device.create_render_pipeline_or_error(desc) {
+            Ok(pipeline) => {
+                render_pipelines.assign(id_in, pipeline);
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Get an ID of one of the bind group layouts. The ID adds a refcount,

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4535,21 +4535,22 @@ impl Device {
         Ok(pipeline)
     }
 
+    /// Creates a render pipeline. If the creation fails,
+    /// it will handle error in device and return an invalid render pipeline.
+    ///
+    /// Corresponds to [GPUDevice.createRenderPipeline](https://www.w3.org/TR/webgpu/#dom-gpudevice-createrenderpipeline)
     pub fn create_render_pipeline(
         self: &Arc<Self>,
         desc: pipeline::ResolvedGeneralRenderPipelineDescriptor,
-    ) -> (
-        Arc<pipeline::RenderPipeline>,
-        Option<pipeline::CreateRenderPipelineError>,
-    ) {
+    ) -> Arc<pipeline::RenderPipeline> {
         profiling::scope!("Device::create_render_pipeline");
-        let (render_pipeline, error) = match self.create_render_pipeline_inner(desc.clone()) {
-            Ok(pipeline) => (pipeline, None),
-            Err(e) => (
-                pipeline::RenderPipeline::invalid(self.clone(), desc.label.to_string()),
-                Some(e),
-            ),
-        };
+
+        let render_pipeline = self
+            .create_render_pipeline_or_error(desc.clone())
+            .unwrap_or_else(|err| {
+                self.handle_error(err, desc.label.as_deref(), "Device::create_render_pipeline");
+                pipeline::RenderPipeline::invalid(self.clone(), desc.label.to_string())
+            });
         #[cfg(feature = "trace")]
         if let Some(ref mut trace) = *self.trace.lock() {
             use crate::device::trace::IntoTrace;
@@ -4562,10 +4563,13 @@ impl Device {
             "Device::create_render_pipeline -> {:?}",
             Arc::as_ptr(&render_pipeline)
         );
-        (render_pipeline, error)
+        render_pipeline
     }
 
-    pub fn create_render_pipeline_inner(
+    /// Creates a render pipeline without raising any error to device.
+    ///
+    /// Corresponds to [GPUDevice.createRenderPipelineAsync](https://www.w3.org/TR/webgpu/#dom-gpudevice-createrenderpipelineasync)
+    pub fn create_render_pipeline_or_error(
         self: &Arc<Self>,
         desc: pipeline::ResolvedGeneralRenderPipelineDescriptor,
     ) -> Result<Arc<pipeline::RenderPipeline>, pipeline::CreateRenderPipelineError> {

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1143,15 +1143,7 @@ impl dispatch::DeviceInterface for CoreDevice {
                 .map(|cache| cache.inner.as_core().wgpu_pipeline_cache.clone()),
         };
 
-        let (wgpu_render_pipeline, error) = self.wgpu_device.create_render_pipeline(descriptor);
-        if let Some(cause) = error {
-            if let wgc::pipeline::CreateRenderPipelineError::Internal { stage, ref error } = cause {
-                log::error!("Shader translation error for stage {stage:?}: {error}");
-                log::error!("Please report it to https://github.com/gfx-rs/wgpu");
-            }
-            self.wgpu_device
-                .handle_error(cause, desc.label, "Device::create_render_pipeline");
-        }
+        let wgpu_render_pipeline = self.wgpu_device.create_render_pipeline(descriptor);
         CoreRenderPipeline {
             wgpu_render_pipeline,
         }
@@ -1234,16 +1226,7 @@ impl dispatch::DeviceInterface for CoreDevice {
                 .map(|cache| cache.inner.as_core().wgpu_pipeline_cache.clone()),
         };
 
-        let (wgpu_render_pipeline, error) =
-            self.wgpu_device.create_render_pipeline(descriptor.into());
-        if let Some(cause) = error {
-            if let wgc::pipeline::CreateRenderPipelineError::Internal { stage, ref error } = cause {
-                log::error!("Shader translation error for stage {stage:?}: {error}");
-                log::error!("Please report it to https://github.com/gfx-rs/wgpu");
-            }
-            self.wgpu_device
-                .handle_error(cause, desc.label, "Device::create_render_pipeline");
-        }
+        let wgpu_render_pipeline = self.wgpu_device.create_render_pipeline(descriptor.into());
         CoreRenderPipeline {
             wgpu_render_pipeline,
         }


### PR DESCRIPTION
**Connections**
Part of https://github.com/gfx-rs/wgpu/issues/8911
Towards https://github.com/gfx-rs/wgpu/issues/10073

**Description**
This is more tricky as we we still need the erroring variant to implement async version in browsers so we followed #10164. Only deno needed additional content timeline validation.

**Testing**
Refactor; deno changes covered by CTS

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
