### PR TITLE
Move erroring of map_async into wgc

### DIFF
--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -36,7 +36,10 @@ pub enum BufferError {
   Canceled(#[from] oneshot::Canceled),
   #[class("DOMExceptionOperationError")]
   #[error(transparent)]
-  Access(#[from] wgpu_core::resource::BufferAccessError),
+  Access(wgpu_core::resource::BufferAccessError),
+  #[class("DOMExceptionAbortError")]
+  #[error("{0}")]
+  Aborted(&'static str),
   #[class("DOMExceptionOperationError")]
   #[error("{0}")]
   Operation(&'static str),
@@ -45,9 +48,18 @@ pub enum BufferError {
   Other(#[from] JsErrorBox),
 }
 
-pub struct GPUBuffer {
-  pub error_handler: super::error::ErrorHandler,
+impl From<wgpu_core::resource::BufferAccessError> for BufferError {
+  fn from(err: wgpu_core::resource::BufferAccessError) -> Self {
+    match err {
+      wgpu_core::resource::BufferAccessError::Device(
+        wgpu_core::device::DeviceError::Lost,
+      ) => BufferError::Aborted("Device lost"),
+      err => BufferError::Access(err),
+    }
+  }
+}
 
+pub struct GPUBuffer {
   pub wgpu_buffer: Arc<wgpu_core::resource::Buffer>,
   pub wgpu_device: Arc<wgpu_core::device::Device>,
 
@@ -144,22 +156,14 @@ impl GPUBuffer {
         sender.send(status).unwrap();
       });
 
-      let err = self
-        .wgpu_buffer
-        .map_async(
-          offset,
-          size,
-          wgpu_core::resource::BufferMapOperation {
-            host: mode,
-            callback: Some(callback),
-          },
-        )
-        .err();
-
-      if err.is_some() {
-        self.error_handler.push_error(err);
-        return Err(BufferError::Operation("validation error occurred"));
-      }
+      self.wgpu_buffer.map_async(
+        offset,
+        size,
+        wgpu_core::resource::BufferMapOperation {
+          host: mode,
+          callback: Some(callback),
+        },
+      );
     }
 
     let done = Rc::new(RefCell::new(false));

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -190,7 +190,6 @@ impl GPUDevice {
     let wgpu_buffer = self.wgpu_device.create_buffer(&wgpu_descriptor);
 
     Ok(GPUBuffer {
-      error_handler: self.error_handler.clone(),
       wgpu_buffer,
       wgpu_device: self.wgpu_device.clone(),
       label: descriptor.label,

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -1135,7 +1135,7 @@ impl Global {
         offset: BufferAddress,
         size: Option<BufferAddress>,
         op: BufferMapOperation,
-    ) -> Result<SubmissionIndex, BufferAccessError> {
+    ) -> Option<SubmissionIndex> {
         let hub = self.hub.borrow();
 
         let buffer = hub.buffers.get(buffer_id);

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -674,7 +674,7 @@ impl Buffer {
         offset: wgt::BufferAddress,
         size: Option<wgt::BufferAddress>,
         op: BufferMapOperation,
-    ) -> Result<SubmissionIndex, BufferAccessError> {
+    ) -> Option<SubmissionIndex> {
         profiling::scope!("Buffer::map_async");
         api_log!(
             "Buffer::map_async {:?} offset {offset:?} size {size:?} op: {op:?}",
@@ -683,11 +683,13 @@ impl Buffer {
 
         self.try_map_async(offset, size, op)
             .map_err(|(mut operation, err)| {
+                self.device
+                    .handle_error(err.clone(), Some(&self.label), "Buffer::map_async");
                 if let Some(callback) = operation.callback.take() {
-                    callback(Err(err.clone()));
+                    callback(Err(err));
                 }
-                err
             })
+            .ok()
     }
 
     /// Try to schedule buffer mapping.

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1704,16 +1704,8 @@ impl dispatch::BufferInterface for CoreBuffer {
             })),
         };
 
-        match self
-            .wgpu_buffer
-            .map_async(range.start, Some(range.end - range.start), operation)
-        {
-            Ok(_) => (),
-            Err(cause) => self
-                .wgpu_buffer
-                .device()
-                .handle_error_nolabel(cause, "Buffer::map_async"),
-        }
+        self.wgpu_buffer
+            .map_async(range.start, Some(range.end - range.start), operation);
     }
 
     fn get_mapped_range(


### PR DESCRIPTION
**Connections**
Part of https://github.com/gfx-rs/wgpu/issues/8911
Towards https://github.com/gfx-rs/wgpu/issues/10073

**Description**
Per spec we need to raise validation error before resolving promise/callback.
Device lost needs to be mapped to abort per spec.

**Testing**
Refactor; there is no device lost CTS test for map_async but other changes should be covered by CTS

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
