### PR TITLE
glsl-out: never emit `invariant gl_FragCoord` on OpenGL ES

### DIFF
--- a/naga/src/back/glsl/writer.rs
+++ b/naga/src/back/glsl/writer.rs
@@ -1080,15 +1080,11 @@ impl<'a, W: Write> Writer<'a, W> {
                 match built_in {
                     crate::BuiltIn::Position { invariant: true } => {
                         match (self.options.version, self.entry_point.stage) {
-                            (
-                                Version::Embedded {
-                                    version: 300,
-                                    is_webgl: true,
-                                },
-                                ShaderStage::Fragment,
-                            ) => {
-                                // `invariant gl_FragCoord` is not allowed in WebGL2 and possibly
-                                // OpenGL ES in general (waiting on confirmation).
+                            (Version::Embedded { .. }, ShaderStage::Fragment) => {
+                                // `invariant gl_FragCoord` is illegal in all OpenGL ES versions:
+                                // `invariant` may only qualify writable variables, and
+                                // `gl_FragCoord` is read-only in the fragment stage
+                                // (GLSL ES 3.00 spec §4.6.1, same language through 3.20).
                                 //
                                 // See https://github.com/KhronosGroup/WebGL/issues/3518
                             }


### PR DESCRIPTION
Original issue: https://github.com/gfx-rs/naga/pull/2254

The 2023 fix only skipped the invariant when targeting WebGL2 (`is_webgl: true`), but `invariant` may only qualify writable variables and `gl_FragCoord` is read-only in the fragment stage under *all* OpenGL ES versions (GLSL ES 3.00 §4.6.1), so native GLES drivers reject the emitted shader as well.

All I did was widen the match arm to all ES versions and drop the stale "waiting on confirmation" comment. This fixes the invalid shaders for Android GLES targets.

Fixes gfx-rs/wgpu#4481

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [X ] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ X] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ X] Commits are logically scoped and individually reviewable.
- [ ]X The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
