### PR TITLE
Unbreak trunk: `zizmor` permissions and stale WGSL snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -990,7 +990,9 @@ jobs:
   zizmor:
     name: "Zizmor"
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      # `zizmor-action` uploads its findings to GitHub code scanning as SARIF.
+      security-events: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/naga/tests/out/wgsl/wgsl-primitive-index-mesh-shader.wgsl
+++ b/naga/tests/out/wgsl/wgsl-primitive-index-mesh-shader.wgsl
@@ -19,7 +19,7 @@ struct MeshOutput {
 
 var<workgroup> mesh_output: MeshOutput;
 
-@mesh(mesh_output) @workgroup_size(1, 1, 1) 
+@mesh(mesh_output) @workgroup_size(1, 1, 1)
 fn ms_main() {
     mesh_output.vertex_count = 3u;
     mesh_output.primitive_count = 1u;
@@ -31,7 +31,7 @@ fn ms_main() {
     return;
 }
 
-@fragment 
+@fragment
 fn fs_main(@builtin(primitive_index) index: u32) -> @location(0) vec4<f32> {
     return vec4<f32>(f32(index), 1f, 1f, 1f);
 }

--- a/naga/tests/out/wgsl/wgsl-ray-tracing-pipeline.wgsl
+++ b/naga/tests/out/wgsl/wgsl-ray-tracing-pipeline.wgsl
@@ -47,7 +47,7 @@ fn closest_hit_main(@builtin(object_ray_origin) origin_1: vec3<f32>, @builtin(ob
     return;
 }
 
-@closest_hit @incoming_payload(incoming_hit_num) 
+@closest_hit @incoming_payload(incoming_hit_num)
 fn closest_hit_triangle(@builtin(instance_index) instance_index: u32, @builtin(primitive_index) primitive_index: u32) {
     incoming_hit_num.hit_num = primitive_index;
     incoming_hit_num.hit_num = instance_index;


### PR DESCRIPTION
**Connections**

Some combination of things caused trunk to break again, #9869 was never green before landing, because its added job was not required.

**Description**

This updates the naga snapshots and fixes zizmor.

**Testing**

It is CI.

**Squash or Rebase?**

Squash.



**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
