### PR TITLE
naga: regenerate WGSL snapshots left stale by #10131

### DIFF
--- a/naga/tests/out/wgsl/wgsl-primitive-index-mesh-shader.wgsl
+++ b/naga/tests/out/wgsl/wgsl-primitive-index-mesh-shader.wgsl
@@ -19,7 +19,7 @@ struct MeshOutput {
 
 var<workgroup> mesh_output: MeshOutput;
 
-@mesh(mesh_output) @workgroup_size(1, 1, 1) 
+@mesh(mesh_output) @workgroup_size(1, 1, 1)
 fn ms_main() {
     mesh_output.vertex_count = 3u;
     mesh_output.primitive_count = 1u;
@@ -31,7 +31,7 @@ fn ms_main() {
     return;
 }
 
-@fragment 
+@fragment
 fn fs_main(@builtin(primitive_index) index: u32) -> @location(0) vec4<f32> {
     return vec4<f32>(f32(index), 1f, 1f, 1f);
 }

--- a/naga/tests/out/wgsl/wgsl-ray-tracing-pipeline.wgsl
+++ b/naga/tests/out/wgsl/wgsl-ray-tracing-pipeline.wgsl
@@ -47,7 +47,7 @@ fn closest_hit_main(@builtin(object_ray_origin) origin_1: vec3<f32>, @builtin(ob
     return;
 }
 
-@closest_hit @incoming_payload(incoming_hit_num) 
+@closest_hit @incoming_payload(incoming_hit_num)
 fn closest_hit_triangle(@builtin(instance_index) instance_index: u32, @builtin(primitive_index) primitive_index: u32) {
     incoming_hit_num.hit_num = primitive_index;
     incoming_hit_num.hit_num = instance_index;


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

_When one pull request builds on another, please put "Depends on
#NNNN" towards the top of its description. This helps maintainers
notice that they shouldn't merge it until its ancestor has been
approved. Don't use draft PR status to indicate this._

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain what you have done to ensure this change is adequately tested
(e.g. adding test cases, running tests on an unusual platform, or
manually checking visual results)._

**Squash or Rebase?**
_If your pull request contains multiple commits, please indicate whether
they need to be squashed into a single commit before they're merged,
or if they're ready to rebase onto `trunk` as they stand. In the
latter case, please ensure that each commit passes all CI tests, so
that we can continue to bisect along `trunk` to isolate bugs._

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [ ] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
