### PR TITLE
ci: stop `trunk` runs from queueing behind each other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,12 @@ env:
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times
 # on PRs that are pushed to multiple times in rapid succession.
+#
+# Off pull requests every run gets a group of its own. `trunk` gets one push
+# after another, and a shared group makes each of those runs wait for the run
+# before it to finish.
 concurrency:
-  group: ${{github.workflow}}-${{github.ref}}
+  group: ${{github.workflow}}-${{github.event_name == 'pull_request' && github.ref || github.run_id}}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 # We distinguish the following kinds of builds:

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -32,8 +32,12 @@ env:
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times
 # on PRs that are pushed to multiple times in rapid succession.
+#
+# Off pull requests every run gets a group of its own. `trunk` gets one push
+# after another, and a shared group makes each of those runs wait for the run
+# before it to finish.
 concurrency:
-  group: ${{github.workflow}}-${{github.ref}}
+  group: ${{github.workflow}}-${{github.event_name == 'pull_request' && github.ref || github.run_id}}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,13 +21,23 @@ env:
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times
 # on PRs that are pushed to multiple times in rapid succession.
+#
+# Off pull requests every run gets a group of its own. `trunk` gets one push
+# after another, and a shared group makes each of those runs wait for the run
+# before it to finish.
 concurrency:
-  group: ${{github.workflow}}-${{github.ref}}
+  group: ${{github.workflow}}-${{github.event_name == 'pull_request' && github.ref || github.run_id}}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    # `Docs` and `Publish` both deploy to `gfx-rs/wgpu-rs.github.io`, so only one
+    # of them may run at a time. This group is shared between the two workflows on
+    # purpose. Off `trunk` nothing deploys, so those runs keep a group of their own.
+    concurrency:
+      group: ${{github.ref == 'refs/heads/trunk' && 'wgpu-rs.github.io' || github.run_id}}
+      cancel-in-progress: false
 
     permissions: {}
 

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -22,8 +22,12 @@ env:
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times
 # on PRs that are pushed to multiple times in rapid succession.
+#
+# Off pull requests every run gets a group of its own. `trunk` gets one push
+# after another, and a shared group makes each of those runs wait for the run
+# before it to finish.
 concurrency:
-  group: ${{github.workflow}}-${{github.ref}}
+  group: ${{github.workflow}}-${{github.event_name == 'pull_request' && github.ref || github.run_id}}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 jobs:

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -19,8 +19,12 @@ env:
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times
 # on PRs that are pushed to multiple times in rapid succession.
+#
+# Off pull requests every run gets a group of its own. `trunk` gets one push
+# after another, and a shared group makes each of those runs wait for the run
+# before it to finish.
 concurrency:
-  group: ${{github.workflow}}-${{github.ref}}
+  group: ${{github.workflow}}-${{github.event_name == 'pull_request' && github.ref || github.run_id}}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,13 +18,23 @@ env:
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times
 # on PRs that are pushed to multiple times in rapid succession.
+#
+# Off pull requests every run gets a group of its own. `trunk` gets one push
+# after another, and a shared group makes each of those runs wait for the run
+# before it to finish.
 concurrency:
-  group: ${{github.workflow}}-${{github.ref}}
+  group: ${{github.workflow}}-${{github.event_name == 'pull_request' && github.ref || github.run_id}}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # `Docs` and `Publish` both deploy to `gfx-rs/wgpu-rs.github.io`, so only one
+    # of them may run at a time. This group is shared between the two workflows on
+    # purpose. Off `trunk` nothing deploys, so those runs keep a group of their own.
+    concurrency:
+      group: ${{github.ref == 'refs/heads/trunk' && 'wgpu-rs.github.io' || github.run_id}}
+      cancel-in-progress: false
     permissions: {}
     steps:
       - name: Checkout repo

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -13,8 +13,12 @@ on:
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times
 # on PRs that are pushed to multiple times in rapid succession.
+#
+# Off pull requests every run gets a group of its own. `trunk` gets one push
+# after another, and a shared group makes each of those runs wait for the run
+# before it to finish.
 concurrency:
-  group: ${{github.workflow}}-${{github.ref}}
+  group: ${{github.workflow}}-${{github.event_name == 'pull_request' && github.ref || github.run_id}}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
 
 jobs:


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

_When one pull request builds on another, please put "Depends on
#NNNN" towards the top of its description. This helps maintainers
notice that they shouldn't merge it until its ancestor has been
approved. Don't use draft PR status to indicate this._

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain what you have done to ensure this change is adequately tested
(e.g. adding test cases, running tests on an unusual platform, or
manually checking visual results)._

**Squash or Rebase?**
_If your pull request contains multiple commits, please indicate whether
they need to be squashed into a single commit before they're merged,
or if they're ready to rebase onto `trunk` as they stand. In the
latter case, please ensure that each commit passes all CI tests, so
that we can continue to bisect along `trunk` to isolate bugs._

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [ ] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
