### PR TITLE
test: Expectation updates for Vulkan SDK 1.4.357

### DIFF
--- a/examples/features/src/big_compute_buffers/tests.rs
+++ b/examples/features/src/big_compute_buffers/tests.rs
@@ -24,10 +24,6 @@ pub static TWO_BUFFERS: GpuTestConfiguration = GpuTestConfiguration::new()
                     .validation_error("could not be compiled into pipeline")
                     // https://github.com/gfx-rs/wgpu/issues/9849
                     .panic("assertion failed: produced"),
-            )
-            .expect_fail(
-                // https://github.com/gfx-rs/wgpu/issues/9849
-                wgpu_test::FailureCase::kosmic_krisp().panic("assertion failed: produced"),
             ),
     )
     .run_async(|ctx| {

--- a/tests/tests/wgpu-gpu/binding_array/storage_textures.rs
+++ b/tests/tests/wgpu-gpu/binding_array/storage_textures.rs
@@ -27,7 +27,13 @@ static BINDING_ARRAY_STORAGE_TEXTURES: GpuTestConfiguration = GpuTestConfigurati
             .limits(Limits {
                 max_binding_array_elements_per_shader_stage: 17,
                 ..Limits::default()
-            }),
+            })
+            .expect_fail(
+                // https://github.com/gfx-rs/wgpu/issues/9849 and/or https://github.com/gfx-rs/wgpu/issues/6745
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline"),
+            ),
     )
     .run_async(|ctx| async move { binding_array_storage_textures(ctx, false).await });
 
@@ -46,7 +52,13 @@ static PARTIAL_BINDING_ARRAY_STORAGE_TEXTURES: GpuTestConfiguration = GpuTestCon
             .limits(Limits {
                 max_binding_array_elements_per_shader_stage: 33,
                 ..Limits::default()
-            }),
+            })
+            .expect_fail(
+                // https://github.com/gfx-rs/wgpu/issues/9849 and/or https://github.com/gfx-rs/wgpu/issues/6745
+                wgpu_test::FailureCase::molten_vk()
+                    .validation_error("Shader library compile failed")
+                    .validation_error("could not be compiled into pipeline"),
+            ),
     )
     .run_async(|ctx| async move { binding_array_storage_textures(ctx, true).await });
 


### PR DESCRIPTION
Updates some test expectations for Vulkan on macOS with results from my M1 and the SDK version from #10213.

**Testing**
Tested locally. These configs don't run in CI.

**Squash or Rebase?** Squash