### PR TITLE
test: Enable mark_externally_initialized test on Mac Vulkan

### DIFF
--- a/tests/tests/wgpu-gpu/zero_init.rs
+++ b/tests/tests/wgpu-gpu/zero_init.rs
@@ -2844,7 +2844,8 @@ static MARK_EXTERNALLY_INITIALIZED_SKIPS_LAZY_CLEAR: GpuTestConfiguration =
                     target_os = "windows",
                     target_os = "linux",
                     target_os = "android",
-                    target_os = "freebsd"
+                    target_os = "freebsd",
+                    target_os = "macos"
                 ))]
                 Backend::Vulkan => {
                     check_mark_externally_initialized::<hal::vulkan::Api>(&ctx).await;


### PR DESCRIPTION
Follow-up to #10075.

I am not certain that this will do the right thing in all cases, but I think it is an improvement. It is not a problem to build the test with Vulkan support and then not actually run it with the Vulkan backend. But running the test with the Vulkan backend when it is not built with Vulkan support (which is what happens on MacOS with an available Vulkan driver before this PR) panics.

This change will not do the right thing if the `wgpu-test` crate is built on MacOS against a `wgpu` _without_ the `vulkan-portability` feature (test build will fail because the test references undefined `hal::vulkan::Api`). I don't think this will happen, because `wgpu-test` is an unpublished crate and `vulkan-portability` is activated in the workspace Cargo.toml. If it could happen, it might require adding `vulkan-portability` as a feature on `wgpu-test` or figuring out a different way to structure this test.

**Testing**
Tested locally with MoltenVK and KosmicKrisp.

**Squash or Rebase?** Squash