### PR TITLE
[core] Log shader translation error and beg for bug reports

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -4366,6 +4366,14 @@ impl Device {
         let compute_pipeline = self
             .create_compute_pipeline_or_error(desc.clone())
             .unwrap_or_else(|err| {
+                if let pipeline::CreateComputePipelineError::Internal(ref error) = err {
+                    log::error!(
+                        "Shader translation error for stage {:?}: {}",
+                        wgt::ShaderStages::COMPUTE,
+                        error
+                    );
+                    log::error!("Please report it to https://github.com/gfx-rs/wgpu");
+                }
                 self.handle_error(
                     err,
                     desc.label.as_deref(),
@@ -4555,6 +4563,10 @@ impl Device {
         let render_pipeline = self
             .create_render_pipeline_or_error(desc.clone())
             .unwrap_or_else(|err| {
+                if let pipeline::CreateRenderPipelineError::Internal { stage, ref error } = err {
+                    log::error!("Shader translation error for stage {stage:?}: {error}");
+                    log::error!("Please report it to https://github.com/gfx-rs/wgpu");
+                }
                 self.handle_error(err, desc.label.as_deref(), "Device::create_render_pipeline");
                 pipeline::RenderPipeline::invalid(self.clone(), desc.label.to_string())
             });


### PR DESCRIPTION
**Connections**
https://github.com/gfx-rs/wgpu/pull/10227#discussion_r3906208333

**Description**
the `_or_error` variant (the one used in async impl) will not log errors. I know servo will log errors by default.

**Testing**
None

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
