### PR TITLE
`Buffer::unmap` should not raise any validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Remove the never-constructed `CreateBlasError::InvalidAabbStride` variant. `create_blas` takes no stride, so it could never be produced; AABB stride is validated at build time as `BuildAccelerationStructureError::InvalidAabbStride`. By @mstampfli in [#9935](https://github.com/gfx-rs/wgpu/pull/9935).
 
 - Added `DownlevelFlags::LINEAR_INTERPOLATION`, indicating that the adapter supports `@interpolate(linear)`. It is absent on GLES/WebGL2, since GLSL ES has no `noperspective` qualifier. By @emilk in [#9972](https://github.com/gfx-rs/wgpu/pull/9972).
+- `Buffer::unmap` will not raise any validation errors anymore per specification. By @sagudev in [#10242](https://github.com/gfx-rs/wgpu/pull/10242).
 
 #### naga
 

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -256,7 +256,7 @@ impl GPUBuffer {
       ab.detach(None);
     }
 
-    self.wgpu_buffer.unmap().map_err(BufferError::Access)?;
+    self.wgpu_buffer.unmap();
 
     *self.map_state.borrow_mut() = "unmapped";
 

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -126,7 +126,7 @@ impl Player {
             }
             Action::DropBuffer(id) => {
                 let buffer = self.buffers.remove(&id).expect("invalid buffer");
-                let _ = buffer.unmap();
+                buffer.unmap();
             }
             Action::CreateTexture(id, desc) => {
                 let texture = device.create_texture(&desc);

--- a/tests/tests/wgpu-gpu/resource_error.rs
+++ b/tests/tests/wgpu-gpu/resource_error.rs
@@ -30,11 +30,7 @@ static BAD_BUFFER_MAP: GpuTestConfiguration = GpuTestConfiguration::new()
             || buffer.slice(..).map_async(wgpu::MapMode::Write, |_| {}),
             Some("Buffer with '' label is invalid"),
         );
-        fail(
-            &ctx.device,
-            || buffer.unmap(),
-            Some("Buffer with '' label is invalid"),
-        );
+        valid(&ctx.device, || buffer.unmap());
         valid(&ctx.device, || buffer.destroy());
         valid(&ctx.device, || buffer.destroy());
     });

--- a/wgpu-core-remote/src/global/device.rs
+++ b/wgpu-core-remote/src/global/device.rs
@@ -17,9 +17,7 @@ use wgpu_core::{
         self, ProgrammableStageDescriptor, RenderPipelineVertexProcessor,
         ResolvedGeneralRenderPipelineDescriptor,
     },
-    resource::{
-        self, BufferAccessError, BufferAccessResult, BufferMapOperation, CreateBufferError,
-    },
+    resource::{self, BufferAccessError, BufferMapOperation, CreateBufferError},
     Label, LabelHelpers, SubmissionIndex,
 };
 
@@ -1193,12 +1191,12 @@ impl Global {
         buffer.get_mapped_range(offset, size)
     }
 
-    pub fn buffer_unmap(&self, buffer_id: id::BufferId) -> BufferAccessResult {
+    pub fn buffer_unmap(&self, buffer_id: id::BufferId) {
         let hub = self.hub.borrow();
 
         let buffer = hub.buffers.get(buffer_id);
 
-        buffer.unmap()
+        buffer.unmap();
     }
 
     pub fn device_on_uncaptured_error(

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -999,20 +999,32 @@ impl Buffer {
     pub fn unmap(self: &Arc<Self>) {
         profiling::scope!("unmap", "Buffer");
         api_log!("Buffer::unmap {:?}", Arc::as_ptr(self));
-        if let Ok(Some((mut operation, status))) = self.unmap_inner() {
+        if let Some((mut operation, status)) = self.unmap_inner() {
             if let Some(callback) = operation.callback.take() {
                 callback(status);
             }
         }
     }
 
-    fn unmap_inner(self: &Arc<Self>) -> Result<Option<BufferMapPendingClosure>, BufferAccessError> {
+    /// Per the WebGPU spec, unmap does not raise any errors
+    /// it just resolves any pending map_async calls with a MapAborted error.
+    /// It is okay to ignore errors because:
+    /// - if the buffer or device was invalid from the start it couldn't have been mapped via `map_async` anyway (no callback to resolve)
+    /// - if the device becomes invalid it calls the callback in `poll`/`maintain`
+    /// - if the buffer was destroyed (via `Buffer::destroy`) it was first unmapped
+    ///
+    /// <https://gpuweb.github.io/gpuweb/#dom-gpubuffer-unmap>
+    fn unmap_inner(self: &Arc<Self>) -> Option<BufferMapPendingClosure> {
         let device = &self.device;
-        self.check_is_valid()?;
-        self.device.check_is_valid()?;
+        // We can stop here if the device is invalid because:
+        // - if the device was invalid from the start it couldn't have been mapped via `map_async` anyway
+        // - if the device becomes invalid it calls the callback in `poll`/`maintain`
+        self.device.check_is_valid().ok()?;
         let snatch_guard = device.snatchable_lock.read();
-        self.check_destroyed(&snatch_guard)?;
-        let raw_buf = self.try_raw(&snatch_guard)?;
+        // We can stop here if the buffer is invalid or destroyed because:
+        // - if the device was invalid from the start it couldn't have been mapped via `map_async` anyway
+        // - if the buffer was destroyed (via `Buffer::destroy`) it was first unmapped
+        let raw_buf = self.try_raw(&snatch_guard).ok()?;
         let map_state = mem::replace(&mut *self.map_state.lock(), BufferMapState::Idle);
         match map_state {
             BufferMapState::Init { staging_buffer } => {
@@ -1070,12 +1082,11 @@ impl Buffer {
                     pending_writes.consume(staging_buffer);
                     pending_writes.insert_buffer(self);
                 }
+                None
             }
-            BufferMapState::Idle => {
-                return Err(BufferAccessError::NotMapped);
-            }
+            BufferMapState::Idle => None,
             BufferMapState::Waiting(pending) => {
-                return Ok(Some((pending.op, Err(BufferAccessError::MapAborted))));
+                Some((pending.op, Err(BufferAccessError::MapAborted)))
             }
             BufferMapState::Active {
                 mapping,
@@ -1104,9 +1115,9 @@ impl Buffer {
                     }
                 }
                 unsafe { device.raw().unmap_buffer(raw_buf) };
+                None
             }
         }
-        Ok(None)
     }
 
     pub fn destroy(self: &Arc<Self>) {

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -996,16 +996,14 @@ impl Buffer {
     }
 
     // Note: This must not be called while holding a lock.
-    pub fn unmap(self: &Arc<Self>) -> Result<(), BufferAccessError> {
+    pub fn unmap(self: &Arc<Self>) {
         profiling::scope!("unmap", "Buffer");
         api_log!("Buffer::unmap {:?}", Arc::as_ptr(self));
-        if let Some((mut operation, status)) = self.unmap_inner()? {
+        if let Ok(Some((mut operation, status))) = self.unmap_inner() {
             if let Some(callback) = operation.callback.take() {
                 callback(status);
             }
         }
-
-        Ok(())
     }
 
     fn unmap_inner(self: &Arc<Self>) -> Result<Option<BufferMapPendingClosure>, BufferAccessError> {
@@ -1127,7 +1125,7 @@ impl Buffer {
             return;
         };
 
-        let _ = self.unmap();
+        self.unmap();
 
         let temp = {
             let mut snatch_guard = device.snatchable_lock.write();

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -1709,13 +1709,7 @@ impl dispatch::BufferInterface for CoreBuffer {
     }
 
     fn unmap(&self) {
-        match self.wgpu_buffer.unmap() {
-            Ok(()) => (),
-            Err(cause) => self
-                .wgpu_buffer
-                .device()
-                .handle_error_nolabel(cause, "Buffer::buffer_unmap"),
-        }
+        self.wgpu_buffer.unmap();
     }
 
     fn destroy(&self) {


### PR DESCRIPTION
**Connections**
Part of #10073
Could be considered as part of https://github.com/gfx-rs/wgpu/issues/8911
we talked about in https://github.com/gfx-rs/wgpu/pull/9811#issuecomment-4893552826

**Description**
Per spec, unmap does not raise any errors. If there is any pending map it should be resolved with abort (in case of lost device this already happened).

**Testing**
Just refactor

**Squash or Rebase?**
Squash or Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
