### PR TITLE
fix(core): Drop internals of `Device` in the correct order

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -224,8 +224,6 @@ impl DeferredBufferMapPendingClosures {
 /// Structure describing a logical device. Some members are internally mutable,
 /// stored behind mutexes.
 pub struct Device {
-    raw: Box<dyn hal::DynDevice>,
-    pub(crate) adapter: Arc<Adapter>,
     pub(crate) queue: OnceCell<Weak<Queue>>,
     pub(crate) zero_buffer: ManuallyDrop<Box<dyn hal::DynBuffer>>,
     pub(crate) empty_bgl: ManuallyDrop<Box<dyn hal::DynBindGroupLayout>>,
@@ -302,7 +300,17 @@ pub struct Device {
     /// binding point will be rendered correctly. Intended to be used as the
     /// [`hal::ExternalTextureBinding::params`] field.
     pub(crate) default_external_texture_params_buffer: ManuallyDrop<Box<dyn hal::DynBuffer>>,
-    // needs to be dropped last
+
+    // Drop order matters!
+    //
+    //  - Any member whose drop might destroy hal resources needs to be dropped
+    //    before the device. Most hal resources are handled manually in
+    //    `Device::drop`, but this applies to `command_allocator`.
+    //  - The device must be dropped before the adapter.
+    //  - Any member whose drop might write into the trace must be dropped
+    //    before the trace.
+    raw: Box<dyn hal::DynDevice>,
+    pub(crate) adapter: Arc<Adapter>,
     #[cfg(feature = "trace")]
     pub(crate) trace: Mutex<Option<Box<dyn trace::Trace + Send + Sync + 'static>>>,
 }


### PR DESCRIPTION
Fixes a crash on Windows that for some reason doesn't show up in CI. Bisection found the crash was introduced by #9950.

Before #9950, `wgpu` held an `Instance` through destruction of the device, so there was no problem.

After #9950, that was no longer the case. Dropping `raw: Box<hal::DynDevice>` would release the reference to the D3D library, and then an access violation occurred while destroying command encoders while dropping `command_allocator`.

`wgpu-hal` requires that resources associated with a device are destroyed before the device itself. (Usually it is Vulkan where this causes problems.) So, reorder the fields in `struct Device` to satisfy this requirement.

There is a note about a previous instance of this issue on dx12 (involving different objects) [here](https://github.com/gfx-rs/wgpu/blob/818586c4d1a8e3529e3db016e68260f0a76f3971/wgpu-hal/src/dx12/mod.rs#L417). We could fix the current instance within the dx12 hal as well, but that would not resolve possible problems on Vulkan.

**Testing**
Resolves a consistent crash running the `vertex_formats` GPU test locally.

**Squash or Rebase?** Squash
