### PR TITLE
fix(hal/vulkan): make copy-only textures viewable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 #### Vulkan
 
 - Fix `HalCounters::textures` drifting negative: `create_texture` never incremented it while `destroy_texture` always decremented it. By @dustyleary in [#10022](https://github.com/gfx-rs/wgpu/pull/10022).
+- Fix `VUID-VkImageViewCreateInfo-image-04441` validation errors when creating a view of a texture whose only usages are `COPY_SRC` and/or `COPY_DST`. By @MannXo in [#10200](https://github.com/gfx-rs/wgpu/issues/10200).
 - Add OpenHarmony surface support via `VK_OHOS_surface`. Previously the Vulkan backend could not create a surface on OpenHarmony, leaving GLES as the only usable backend. By @ozongzi in [#9908](https://github.com/gfx-rs/wgpu/pull/9908).
 
 #### Metal

--- a/tests/tests/wgpu-gpu/texture_view_creation.rs
+++ b/tests/tests/wgpu-gpu/texture_view_creation.rs
@@ -8,6 +8,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         STENCIL_ONLY_VIEW_CREATION,
         DEPTH_ONLY_VIEW_CREATION,
         SHARED_USAGE_VIEW_CREATION,
+        COPY_ONLY_VIEW_CREATION,
     ]);
 }
 
@@ -114,5 +115,36 @@ static SHARED_USAGE_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::
                 ),
                 ..Default::default()
             });
+        }
+    });
+
+#[apply(gpu_test!)]
+static COPY_ONLY_VIEW_CREATION: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(TestParameters::default().enable_noop())
+    .run_async(|ctx| async move {
+        // Regression test for https://github.com/gfx-rs/wgpu/issues/10200: a texture whose
+        // only usages are copies still has to be viewable.
+        for format in [TextureFormat::Rgba8Unorm, TextureFormat::Rgba8Snorm] {
+            for usage in [
+                TextureUsages::COPY_DST,
+                TextureUsages::COPY_SRC,
+                TextureUsages::COPY_SRC | TextureUsages::COPY_DST,
+            ] {
+                let texture = ctx.device.create_texture(&TextureDescriptor {
+                    label: None,
+                    size: Extent3d {
+                        width: 256,
+                        height: 256,
+                        depth_or_array_layers: 1,
+                    },
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: TextureDimension::D2,
+                    format,
+                    usage,
+                    view_formats: &[],
+                });
+                let _view = texture.create_view(&TextureViewDescriptor::default());
+            }
         }
     });

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -3389,7 +3389,7 @@ fn is_float32_blendable_supported(instance: &ash::Instance, phd: vk::PhysicalDev
     })
 }
 
-fn supports_format(
+pub(super) fn supports_format(
     instance: &ash::Instance,
     phd: vk::PhysicalDevice,
     format: vk::Format,

--- a/wgpu-hal/src/vulkan/conv.rs
+++ b/wgpu-hal/src/vulkan/conv.rs
@@ -273,6 +273,17 @@ pub fn map_queue_family(family: crate::QueueFamily) -> u32 {
     }
 }
 
+/// Image usages of which an image must have at least one to be viewable, per
+/// `VUID-VkImageViewCreateInfo-image-04441`.
+pub const VIEWABLE_IMAGE_USAGES: vk::ImageUsageFlags = vk::ImageUsageFlags::from_raw(
+    vk::ImageUsageFlags::SAMPLED.as_raw()
+        | vk::ImageUsageFlags::STORAGE.as_raw()
+        | vk::ImageUsageFlags::COLOR_ATTACHMENT.as_raw()
+        | vk::ImageUsageFlags::DEPTH_STENCIL_ATTACHMENT.as_raw()
+        | vk::ImageUsageFlags::INPUT_ATTACHMENT.as_raw()
+        | vk::ImageUsageFlags::TRANSIENT_ATTACHMENT.as_raw(),
+);
+
 pub fn map_texture_usage(usage: wgt::TextureUses) -> vk::ImageUsageFlags {
     let mut flags = vk::ImageUsageFlags::empty();
     if usage.contains(wgt::TextureUses::COPY_SRC) {

--- a/wgpu-hal/src/vulkan/device.rs
+++ b/wgpu-hal/src/vulkan/device.rs
@@ -409,6 +409,24 @@ impl super::Device {
                 vk::ImageCreateFlags::MUTABLE_FORMAT | vk::ImageCreateFlags::EXTENDED_USAGE;
         }
 
+        let mut usage = conv::map_texture_usage(desc.usage);
+        // wgpu allows views of textures that are only ever copied to or from, but Vulkan
+        // requires a viewable image to carry at least one of `VIEWABLE_IMAGE_USAGES`. Add a
+        // usage the format supports so that such views stay valid. Images backed by external
+        // memory are left alone: their usage has to match the resource being imported.
+        if !usage.intersects(conv::VIEWABLE_IMAGE_USAGES)
+            && external_memory_image_create_info.is_none()
+            && super::adapter::supports_format(
+                &self.shared.instance.raw,
+                self.shared.physical_device,
+                original_format,
+                tiling,
+                vk::FormatFeatureFlags::SAMPLED_IMAGE,
+            )
+        {
+            usage |= vk::ImageUsageFlags::SAMPLED;
+        }
+
         let mut vk_info = vk::ImageCreateInfo::default()
             .flags(raw_flags)
             .image_type(conv::map_texture_dimension(desc.dimension))
@@ -418,7 +436,7 @@ impl super::Device {
             .array_layers(desc.array_layer_count())
             .samples(vk::SampleCountFlags::from_raw(desc.sample_count))
             .tiling(tiling)
-            .usage(conv::map_texture_usage(desc.usage))
+            .usage(usage)
             .sharing_mode(vk::SharingMode::EXCLUSIVE)
             .initial_layout(vk::ImageLayout::UNDEFINED);
 


### PR DESCRIPTION
**Connections**

Fixes #10200

**Description**

Vulkan requires that any image you create a view of was created with at least one of `VK_IMAGE_USAGE_SAMPLED_BIT`, `STORAGE_BIT`, `COLOR_ATTACHMENT_BIT`, `DEPTH_STENCIL_ATTACHMENT_BIT`, `INPUT_ATTACHMENT_BIT` or `TRANSIENT_ATTACHMENT_BIT` (`VUID-VkImageViewCreateInfo-image-04441`). A wgpu texture whose only usages are `COPY_SRC` and/or `COPY_DST` maps to an image with only the transfer usages, so creating any view of it triggers a validation error.

`wgpu-core` already adds a usage so every texture can be initialized (`map_texture_usage_for_texture`): `COLOR_TARGET` when the format is renderable and the texture is 2D, otherwise `COPY_DST`. That is why the issue is specific to `COPY_DST`. A `COPY_SRC`-only `Rgba8Unorm` texture picks up `COLOR_TARGET` and is viewable by accident, while a `COPY_DST`-only one stays transfer-only. The same applies to a `COPY_SRC`-only texture in a format that is not renderable, such as `Rgba8Snorm`, which falls back to `COPY_DST` and is equally affected.

The fix is in the Vulkan backend, as suggested in the issue. When the usages mapped for an image include none of the viewable ones, `VK_IMAGE_USAGE_SAMPLED_BIT` is added.

Two conditions on that, both deliberate:

- The bit is only added when the format reports `VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT` for the image's tiling. `SAMPLED` and `TRANSFER_*` are independent format features, so adding the bit unconditionally could turn a working `vkCreateImage` into a failing one. This also makes the DRM format modifier path a no-op for free, since `supports_format` only answers for linear and optimal tiling.
- Images backed by external memory are left alone. Their usage has to match the resource being imported, and widening it could break the import.

`VkImageViewUsageCreateInfo` is untouched. Its `usage` does override the image's for the purposes of this VUID, but `wgpu-core` masks `COPY_SRC`/`COPY_DST` out of view usages, so a copy-only texture produces an empty hal view usage and the struct is never chained.

**Testing**

Added `COPY_ONLY_VIEW_CREATION` to `tests/tests/wgpu-gpu/texture_view_creation.rs`, covering `Rgba8Unorm` and `Rgba8Snorm` against `COPY_DST`, `COPY_SRC` and `COPY_SRC | COPY_DST`. It needs no assertions: the harness turns any message reaching `VALIDATION_CANARY` into a test failure, so the test fails on Vulkan without this change.

Verified locally on macOS (aarch64-apple-darwin):

- `cargo clippy --target aarch64-apple-darwin --tests --benches --all-features` with `RUSTFLAGS=-D warnings`, clean
- `cargo clippy --target aarch64-apple-darwin -p wgpu-hal --no-default-features --features vulkan`, clean
- `cargo fmt --all -- --check`, clean
- `cargo xtask changelog`, clean
- `cargo xtask test view_creation`, 4 passed on Metal

I do not have a Vulkan setup, so the validation error itself was not reproduced locally and the new test has only been run on Metal, where it passes but proves nothing about the fix. Confirmation has to come from the Vulkan CI job. Happy to adjust if it turns out the added `SAMPLED` bit needs a different fallback on some driver.

**Squash or Rebase?**

Single commit, ready to rebase onto `trunk` as it stands.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [x] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [x] (If applicable) Tests demonstrate the validation and altered logic works.
