### PR TITLE
test: CTS list updates; disable slow test

### DIFF
--- a/cts_runner/skip.lst
+++ b/cts_runner/skip.lst
@@ -3,6 +3,15 @@
 // The `cts_runner` integration test `lst_files_are_sorted` verifies that test selectors
 // appear in this file in order -- including ones in comments.
 
+webgpu:api,operation,texture_view,texture_component_swizzle:* // dx12, passes but very slow, https://github.com/gfx-rs/wgpu/issues/9229
+
+webgpu:api,validation,capability_checks,limits,maxStorageBuffersInFragmentStage:* // slow, https://github.com/gfx-rs/wgpu/issues/9229
+webgpu:api,validation,capability_checks,limits,maxStorageBuffersInVertexStage:* // slow, https://github.com/gfx-rs/wgpu/issues/9229
+webgpu:api,validation,capability_checks,limits,maxStorageBuffersPerShaderStage:* // slow, https://github.com/gfx-rs/wgpu/issues/9229
+webgpu:api,validation,capability_checks,limits,maxStorageTexturesInFragmentStage:* // slow, https://github.com/gfx-rs/wgpu/issues/9229
+webgpu:api,validation,capability_checks,limits,maxStorageTexturesInVertexStage:* // slow, https://github.com/gfx-rs/wgpu/issues/9229
+webgpu:api,validation,capability_checks,limits,maxStorageTexturesPerShaderStage:* // slow, https://github.com/gfx-rs/wgpu/issues/9229
+webgpu:api,validation,createBindGroupLayout:max_resources_per_stage,* // dx12/vulkan, passes but very slow, https://github.com/gfx-rs/wgpu/issues/9229
 webgpu:api,validation,dispatch:* // linear indexing, https://github.com/gfx-rs/wgpu/issues/9296
 webgpu:api,validation,encoding,cmds,render,draw:last_buffer_setting_take_account:* // unimplemented in CTS
 webgpu:api,validation,encoding,cmds,render,indirect_multi_draw:* // no 'chromium-experimental-multi-draw-indirect' feature
@@ -11,8 +20,15 @@ webgpu:api,validation,encoding,cmds,render,state_tracking:all_needed_vertex_buff
 webgpu:api,validation,gpu_external_texture_expiration:* // external texture
 webgpu:api,validation,queue,copyToTexture,CopyExternalImageToTexture:* // external texture
 
+webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_1d_coords:* // slow, https://github.com/gfx-rs/wgpu/issues/9229
+webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_2d_coords:* // slow, https://github.com/gfx-rs/wgpu/issues/9229
+webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_3d_coords:* // slow, https://github.com/gfx-rs/wgpu/issues/9229
+
 webgpu:shader,validation,decl,immediate:* // WGSL language extension 'immediate_address_space' isn't added, https://github.com/gfx-rs/wgpu/issues/8556
 webgpu:shader,validation,expression,call,builtin,atomicStoreMinMax:* // device feature 'atomic-vec2u-min-max' isn't implemented
+webgpu:shader,validation,expression,call,builtin,bufferArrayView:* // buffer_view feature
+webgpu:shader,validation,expression,call,builtin,bufferLength:* // ibid.
+webgpu:shader,validation,expression,call,builtin,bufferView:* // ibid.
 webgpu:shader,validation,expression,call,builtin,quadBroadcast:* // subgroups, https://github.com/gfx-rs/wgpu/issues/8722
 webgpu:shader,validation,expression,call,builtin,quadSwap:* // ibid.
 webgpu:shader,validation,expression,call,builtin,subgroupAdd:* // ibid.

--- a/cts_runner/test.lst
+++ b/cts_runner/test.lst
@@ -59,7 +59,8 @@ webgpu:api,operation,rendering,depth:*
 webgpu:api,operation,rendering,draw:*
 fails-if(dx12,vulkan) webgpu:api,operation,sampling,*
 webgpu:api,operation,shader_module,compilation_info:*
-webgpu:api,operation,texture_view,texture_component_swizzle:*
+// Doesn't actually fail, but is very slow. https://github.com/gfx-rs/wgpu/issues/9229
+fails-if(dx12) webgpu:api,operation,texture_view,texture_component_swizzle:*
 webgpu:api,operation,uncapturederror:iff_uncaptured:*
 //FAIL: webgpu:api,operation,uncapturederror:onuncapturederror_order_wrt_addEventListener
 // There are also two unimplemented SKIPs in uncapturederror not enumerated here.
@@ -245,6 +246,7 @@ webgpu:api,validation,image_copy,layout_related:required_bytes_in_copy:*
 webgpu:api,validation,image_copy,layout_related:rows_per_image_alignment:*
 webgpu:api,validation,image_copy,texture_related:*
 fails-if(dx12) webgpu:api,validation,layout_shader_compat:pipeline_layout_shader_exact_match:*
+webgpu:api,validation,min_buffer_binding_size:*
 webgpu:api,validation,pipeline,immediates:*
 webgpu:api,validation,query_set,destroy:*
 webgpu:api,validation,queue,buffer_mapped:*


### PR DESCRIPTION
Main reason for this PR is to disable the `texture_component_swizzle` test on dx12. It increased the CI runtime from ~20 to ~45 minutes. Also adds new tests to the lists and notes other skipped-because-slow tests in skip.lst.

**Squash or Rebase?** Squash