### PR TITLE
[deno] Use meta from wgc instead of storing in deno objects

### DIFF
--- a/deno_webgpu/adapter.rs
+++ b/deno_webgpu/adapter.rs
@@ -223,7 +223,6 @@ impl GPUAdapter {
     let queue_obj = deno_core::cppgc::make_cppgc_object(
       scope,
       GPUQueue {
-        label: descriptor.label.clone(),
         wgpu_queue: queue,
         wgpu_device: wgpu_device.clone(),
       },
@@ -232,7 +231,6 @@ impl GPUAdapter {
 
     let device = GPUDevice {
       wgpu_device: wgpu_device.clone(),
-      label: descriptor.label,
       queue_obj,
       adapter_info: self.info.clone(),
       error_handler,

--- a/deno_webgpu/bind_group.rs
+++ b/deno_webgpu/bind_group.rs
@@ -14,6 +14,7 @@ use deno_core::webidl::WebIdlError;
 use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
+use wgpu_core::resource::Labeled;
 
 use crate::buffer::GPUBuffer;
 use crate::error::GPUGenericError;
@@ -24,7 +25,6 @@ use crate::texture::GPUTextureView;
 
 pub struct GPUBindGroup {
   pub wgpu_bind_group: Arc<wgpu_core::binding_model::BindGroup>,
-  pub label: String,
 }
 
 impl WebIdlInterfaceConverter for GPUBindGroup {
@@ -48,7 +48,7 @@ impl GPUBindGroup {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_bind_group.label().to_string()
   }
   #[setter]
   #[string]

--- a/deno_webgpu/bind_group_layout.rs
+++ b/deno_webgpu/bind_group_layout.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use deno_core::op2;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
+use wgpu_core::resource::Labeled as _;
 
 use crate::error::GPUGenericError;
 use crate::texture::GPUTextureViewDimension;
@@ -12,7 +13,6 @@ use crate::webidl::GPUShaderStageFlags;
 
 pub struct GPUBindGroupLayout {
   pub wgpu_bind_group_layout: Arc<wgpu_core::binding_model::BindGroupLayout>,
-  pub label: String,
 }
 
 impl deno_core::webidl::WebIdlInterfaceConverter for GPUBindGroupLayout {
@@ -36,7 +36,7 @@ impl GPUBindGroupLayout {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_bind_group_layout.label().to_string()
   }
   #[setter]
   #[string]

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -13,6 +13,7 @@ use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use deno_error::JsErrorBox;
 use wgpu_core::device::HostMap as MapMode;
+use wgpu_core::resource::Labeled as _;
 
 use crate::error::GPUGenericError;
 
@@ -63,8 +64,6 @@ pub struct GPUBuffer {
   pub wgpu_buffer: Arc<wgpu_core::resource::Buffer>,
   pub wgpu_device: Arc<wgpu_core::device::Device>,
 
-  pub label: String,
-
   pub size: u64,
   pub usage: u32,
 
@@ -95,7 +94,7 @@ impl GPUBuffer {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_buffer.label().to_string()
   }
   #[setter]
   #[string]

--- a/deno_webgpu/buffer.rs
+++ b/deno_webgpu/buffer.rs
@@ -64,7 +64,6 @@ pub struct GPUBuffer {
   pub wgpu_buffer: Arc<wgpu_core::resource::Buffer>,
   pub wgpu_device: Arc<wgpu_core::device::Device>,
 
-  pub size: u64,
   pub usage: u32,
 
   pub map_state: RefCell<&'static str>,
@@ -105,7 +104,7 @@ impl GPUBuffer {
   #[getter]
   #[number]
   fn size(&self) -> u64 {
-    self.size
+    self.wgpu_buffer.size()
   }
   #[getter]
   fn usage(&self) -> u32 {

--- a/deno_webgpu/command_buffer.rs
+++ b/deno_webgpu/command_buffer.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 use deno_core::op2;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
+use wgpu_core::resource::Labeled as _;
 
 use crate::error::GPUGenericError;
 
 pub struct GPUCommandBuffer {
   pub wgpu_command_buffer: Arc<wgpu_core::command::CommandBuffer>,
-  pub label: String,
 }
 
 impl deno_core::webidl::WebIdlInterfaceConverter for GPUCommandBuffer {
@@ -34,7 +34,7 @@ impl GPUCommandBuffer {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_command_buffer.label().to_string()
   }
   #[setter]
   #[string]

--- a/deno_webgpu/command_encoder.rs
+++ b/deno_webgpu/command_encoder.rs
@@ -15,6 +15,7 @@ use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use deno_error::JsErrorBox;
 use wgpu_core::command::PassChannel;
+use wgpu_core::resource::Labeled as _;
 use wgpu_types::{BufferAddress, TexelCopyBufferInfo};
 
 use crate::buffer::GPUBuffer;
@@ -27,7 +28,6 @@ use crate::webidl::GPUExtent3D;
 
 pub struct GPUCommandEncoder {
   pub wgpu_command_encoder: Arc<wgpu_core::command::CommandEncoder>,
-  pub label: String,
 
   // Weak reference to the JS object so we can attach a finalizer.
   // See `GPUDevice::create_command_encoder`.
@@ -52,7 +52,7 @@ impl GPUCommandEncoder {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_command_encoder.label().to_string()
   }
   #[setter]
   #[string]
@@ -395,7 +395,6 @@ impl GPUCommandEncoder {
 
     GPUCommandBuffer {
       wgpu_command_buffer,
-      label: descriptor.label,
     }
   }
 

--- a/deno_webgpu/compute_pipeline.rs
+++ b/deno_webgpu/compute_pipeline.rs
@@ -8,6 +8,7 @@ use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use indexmap::IndexMap;
+use wgpu_core::resource::Labeled as _;
 
 use crate::bind_group_layout::GPUBindGroupLayout;
 use crate::error::GPUGenericError;
@@ -16,7 +17,6 @@ use crate::webidl::GPUPipelineLayoutOrGPUAutoLayoutMode;
 
 pub struct GPUComputePipeline {
   pub wgpu_compute_pipeline: Arc<wgpu_core::pipeline::ComputePipeline>,
-  pub label: String,
 }
 
 impl WebIdlInterfaceConverter for GPUComputePipeline {
@@ -40,7 +40,7 @@ impl GPUComputePipeline {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_compute_pipeline.label().to_string()
   }
   #[setter]
   #[string]
@@ -56,7 +56,6 @@ impl GPUComputePipeline {
     // TODO(wgpu): needs to support retrieving the label
     GPUBindGroupLayout {
       wgpu_bind_group_layout,
-      label: "".to_string(),
     }
   }
 }

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -192,7 +192,6 @@ impl GPUDevice {
     Ok(GPUBuffer {
       wgpu_buffer,
       wgpu_device: self.wgpu_device.clone(),
-      size: descriptor.size,
       usage: descriptor.usage,
       map_state: RefCell::new(if descriptor.mapped_at_creation {
         "mapped"
@@ -420,7 +419,7 @@ impl GPUDevice {
             BindingResource::Buffer(wgpu_core::binding_model::BufferBinding {
               buffer: buffer.wgpu_buffer.clone(),
               offset: 0,
-              size: Some(buffer.size),
+              size: Some(buffer.wgpu_buffer.size()),
             })
           }
           GPUBindingResource::BufferBinding(buffer_binding) => {

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -248,9 +248,6 @@ impl GPUDevice {
     Ok(GPUTexture {
       wgpu_texture,
       default_view: Default::default(),
-      size: wgpu_descriptor.size,
-      mip_level_count: wgpu_descriptor.mip_level_count,
-      sample_count: wgpu_descriptor.sample_count,
       dimension: descriptor.dimension,
       format: descriptor.format,
       usage: GPUTextureUsageFlags(usage),

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -15,6 +15,7 @@ use deno_error::JsErrorBox;
 use wgpu_core::binding_model::BindingResource;
 use wgpu_core::error::EmptyErrorScopeStack;
 use wgpu_core::pipeline::ProgrammableStageDescriptor;
+use wgpu_core::resource::Labeled;
 use wgpu_types::BindingType;
 
 use super::bind_group::GPUBindGroup;
@@ -47,8 +48,6 @@ pub(crate) const DEVICE_EXTERNAL_MEMORY_SIZE: i64 = 1 << 24; // 16 MB
 pub struct GPUDevice {
   pub wgpu_device: Arc<wgpu_core::device::Device>,
   pub wgpu_adapter: Arc<wgpu_core::instance::Adapter>,
-
-  pub label: String,
 
   pub features: SameObject<GPUSupportedFeatures>,
   pub limits: SameObject<GPUSupportedLimits>,
@@ -101,7 +100,7 @@ impl GPUDevice {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_device.label().to_string()
   }
   #[setter]
   #[string]
@@ -193,7 +192,6 @@ impl GPUDevice {
     Ok(GPUBuffer {
       wgpu_buffer,
       wgpu_device: self.wgpu_device.clone(),
-      label: descriptor.label,
       size: descriptor.size,
       usage: descriptor.usage,
       map_state: RefCell::new(if descriptor.mapped_at_creation {
@@ -251,7 +249,6 @@ impl GPUDevice {
     Ok(GPUTexture {
       wgpu_texture,
       default_view: Default::default(),
-      label: descriptor.label,
       size: wgpu_descriptor.size,
       mip_level_count: wgpu_descriptor.mip_level_count,
       sample_count: wgpu_descriptor.sample_count,
@@ -286,10 +283,7 @@ impl GPUDevice {
 
     let wgpu_sampler = self.wgpu_device.create_sampler(&wgpu_descriptor);
 
-    Ok(GPUSampler {
-      wgpu_sampler,
-      label: descriptor.label,
-    })
+    Ok(GPUSampler { wgpu_sampler })
   }
 
   #[reentrant]
@@ -366,7 +360,6 @@ impl GPUDevice {
 
     Ok(GPUBindGroupLayout {
       wgpu_bind_group_layout,
-      label: descriptor.label,
     })
   }
 
@@ -398,7 +391,6 @@ impl GPUDevice {
 
     GPUPipelineLayout {
       wgpu_pipeline_layout,
-      label: descriptor.label,
     }
   }
 
@@ -455,10 +447,7 @@ impl GPUDevice {
 
     let wgpu_bind_group = self.wgpu_device.create_bind_group(&wgpu_descriptor);
 
-    GPUBindGroup {
-      wgpu_bind_group,
-      label: descriptor.label,
-    }
+    GPUBindGroup { wgpu_bind_group }
   }
 
   #[reentrant]
@@ -491,7 +480,7 @@ impl GPUDevice {
 
     GPUShaderModule {
       wgpu_shader_module,
-      label: descriptor.label,
+
       compilation_info,
     }
   }
@@ -503,13 +492,11 @@ impl GPUDevice {
     &self,
     #[webidl] descriptor: super::compute_pipeline::GPUComputePipelineDescriptor,
   ) -> GPUComputePipeline {
-    let label = descriptor.label.clone();
     let wgpu_descriptor = transform_compute_pipeline_descriptor(descriptor);
     let wgpu_compute_pipeline =
       self.wgpu_device.create_compute_pipeline(wgpu_descriptor);
     GPUComputePipeline {
       wgpu_compute_pipeline,
-      label,
     }
   }
 
@@ -520,14 +507,12 @@ impl GPUDevice {
     &self,
     #[webidl] descriptor: super::render_pipeline::GPURenderPipelineDescriptor,
   ) -> Result<GPURenderPipeline, JsErrorBox> {
-    let label = descriptor.label.clone();
     let wgpu_descriptor =
       self.transform_render_pipeline_descriptor(descriptor)?;
     let wgpu_render_pipeline =
       self.wgpu_device.create_render_pipeline(wgpu_descriptor);
     Ok(GPURenderPipeline {
       wgpu_render_pipeline,
-      label,
     })
   }
 
@@ -544,7 +529,6 @@ impl GPUDevice {
     let resolver = v8::PromiseResolver::new(scope).unwrap();
     let promise = resolver.get_promise(scope);
 
-    let label = descriptor.label.clone();
     let wgpu_descriptor = transform_compute_pipeline_descriptor(descriptor);
     match self
       .wgpu_device
@@ -553,7 +537,6 @@ impl GPUDevice {
       Ok(wgpu_compute_pipeline) => {
         let pipeline = GPUComputePipeline {
           wgpu_compute_pipeline,
-          label,
         };
         let val = make_cppgc_object(scope, pipeline).into();
         resolver.resolve(scope, val);
@@ -581,8 +564,6 @@ impl GPUDevice {
     scope: &mut v8::HandleScope,
     #[webidl] descriptor: super::render_pipeline::GPURenderPipelineDescriptor,
   ) -> Result<v8::Global<v8::Promise>, JsErrorBox> {
-    let label = descriptor.label.clone();
-
     let wgpu_descriptor =
       self.transform_render_pipeline_descriptor(descriptor)?;
 
@@ -596,7 +577,6 @@ impl GPUDevice {
       Ok(wgpu_render_pipeline) => {
         let render_pipeline = GPURenderPipeline {
           wgpu_render_pipeline,
-          label,
         };
         let val = make_cppgc_object(scope, render_pipeline).into();
         resolver.resolve(scope, val);
@@ -642,7 +622,6 @@ impl GPUDevice {
 
     let encoder = GPUCommandEncoder {
       wgpu_command_encoder,
-      label,
       #[cfg(target_vendor = "apple")]
       weak: std::sync::OnceLock::new(),
     };
@@ -751,7 +730,6 @@ impl GPUDevice {
       wgpu_query_set,
       r#type: descriptor.r#type,
       count: descriptor.count,
-      label: descriptor.label,
     })
   }
 

--- a/deno_webgpu/device.rs
+++ b/deno_webgpu/device.rs
@@ -725,11 +725,7 @@ impl GPUDevice {
 
     let wgpu_query_set = self.wgpu_device.create_query_set(&wgpu_descriptor);
 
-    Ok(GPUQuerySet {
-      wgpu_query_set,
-      r#type: descriptor.r#type,
-      count: descriptor.count,
-    })
+    Ok(GPUQuerySet { wgpu_query_set })
   }
 
   #[getter]

--- a/deno_webgpu/pipeline_layout.rs
+++ b/deno_webgpu/pipeline_layout.rs
@@ -7,12 +7,12 @@ use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use std::sync::Arc;
+use wgpu_core::resource::Labeled as _;
 
 use crate::error::GPUGenericError;
 
 pub struct GPUPipelineLayout {
   pub wgpu_pipeline_layout: Arc<wgpu_core::binding_model::PipelineLayout>,
-  pub label: String,
 }
 
 impl WebIdlInterfaceConverter for GPUPipelineLayout {
@@ -36,7 +36,7 @@ impl GPUPipelineLayout {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_pipeline_layout.label().to_string()
   }
   #[setter]
   #[string]

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -13,8 +13,6 @@ use crate::error::GPUGenericError;
 
 pub struct GPUQuerySet {
   pub wgpu_query_set: Arc<wgpu_core::resource::QuerySet>,
-  pub r#type: GPUQueryType,
-  pub count: u32,
 }
 
 impl WebIdlInterfaceConverter for GPUQuerySet {
@@ -56,13 +54,13 @@ impl GPUQuerySet {
   #[getter]
   #[string]
   #[rename("type")]
-  fn r#type(&self) -> &'static str {
-    self.r#type.as_str()
+  fn r#type(&self) -> String {
+    self.wgpu_query_set.descriptor().ty.to_string()
   }
 
   #[getter]
   fn count(&self) -> u32 {
-    self.count
+    self.wgpu_query_set.descriptor().count
   }
 }
 

--- a/deno_webgpu/query_set.rs
+++ b/deno_webgpu/query_set.rs
@@ -7,6 +7,7 @@ use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use deno_error::JsErrorBox;
+use wgpu_core::resource::Labeled;
 
 use crate::error::GPUGenericError;
 
@@ -14,7 +15,6 @@ pub struct GPUQuerySet {
   pub wgpu_query_set: Arc<wgpu_core::resource::QuerySet>,
   pub r#type: GPUQueryType,
   pub count: u32,
-  pub label: String,
 }
 
 impl WebIdlInterfaceConverter for GPUQuerySet {
@@ -38,7 +38,7 @@ impl GPUQuerySet {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_query_set.label().to_string()
   }
   #[setter]
   #[string]

--- a/deno_webgpu/queue.rs
+++ b/deno_webgpu/queue.rs
@@ -12,6 +12,7 @@ use deno_core::v8;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use deno_error::JsErrorBox;
+use wgpu_core::resource::Labeled;
 
 use crate::buffer::GPUBuffer;
 use crate::command_buffer::GPUCommandBuffer;
@@ -23,8 +24,6 @@ use crate::webidl::GPUExtent3D;
 use crate::webidl::GPUOrigin3D;
 
 pub struct GPUQueue {
-  pub label: String,
-
   pub wgpu_queue: Arc<wgpu_core::device::queue::Queue>,
   pub wgpu_device: Arc<wgpu_core::device::Device>,
 }
@@ -46,7 +45,7 @@ impl GPUQueue {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_queue.label().to_string()
   }
   #[setter]
   #[string]

--- a/deno_webgpu/render_pipeline.rs
+++ b/deno_webgpu/render_pipeline.rs
@@ -9,6 +9,7 @@ use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use indexmap::IndexMap;
+use wgpu_core::resource::Labeled;
 
 use crate::bind_group_layout::GPUBindGroupLayout;
 use crate::error::GPUGenericError;
@@ -20,7 +21,6 @@ use crate::webidl::GPUPipelineLayoutOrGPUAutoLayoutMode;
 
 pub struct GPURenderPipeline {
   pub wgpu_render_pipeline: Arc<wgpu_core::pipeline::RenderPipeline>,
-  pub label: String,
 }
 
 impl WebIdlInterfaceConverter for GPURenderPipeline {
@@ -44,7 +44,7 @@ impl GPURenderPipeline {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_render_pipeline.label().to_string()
   }
   #[setter]
   #[string]
@@ -57,10 +57,8 @@ impl GPURenderPipeline {
     let wgpu_bind_group_layout =
       self.wgpu_render_pipeline.get_bind_group_layout(index);
 
-    // TODO(wgpu): needs to add a way to retrieve the label
     GPUBindGroupLayout {
       wgpu_bind_group_layout,
-      label: "".to_string(),
     }
   }
 }

--- a/deno_webgpu/sampler.rs
+++ b/deno_webgpu/sampler.rs
@@ -6,12 +6,12 @@ use deno_core::op2;
 use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
+use wgpu_core::resource::Labeled;
 
 use crate::error::GPUGenericError;
 
 pub struct GPUSampler {
   pub wgpu_sampler: Arc<wgpu_core::resource::Sampler>,
-  pub label: String,
 }
 
 impl WebIdlInterfaceConverter for GPUSampler {
@@ -35,7 +35,7 @@ impl GPUSampler {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_sampler.label().to_string()
   }
   #[setter]
   #[string]

--- a/deno_webgpu/shader.rs
+++ b/deno_webgpu/shader.rs
@@ -8,12 +8,12 @@ use deno_core::v8;
 use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
+use wgpu_core::resource::Labeled;
 
 use crate::error::GPUGenericError;
 
 pub struct GPUShaderModule {
   pub wgpu_shader_module: Arc<wgpu_core::pipeline::ShaderModule>,
-  pub label: String,
   pub compilation_info: v8::Global<v8::Object>,
 }
 
@@ -38,7 +38,7 @@ impl GPUShaderModule {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_shader_module.label().to_string()
   }
   #[setter]
   #[string]

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -150,13 +150,6 @@ impl GPUCanvasContext {
         let texture = GPUTexture {
           wgpu_texture: output.texture.unwrap(),
           default_view: Default::default(),
-          size: wgpu_types::Extent3d {
-            width: *self.width.borrow(),
-            height: *self.height.borrow(),
-            depth_or_array_layers: 1,
-          },
-          mip_level_count: 0,
-          sample_count: 0,
           dimension: crate::texture::GPUTextureDimension::D2,
           format: config.format.clone(),
           usage: config.usage,

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -150,7 +150,6 @@ impl GPUCanvasContext {
         let texture = GPUTexture {
           wgpu_texture: output.texture.unwrap(),
           default_view: Default::default(),
-          label: "".to_string(),
           size: wgpu_types::Extent3d {
             width: *self.width.borrow(),
             height: *self.height.borrow(),

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -8,6 +8,7 @@ use deno_core::webidl::WebIdlInterfaceConverter;
 use deno_core::GarbageCollected;
 use deno_core::WebIDL;
 use deno_error::JsErrorBox;
+use wgpu_core::resource::Labeled;
 use wgpu_core::resource::ParentDevice;
 use wgpu_types::AstcBlock;
 use wgpu_types::AstcChannel;
@@ -45,8 +46,6 @@ pub(crate) struct GPUTextureDescriptor {
 pub struct GPUTexture {
   pub wgpu_texture: Arc<wgpu_core::resource::Texture>,
   pub default_view: OnceLock<Arc<wgpu_core::resource::TextureView>>,
-
-  pub label: String,
 
   pub size: Extent3d,
   pub mip_level_count: u32,
@@ -86,7 +85,7 @@ impl GPUTexture {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_texture.label().to_string()
   }
   #[setter]
   #[string]
@@ -168,10 +167,7 @@ impl GPUTexture {
 
     let wgpu_texture_view = self.wgpu_texture.create_view(&wgpu_descriptor);
 
-    Ok(GPUTextureView {
-      wgpu_texture_view,
-      label: descriptor.label,
-    })
+    Ok(GPUTextureView { wgpu_texture_view })
   }
 }
 
@@ -251,7 +247,6 @@ impl From<GPUTextureAspect> for TextureAspect {
 
 pub struct GPUTextureView {
   pub wgpu_texture_view: Arc<wgpu_core::resource::TextureView>,
-  pub label: String,
 }
 
 impl WebIdlInterfaceConverter for GPUTextureView {
@@ -276,7 +271,7 @@ impl GPUTextureView {
   #[getter]
   #[string]
   fn label(&self) -> String {
-    self.label.clone()
+    self.wgpu_texture_view.label().to_string()
   }
   #[setter]
   #[string]

--- a/deno_webgpu/texture.rs
+++ b/deno_webgpu/texture.rs
@@ -12,7 +12,6 @@ use wgpu_core::resource::Labeled;
 use wgpu_core::resource::ParentDevice;
 use wgpu_types::AstcBlock;
 use wgpu_types::AstcChannel;
-use wgpu_types::Extent3d;
 use wgpu_types::TextureAspect;
 use wgpu_types::TextureDimension;
 use wgpu_types::TextureFormat;
@@ -47,9 +46,6 @@ pub struct GPUTexture {
   pub wgpu_texture: Arc<wgpu_core::resource::Texture>,
   pub default_view: OnceLock<Arc<wgpu_core::resource::TextureView>>,
 
-  pub size: Extent3d,
-  pub mip_level_count: u32,
-  pub sample_count: u32,
   pub dimension: GPUTextureDimension,
   pub format: GPUTextureFormat,
   pub usage: GPUTextureUsageFlags,
@@ -95,23 +91,23 @@ impl GPUTexture {
 
   #[getter]
   fn width(&self) -> u32 {
-    self.size.width
+    self.wgpu_texture.descriptor().size.width
   }
   #[getter]
   fn height(&self) -> u32 {
-    self.size.height
+    self.wgpu_texture.descriptor().size.height
   }
   #[getter]
   fn depth_or_array_layers(&self) -> u32 {
-    self.size.depth_or_array_layers
+    self.wgpu_texture.descriptor().size.depth_or_array_layers
   }
   #[getter]
   fn mip_level_count(&self) -> u32 {
-    self.mip_level_count
+    self.wgpu_texture.descriptor().mip_level_count
   }
   #[getter]
   fn sample_count(&self) -> u32 {
-    self.sample_count
+    self.wgpu_texture.descriptor().sample_count
   }
   #[getter]
   #[string]

--- a/wgpu-types/src/lib.rs
+++ b/wgpu-types/src/lib.rs
@@ -512,6 +512,16 @@ pub enum QueryType {
     PipelineStatistics(PipelineStatisticsTypes),
 }
 
+impl fmt::Display for QueryType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Occlusion => f.write_str("occlusion"),
+            Self::Timestamp => f.write_str("timestamp"),
+            Self::PipelineStatistics(_) => f.write_str("pipeline-statistics"),
+        }
+    }
+}
+
 bitflags::bitflags! {
     /// Flags for which pipeline data should be recorded in a query.
     ///


### PR DESCRIPTION
**Description**
Very similar to what I've done in wgpu before, we now start using metadata from wgc objects directly instead of storing them separately in deno objects.

**Testing**
Just refactor.

**Squash or Rebase?**
Rebase

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
