### PR TITLE
[core] public `*_pipeline_or_error` methods return invalid pipeline on lost device

### DIFF
--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -19,8 +19,8 @@ use smallvec::SmallVec;
 use wgpu_sync::atomic::{AtomicBool, Ordering};
 use wgpu_sync::OnceCell;
 use wgt::{
-    math::align_to, ColorWrites, DeviceLostReason, TextureFormat, TextureSampleType,
-    TextureViewDimension,
+    error::WebGpuError, math::align_to, ColorWrites, DeviceLostReason, TextureFormat,
+    TextureSampleType, TextureViewDimension,
 };
 
 #[cfg(feature = "trace")]
@@ -4326,7 +4326,7 @@ impl Device {
     ) -> Arc<pipeline::ComputePipeline> {
         profiling::scope!("Device::create_compute_pipeline");
         let compute_pipeline = self
-            .create_compute_pipeline_or_error(desc.clone())
+            .create_compute_pipeline_or_error_inner(desc.clone())
             .unwrap_or_else(|err| {
                 if let pipeline::CreateComputePipelineError::Internal(ref error) = err {
                     log::error!(
@@ -4361,9 +4361,24 @@ impl Device {
     }
 
     /// Creates a compute pipeline without raising any error to device.
+    /// Device lost errors will be mapped to invalid compute pipeline
+    /// as required by specification.
     ///
     /// Corresponds to [GPUDevice.createComputePipelineAsync](https://www.w3.org/TR/webgpu/#dom-gpudevice-createcomputepipelineasync)
     pub fn create_compute_pipeline_or_error(
+        self: &Arc<Self>,
+        desc: pipeline::ComputePipelineDescriptor,
+    ) -> Result<Arc<pipeline::ComputePipeline>, pipeline::CreateComputePipelineError> {
+        let label = desc.label.to_string();
+        match self.create_compute_pipeline_or_error_inner(desc) {
+            Err(err) if err.webgpu_error_type() == wgt::error::ErrorType::DeviceLost => {
+                Ok(pipeline::ComputePipeline::invalid(self.clone(), label))
+            }
+            result => result,
+        }
+    }
+
+    fn create_compute_pipeline_or_error_inner(
         self: &Arc<Self>,
         desc: pipeline::ComputePipelineDescriptor,
     ) -> Result<Arc<pipeline::ComputePipeline>, pipeline::CreateComputePipelineError> {
@@ -4523,7 +4538,7 @@ impl Device {
         profiling::scope!("Device::create_render_pipeline");
 
         let render_pipeline = self
-            .create_render_pipeline_or_error(desc.clone())
+            .create_render_pipeline_or_error_inner(desc.clone())
             .unwrap_or_else(|err| {
                 if let pipeline::CreateRenderPipelineError::Internal { stage, ref error } = err {
                     log::error!("Shader translation error for stage {stage:?}: {error}");
@@ -4548,9 +4563,24 @@ impl Device {
     }
 
     /// Creates a render pipeline without raising any error to device.
+    /// Device lost errors will be mapped to invalid render pipeline
+    /// as required by specification.
     ///
     /// Corresponds to [GPUDevice.createRenderPipelineAsync](https://www.w3.org/TR/webgpu/#dom-gpudevice-createrenderpipelineasync)
     pub fn create_render_pipeline_or_error(
+        self: &Arc<Self>,
+        desc: pipeline::ResolvedGeneralRenderPipelineDescriptor,
+    ) -> Result<Arc<pipeline::RenderPipeline>, pipeline::CreateRenderPipelineError> {
+        let label = desc.label.to_string();
+        match self.create_render_pipeline_or_error_inner(desc) {
+            Err(e) if e.webgpu_error_type() == wgt::error::ErrorType::DeviceLost => Ok(
+                pipeline::RenderPipeline::invalid(self.clone(), label.to_string()),
+            ),
+            result => result,
+        }
+    }
+
+    fn create_render_pipeline_or_error_inner(
         self: &Arc<Self>,
         desc: pipeline::ResolvedGeneralRenderPipelineDescriptor,
     ) -> Result<Arc<pipeline::RenderPipeline>, pipeline::CreateRenderPipelineError> {


### PR DESCRIPTION
**Connections**
Fixup https://github.com/gfx-rs/wgpu/pull/10227
Fixup https://github.com/gfx-rs/wgpu/pull/10164

**Description**
This is currently important only in wgc-remote, but it still made sense to implement in wgc to futureproof us.
In device lost case we need to return invalid pipeline as per spec: https://www.w3.org/TR/webgpu/#ref-for-abstract-opdef-invalid%E2%91%A0%E2%91%A4.

**Testing**
None

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
