### PR TITLE
fix(gles): blit to the default back buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
 #### GLES
 
+- Fix black EGL surfaces on some platforms by selecting the default framebuffer's color buffer before presentation. By @valadaptive in [#10268](https://github.com/gfx-rs/wgpu/pull/10268).
 - Avoid duplicate `EGL_SURFACE_TYPE` attributes when selecting an EGL framebuffer configuration, which caused Mesa to return no matching configurations. By @BlueJayLouche and @scroix in [#10048](https://github.com/gfx-rs/wgpu/pull/10048).
 - `@interpolate(linear)` is now rejected by `Device::create_shader_module` on adapters that lack `DownlevelFlags::LINEAR_INTERPOLATION` (GLES/WebGL2), with a shader label and a source span. Previously such a shader validated fine and then failed at pipeline creation with `The selected version doesn't support Features(NOPERSPECTIVE_QUALIFIER)`. By @emilk in [#9972](https://github.com/gfx-rs/wgpu/pull/9972).
 - Fixed signed integer `%` (and `%=`) returning the wrong result for negative operands in the GLSL (OpenGL/GLES) backend, e.g. `-1 % 768` yielding `255` instead of `-1`. GLSL's `%` is undefined when either operand is negative, so signed remainder is now lowered as `a - b * (a / b)`, matching the SPIR-V, HLSL, and Metal backends. By @mstampfli in [#9687](https://github.com/gfx-rs/wgpu/pull/9687).

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1162,6 +1162,7 @@ impl Surface {
         unsafe { gl.color_mask(true, true, true, true) };
 
         unsafe { gl.bind_framebuffer(glow::DRAW_FRAMEBUFFER, None) };
+        unsafe { gl.draw_buffers(&[glow::BACK]) };
         unsafe { gl.bind_framebuffer(glow::READ_FRAMEBUFFER, Some(sc.framebuffer)) };
 
         if !matches!(self.srgb_kind, SrgbFrameBufferKind::None) {


### PR DESCRIPTION
**Connections**

Part of the pile of issues related to GL + Nvidia + Linux (https://github.com/gfx-rs/wgpu/issues/4751, somewhat https://github.com/gfx-rs/wgpu/issues/8675).

**Description**

There are a couple of other hurdles to running the GL backend on Nvidia + Linux + X11 (I need to lower `tier_threshold` and request an OpenGL 4.3 context). Once those are out of the way, I found that the displayed window was always completely black.

This appears to be because the blitting code binds the framebuffer without ever selecting its draw buffer. I'm not sure how this has worked up until now on any platform--maybe most platforms/drivers have already selected the `BACK` buffer automatically by this point?

Explicitly selecting the back buffer fixes the issue and allows things to be drawn properly.

It's hard to find specific info on this, but I believe it's fine to always select `BACK` even in single-buffered mode. The [OpenGL 4.6 spec says:](https://registry.khronos.org/OpenGL/specs/gl/glspec46.core.pdf#page=541)

> If the default framebuffer is affected, then each of the constants must be one of the values listed in table 17.6 or the special value BACK. When BACK is used, n must be 1 and color values are written into the left buffer for single-buffered contexts, or into the back left buffer for double-buffered contexts.

**Testing**

Tested this manually on my machine (Nvidia + Linux + X11). I had to make some other aforementioned changes to get it to actually run (not included in this PR).

**Squash or Rebase?**

Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
