### PR TITLE
fix(webgpu): register uncaptured error handler with addEventListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
 - Recognize `GPUInternalError` when converting a WebGPU error, mapping it to `Error::Internal` instead of panicking with "Unexpected error". By @evilpies in [#9919](https://github.com/gfx-rs/wgpu/pull/9919).
 - Fix `pop_error_scope` panics when it returns `null`. By @beicause in [#10039](https://github.com/gfx-rs/wgpu/pull/10039).
+- Fix `Device::on_uncaptured_error` never firing in browsers that do not implement `GPUDevice.onuncapturederror`, such as Safari, by listening for the `uncapturederror` event instead of assigning to that attribute. By @zemse in [#10270](https://github.com/gfx-rs/wgpu/pull/10270).
 
 ### Performance
 

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -1071,6 +1071,7 @@ fn future_request_device(
                     inner: device,
                     ident: crate::cmp::Identifier::create(),
                     error_scope_count: Rc::new(Cell::new(0)),
+                    uncaptured_error_listener: Rc::new(RefCell::new(None)),
                 }
                 .into(),
                 WebQueue {
@@ -1298,6 +1299,9 @@ pub struct WebDevice {
     ident: crate::cmp::Identifier,
     /// Current number of error scopes that have been pushed on the device.
     error_scope_count: Rc<Cell<u32>>,
+    /// The `uncapturederror` listener currently registered on the device, so
+    /// that setting a new handler can unregister the previous one.
+    uncaptured_error_listener: Rc<RefCell<Option<js_sys::Function>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -2809,8 +2813,27 @@ impl dispatch::DeviceInterface for WebDevice {
             let error = error_from_js(event.error().value_of());
             handler(error);
         }) as Box<dyn FnMut(_)>);
+        let listener: js_sys::Function = f.as_ref().unchecked_ref::<js_sys::Function>().clone();
+
+        // Not every browser implements the `onuncapturederror` attribute
+        // (Safari does not, see <https://bugs.webkit.org/show_bug.cgi?id=323544>),
+        // where assigning to it silently does nothing. The event is dispatched
+        // either way, so listen for it instead.
         self.inner
-            .set_onuncapturederror(Some(f.as_ref().unchecked_ref()));
+            .add_event_listener_with_callback("uncapturederror", &listener)
+            .expect("Adding an event listener should never fail");
+
+        // Setting a handler replaces the previous one, as on the other backends.
+        let previous = self
+            .uncaptured_error_listener
+            .borrow_mut()
+            .replace(listener);
+        if let Some(previous) = previous {
+            self.inner
+                .remove_event_listener_with_callback("uncapturederror", &previous)
+                .expect("Removing an event listener should never fail");
+        }
+
         // Release memory management of this closure from Rust to the JS GC.
         // TODO: This will leak if weak references is not supported.
         f.forget();


### PR DESCRIPTION
**Connections**

Fixes #10269.

**Description**

`Device::on_uncaptured_error` installed its handler by assigning to `GPUDevice.onuncapturederror`. Safari does not implement that event handler attribute, so the assignment created an ordinary expando property that nothing ever called, and the handler was silently dead for every device error. The `uncapturederror` event itself is dispatched there, so this registers with `add_event_listener_with_callback` instead. That also stops wgpu from clobbering, or being clobbered by, an `onuncapturederror` the embedding page set for itself.

`wgpu-core` stores a single `uncaptured_handler` and overwrites it, and the attribute assignment replaced the previous handler too, so `WebDevice` now keeps the registered listener and removes it before adding a new one. Without that, repeated calls would accumulate listeners and all of them would fire, which would be a behavior change rather than a fix.

The closure is still `forget()`ten as before, so the existing leak noted in the `TODO` there is unchanged; only the `js_sys::Function` needed to unregister is retained.

The missing attribute is reported to WebKit as <https://bugs.webkit.org/show_bug.cgi?id=323544>.

**Testing**

No automated coverage: the WebGPU backend's error paths aren't reachable from the test suite, and this is browser-behavior specific.

What I did check:

- `cargo check -p wgpu --target wasm32-unknown-unknown --no-default-features --features webgpu`, plus native `cargo check`, `cargo fmt --check` and `clippy`, all clean.
- The underlying browser behavior is measured, on Safari 26.6 (WebKit 605.1.15) and Chrome 152.0.7977.66 on macOS 26.6. `'onuncapturederror' in device` is `false` in Safari and `true` in Chrome; with both an attribute assignment and an `addEventListener` registration in place, Safari runs only the listener while Chrome runs both. The full reduction is in #10269.

I have not yet run the patched Rust end to end in a browser. Happy to do that and report back before this lands if you'd like it confirmed from the wgpu side rather than the JS reduction.

**Squash or Rebase?**

Single commit.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [x] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works.
