### PR TITLE
[v24][metal] Call [super dealloc] in WgpuObserverLayer dealloc to prevent CAMetalLayer leak

### DIFF
--- a/wgpu-hal/src/metal/layer_observer.rs
+++ b/wgpu-hal/src/metal/layer_observer.rs
@@ -187,4 +187,6 @@ extern "C" fn dealloc(this: &Object, _cmd: Sel) {
             unsafe { msg_send![class!(NSString), stringWithUTF8String: BOUNDS.as_ptr()] };
         let _: () = unsafe { msg_send![root_layer, removeObserver: this forKeyPath: key_path] };
     }
+
+    let _: () = unsafe { msg_send![super(this, class!(CAMetalLayer)), dealloc] };
 }


### PR DESCRIPTION
## Description
In the `wgpu-hal` Metal backend on `v24`, `WgpuObserverLayer` subclasses `CAMetalLayer` via `objc 0.2.7`.
Its `dealloc` implementation deregisters KVO observers from its superlayer, but neglected to invoke `[super dealloc]`.

Because the superclass destructor is omitted:
1. `CAMetalLayer` / `CALayer` / `NSObject` destructors never run.
2. Internal CoreAnimation image queues (`CAImageQueue`), FramePacing structures (`FPCAMetalLayerState`), and `IOSurface` swapchain drawables remain retained indefinitely on the heap.
3. In applications that repeatedly create and destroy compositor surfaces or attach/detach split panes, this causes catastrophic GPU memory accumulation (hundreds of retained observer layers and gigabytes of dirty `IOSurface` framebuffer allocations).

This patch adds `[super(this, class!(CAMetalLayer)), dealloc]` so that the full cleanup chain executes when refcount drops to 0.

## Validation
Verified in isolated lifecycle tests with heap inspection (`/usr/bin/heap`) and memory footprint analysis (`/usr/bin/footprint`):
- **Before**: 50 creation/destruction cycles retain 50 `WgpuObserverLayer`, 50 `WgpuObserverLayer._priv`, 50 `FPCAMetalLayerState`, and 50 `CAImageQueue` instances.
- **After**: All 50 instances are properly deallocated down to zero upon release.