### PR TITLE
Fix doc_comments struct_member indices for undocumented members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
 #### Naga
 
+- Fix `Module::doc_comments`'s `struct_members` keys being off by the number of undocumented members preceding a documented one, so doc comments on struct members were attached to the wrong member. By @atirna in [#10249](https://github.com/gfx-rs/wgpu/issues/10249).
 - Replace embedded NUL characters with `?` when writing debug strings to SPIR-V. By @andyleiserson in [#9904](https://github.com/gfx-rs/wgpu/pull/9904).
 - Fix invalid HLSL generated for `textureSampleLevel` with non-2D textures. By @mvanhorn in [#9717](https://github.com/gfx-rs/wgpu/issues/9717).
 - Reject return types on compute shader entrypoints. By @ErichDonGubler in [#10026](https://github.com/gfx-rs/wgpu/pull/10026).

--- a/naga/src/front/wgsl/lower/mod.rs
+++ b/naga/src/front/wgsl/lower/mod.rs
@@ -4753,6 +4753,8 @@ impl<'source, 'temp> Lowerer<'source, 'temp> {
                 doc_comments.push(Some(
                     member.doc_comments.iter().map(|s| s.to_string()).collect(),
                 ));
+            } else {
+                doc_comments.push(None);
             }
             members.push(ir::StructMember {
                 name: Some(member.name.name.to_owned()),

--- a/naga/tests/in/wgsl/types_with_comments.wgsl
+++ b/naga/tests/in/wgsl/types_with_comments.wgsl
@@ -28,6 +28,22 @@ struct TestS {
     test_m: u32,
 }
 
+/// struct with undocumented member before documented member
+struct TestT {
+    test_m: u32,
+    /// 2nd member doc comment
+    test_m2: u32,
+}
+
+/// struct with undocumented member between documented members
+struct TestU {
+    /// 1st member doc comment
+    test_m: u32,
+    test_m2: u32,
+    /// 3rd member doc comment
+    test_m3: u32,
+}
+
 /// function f doc comment
 fn test_f() {}
 
@@ -39,5 +55,7 @@ fn test_g() {}
 fn test_ep() {
     _ = w_mem2;
     _ = TestS();
+    _ = TestT();
+    _ = TestU();
     test_g();
 }

--- a/naga/tests/out/ir/wgsl-types_with_comments.compact.ron
+++ b/naga/tests/out/ir/wgsl-types_with_comments.compact.ron
@@ -32,6 +32,52 @@
                 span: 4,
             ),
         ),
+        (
+            name: Some("TestT"),
+            inner: Struct(
+                members: [
+                    (
+                        name: Some("test_m"),
+                        ty: 1,
+                        binding: None,
+                        offset: 0,
+                    ),
+                    (
+                        name: Some("test_m2"),
+                        ty: 1,
+                        binding: None,
+                        offset: 4,
+                    ),
+                ],
+                span: 8,
+            ),
+        ),
+        (
+            name: Some("TestU"),
+            inner: Struct(
+                members: [
+                    (
+                        name: Some("test_m"),
+                        ty: 1,
+                        binding: None,
+                        offset: 0,
+                    ),
+                    (
+                        name: Some("test_m2"),
+                        ty: 1,
+                        binding: None,
+                        offset: 4,
+                    ),
+                    (
+                        name: Some("test_m3"),
+                        ty: 1,
+                        binding: None,
+                        offset: 8,
+                    ),
+                ],
+                span: 12,
+            ),
+        ),
     ],
     special_types: (
         ray_desc: None,
@@ -96,10 +142,14 @@
                         pointer: 0,
                     ),
                     ZeroValue(2),
+                    ZeroValue(3),
+                    ZeroValue(4),
                 ],
                 named_expressions: {
                     1: "phony",
                     2: "phony",
+                    3: "phony",
+                    4: "phony",
                 },
                 body: [
                     Emit((
@@ -129,10 +179,25 @@
             2: [
                 "/// struct S doc comment",
             ],
+            3: [
+                "/// struct with undocumented member before documented member",
+            ],
+            4: [
+                "/// struct with undocumented member between documented members",
+            ],
         },
         struct_members: {
             (2, 0): [
                 "/// member doc comment",
+            ],
+            (3, 1): [
+                "/// 2nd member doc comment",
+            ],
+            (4, 0): [
+                "/// 1st member doc comment",
+            ],
+            (4, 2): [
+                "/// 3rd member doc comment",
             ],
         },
         entry_points: {

--- a/naga/tests/out/ir/wgsl-types_with_comments.ron
+++ b/naga/tests/out/ir/wgsl-types_with_comments.ron
@@ -57,6 +57,52 @@
                 span: 4,
             ),
         ),
+        (
+            name: Some("TestT"),
+            inner: Struct(
+                members: [
+                    (
+                        name: Some("test_m"),
+                        ty: 2,
+                        binding: None,
+                        offset: 0,
+                    ),
+                    (
+                        name: Some("test_m2"),
+                        ty: 2,
+                        binding: None,
+                        offset: 4,
+                    ),
+                ],
+                span: 8,
+            ),
+        ),
+        (
+            name: Some("TestU"),
+            inner: Struct(
+                members: [
+                    (
+                        name: Some("test_m"),
+                        ty: 2,
+                        binding: None,
+                        offset: 0,
+                    ),
+                    (
+                        name: Some("test_m2"),
+                        ty: 2,
+                        binding: None,
+                        offset: 4,
+                    ),
+                    (
+                        name: Some("test_m3"),
+                        ty: 2,
+                        binding: None,
+                        offset: 8,
+                    ),
+                ],
+                span: 12,
+            ),
+        ),
     ],
     special_types: (
         ray_desc: None,
@@ -154,10 +200,14 @@
                         pointer: 0,
                     ),
                     ZeroValue(4),
+                    ZeroValue(5),
+                    ZeroValue(6),
                 ],
                 named_expressions: {
                     1: "phony",
                     2: "phony",
+                    3: "phony",
+                    4: "phony",
                 },
                 body: [
                     Emit((
@@ -190,6 +240,12 @@
             4: [
                 "/// struct S doc comment",
             ],
+            5: [
+                "/// struct with undocumented member before documented member",
+            ],
+            6: [
+                "/// struct with undocumented member between documented members",
+            ],
         },
         struct_members: {
             (3, 0): [
@@ -197,6 +253,15 @@
             ],
             (4, 0): [
                 "/// member doc comment",
+            ],
+            (5, 1): [
+                "/// 2nd member doc comment",
+            ],
+            (6, 0): [
+                "/// 1st member doc comment",
+            ],
+            (6, 2): [
+                "/// 3rd member doc comment",
             ],
         },
         entry_points: {


### PR DESCRIPTION
**Connections**

Fixes #10249

**Description**

When a struct member with a doc comment is preceded by members without one, `naga`'s WGSL frontend attached the comment to the wrong `StructMember` index. The `doc_comments` vec built in `r#struct` only got an entry for documented members, so the `enumerate()` over it used the count of documented members as the map key instead of the member's actual position.

For the example in the issue this produced `{([1], 0): ["/// Position of the sun"]}` instead of `{([1], 1): [...]}`.

Now a `None` entry is pushed for undocumented members (the `Option` was already there for exactly this purpose), so indices stay aligned with the real member order. Anyone consuming `module.doc_comments` (codegen, doc extraction) gets comments on the members they were written on.

**Testing**

Extended the existing `types_with_comments` snapshot test with partially documented structs:

- documented member after an undocumented one: key is now the member index (`(handle, 1)`), was `(handle, 0)`
- undocumented member between two documented ones: keys `0` and `2`, no shift for later members

With the fix reverted the regenerated snapshots disagree with the committed ones, so the case fails on unfixed trunk.

- `cargo test -p naga`
- `cargo fmt --check`
- `cargo clippy -p naga --tests`

**Squash or Rebase?**

Squash, please.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [x] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
