### PR TITLE
fix: emit `NeedsInitializedMemory` for `create_external_texture_binding_from_view`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Fixed a deadlock between `Queue::compact_blas` and `Queue::submit`, which acquired `Device::command_indices` and `Queue::pending_writes` in opposite orders. By @mstampfli in [#10118](https://github.com/gfx-rs/wgpu/pull/10118).
 - Fixed some cases of passing object labels to platform APIs despite `InstanceFlags::DISCARD_HAL_LABELS` being set. By @andyleiserson in [#10121](https://github.com/gfx-rs/wgpu/pull/10121) and [#10123](https://github.com/gfx-rs/wgpu/pull/10123).
 - Clean up resources properly when `Device::new` fails, to avoid a leak or panic. By @andyleiserson in [#10160](https://github.com/gfx-rs/wgpu/pull/10160).
+- Fix initialization tracking for `TextureView`s bound to `external_texture` binding points. By @ErichDonGubler in [#10276](https://github.com/gfx-rs/wgpu/pull/10276).
 
 #### naga
 

--- a/tests/tests/wgpu-gpu/external_texture/mod.rs
+++ b/tests/tests/wgpu-gpu/external_texture/mod.rs
@@ -13,6 +13,7 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
         EXTERNAL_TEXTURE_SAMPLE,
         EXTERNAL_TEXTURE_SAMPLE_YUV,
         EXTERNAL_TEXTURE_SAMPLE_TRANSFORM,
+        EXTERNAL_TEXTURE_FROM_VIEW_ZERO_INIT_AFTER_DISCARD,
     ]);
 }
 
@@ -1125,3 +1126,73 @@ static EXTERNAL_TEXTURE_SAMPLE_TRANSFORM: GpuTestConfiguration = GpuTestConfigur
         );
         assert_eq!(&samples, &[RED_F32, GREEN_F32, BLUE_F32, YELLOW_F32]);
     });
+
+/// Tests that a `TextureView` bound to an `external_texture` binding point reads as
+/// zero when the underlying texture is uninitialized.
+///
+/// This path must register the same `NeedsInitializedMemory` init action as the
+/// ordinary sampled-texture path. Without it, nothing clears the texture before the
+/// shader samples plane 0, and the load returns whatever the allocation held.
+///
+/// The texture is cleared to a non-zero sentinel and then discarded, rather than
+/// merely left freshly allocated: discarding returns it to the uninitialized state
+/// while leaving the sentinel in memory, so a missing init action is observable
+/// without relying on the allocator to hand back dirty pages.
+#[apply(gpu_test!)]
+static EXTERNAL_TEXTURE_FROM_VIEW_ZERO_INIT_AFTER_DISCARD: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .features(wgpu::Features::EXTERNAL_TEXTURE),
+        )
+        .run_async(|ctx| async move {
+            let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+                label: None,
+                size: wgpu::Extent3d {
+                    width: 2,
+                    height: 2,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba8Unorm,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            });
+            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+            let mut encoder = ctx
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+            // Store the sentinel, then discard it in a second pass. A single
+            // clear-and-discard pass would let the backend elide the write.
+            for (load, store) in [
+                (wgpu::LoadOp::Clear(wgpu::Color::RED), wgpu::StoreOp::Store),
+                (wgpu::LoadOp::Load, wgpu::StoreOp::Discard),
+            ] {
+                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &view,
+                        depth_slice: None,
+                        resolve_target: None,
+                        ops: wgpu::Operations { load, store },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                    multiview_mask: None,
+                });
+            }
+            ctx.queue.submit(Some(encoder.finish()));
+
+            let loads = get_loads(
+                &ctx,
+                &[[0, 0], [1, 0], [0, 1], [1, 1]],
+                wgpu::BindingResource::TextureView(&view),
+            );
+            assert_eq!(&loads, &[TRANSPARENT_BLACK_F32; 4]);
+        });

--- a/wgpu-core/src/device/resource.rs
+++ b/wgpu-core/src/device/resource.rs
@@ -3608,6 +3608,7 @@ impl Device {
         binding: u32,
         decl: &wgt::BindGroupLayoutEntry,
         view: &'a Arc<TextureView>,
+        texture_init_actions: &mut Vec<TextureInitTrackerAction>,
         used: &mut BindGroupStates,
         snatch_guard: &'a SnatchGuard,
     ) -> Result<
@@ -3653,6 +3654,18 @@ impl Device {
             0,
             NonZeroU64::new(size_of::<ExternalTextureParams>() as u64).unwrap(),
         );
+
+        texture_init_actions.push(TextureInitTrackerAction {
+            texture: view.parent.clone(),
+            range: TextureInitRange {
+                mip_range: view.desc.range.mip_range(view.parent.desc.mip_level_count),
+                layer_range: view
+                    .desc
+                    .range
+                    .layer_range(view.parent.desc.array_layer_count()),
+            },
+            kind: MemoryInitKind::NeedsInitializedMemory,
+        });
 
         Ok(hal::ExternalTextureBinding { planes, params })
     }
@@ -3801,6 +3814,7 @@ impl Device {
                             binding,
                             decl,
                             view,
+                            &mut texture_init_actions,
                             &mut used,
                             &snatch_guard,
                         )?;


### PR DESCRIPTION
**Description**

We had a gap for initialization of textures here that I noticed. Oops!

Recommended review experience is commit-by-commit.

**Testing**

Tested the new test added here as a standalone stack at https://github.com/erichDonGubler-mozilla/wgpu/commit/6dba902, which fails without this fix. Warning: This is mostly AI-generated, with only a light review pass. I might need some correction on that count specifically.

**Squash or Rebase?**

Squash.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [x] ~~(If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.~~ External textures are not exposed in `wgpu`, so this isn't relevant.
- [x] ~~(If applicable) Validation and feature gates are in place to confine behavioral changes.~~ This is a bugfix, so we don't gate anything here.
- [x] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
