### PR TITLE
fix(naga msl-out): typed 64-bit literals in integer div/rem zero guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,7 +174,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Fix a panic in the SPIR-V frontend when a subgroup collective operation (e.g. `OpGroupNonUniformUMin`) or `OpGroupNonUniformBallot` used an argument whose value needed to be spilled to a temporary variable, such as when the argument was computed inside a loop. By @nazar-pc in [#9957](https://github.com/gfx-rs/wgpu/issues/9957).
 - Lower `@builtin(instance_index)` in `@any_hit` and `@closest_hit` entry points to SPIR-V's `InstanceId` rather than `InstanceIndex`, which Vulkan only permits in the vertex stage. By @JMS55 in [10154](https://github.com/gfx-rs/wgpu/pull/10154).
 - Report WGSL type mismatches in `return` statements, function call arguments and composite constructors as WGSL errors naming both types, instead of IR validation errors that could only name the operands by handle index (such as "The \`return\` expression Some([1]) does not match the declared return type Some([1])"). By @emilk in [#9973](https://github.com/gfx-rs/wgpu/pull/9973).
-- Fix ambiguous `metal::select` calls in the Metal backend's division/remainder zero guards for 64-bit integers: the guards now emit `L`/`uL` suffixed literals (e.g. `metal::select(rhs, 1uL, rhs == 0uL)`) so MSL generated for `i64`/`u64` `/` and `%` compiles. By @Statesman-forge in [#PRNUM](https://github.com/gfx-rs/wgpu/pull/PRNUM).
+- Fix ambiguous `metal::select` calls in the Metal backend's division/remainder zero guards for 64-bit integers: the guards now emit `L`/`uL` suffixed literals (e.g. `metal::select(rhs, 1uL, rhs == 0uL)`) so MSL generated for `i64`/`u64` `/` and `%` compiles. By @Statesman-forge in [#10278](https://github.com/gfx-rs/wgpu/pull/10278).
 
 #### Validation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Fix a panic in the SPIR-V frontend when a subgroup collective operation (e.g. `OpGroupNonUniformUMin`) or `OpGroupNonUniformBallot` used an argument whose value needed to be spilled to a temporary variable, such as when the argument was computed inside a loop. By @nazar-pc in [#9957](https://github.com/gfx-rs/wgpu/issues/9957).
 - Lower `@builtin(instance_index)` in `@any_hit` and `@closest_hit` entry points to SPIR-V's `InstanceId` rather than `InstanceIndex`, which Vulkan only permits in the vertex stage. By @JMS55 in [10154](https://github.com/gfx-rs/wgpu/pull/10154).
 - Report WGSL type mismatches in `return` statements, function call arguments and composite constructors as WGSL errors naming both types, instead of IR validation errors that could only name the operands by handle index (such as "The \`return\` expression Some([1]) does not match the declared return type Some([1])"). By @emilk in [#9973](https://github.com/gfx-rs/wgpu/pull/9973).
+- Fix ambiguous `metal::select` calls in the Metal backend's division/remainder zero guards for 64-bit integers: the guards now emit `L`/`uL` suffixed literals (e.g. `metal::select(rhs, 1uL, rhs == 0uL)`) so MSL generated for `i64`/`u64` `/` and `%` compiles. By @Statesman-forge in [#PRNUM](https://github.com/gfx-rs/wgpu/pull/PRNUM).
 
 #### Validation
 

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -5969,9 +5969,11 @@ template <typename A>
                     "{type_name} {DIV_FUNCTION}({type_name} lhs, {type_name} rhs) {{"
                 )?;
                 let level = back::Level(1);
-                // Sub-32-bit types need typed literal wrappers (e.g. `short(1)`)
-                // to avoid ambiguous metal::select overloads. For >= 32-bit,
-                // bare literals like `1`, `-1`, `0` are unambiguous.
+                // The literal operands of `metal::select` must have the same
+                // scalar type as `rhs`, otherwise the call is ambiguous.
+                // Sub-32-bit types need typed literal wrappers (e.g.
+                // `short(1)`), and 64-bit types need suffixed literals (e.g.
+                // `1L` / `1uL`). Bare `1` / `1u` are only correct for 32-bit.
                 let (lp, rp) = if scalar.width < 4 {
                     (format!("{type_name}("), ")".to_string())
                 } else {
@@ -5979,10 +5981,10 @@ template <typename A>
                 };
                 match scalar.kind {
                     crate::ScalarKind::Sint => {
-                        let min_val = match scalar.width {
-                            2 => crate::Literal::I16(i16::MIN),
-                            4 => crate::Literal::I32(i32::MIN),
-                            8 => crate::Literal::I64(i64::MIN),
+                        let (min_val, suffix) = match scalar.width {
+                            2 => (crate::Literal::I16(i16::MIN), ""),
+                            4 => (crate::Literal::I32(i32::MIN), ""),
+                            8 => (crate::Literal::I64(i64::MIN), "L"),
                             _ => {
                                 return Err(Error::GenericValidation(format!(
                                     "Unexpected width for scalar {scalar:?}"
@@ -5991,13 +5993,20 @@ template <typename A>
                         };
                         write!(
                             self.out,
-                            "{level}return lhs / metal::select(rhs, {lp}1{rp}, (lhs == "
+                            "{level}return lhs / metal::select(rhs, {lp}1{suffix}{rp}, (lhs == "
                         )?;
                         self.put_literal(min_val)?;
-                        writeln!(self.out, " & rhs == {lp}-1{rp}) | (rhs == {lp}0{rp}));")?
+                        writeln!(
+                            self.out,
+                            " & rhs == {lp}-1{suffix}{rp}) | (rhs == {lp}0{suffix}{rp}));"
+                        )?
                     }
                     crate::ScalarKind::Uint => {
-                        let suffix = if scalar.width < 4 { "" } else { "u" };
+                        let suffix = match scalar.width {
+                            8 => "uL",
+                            4 => "u",
+                            _ => "",
+                        };
                         writeln!(
                             self.out,
                             "{level}return lhs / metal::select(rhs, {lp}1{suffix}{rp}, rhs == {lp}0{suffix}{rp});"
@@ -6059,6 +6068,9 @@ template <typename A>
                     "{type_name} {MOD_FUNCTION}({type_name} lhs, {type_name} rhs) {{"
                 )?;
                 let level = back::Level(1);
+                // See the corresponding comment in the `Divide` arm above:
+                // `metal::select` literal operands must match `rhs`'s scalar
+                // type exactly to avoid overload ambiguity.
                 let (lp, rp) = if scalar.width < 4 {
                     (format!("{type_name}("), ")".to_string())
                 } else {
@@ -6066,10 +6078,10 @@ template <typename A>
                 };
                 match scalar.kind {
                     crate::ScalarKind::Sint => {
-                        let min_val = match scalar.width {
-                            2 => crate::Literal::I16(i16::MIN),
-                            4 => crate::Literal::I32(i32::MIN),
-                            8 => crate::Literal::I64(i64::MIN),
+                        let (min_val, suffix) = match scalar.width {
+                            2 => (crate::Literal::I16(i16::MIN), ""),
+                            4 => (crate::Literal::I32(i32::MIN), ""),
+                            8 => (crate::Literal::I64(i64::MIN), "L"),
                             _ => {
                                 return Err(Error::GenericValidation(format!(
                                     "Unexpected width for scalar {scalar:?}"
@@ -6078,14 +6090,21 @@ template <typename A>
                         };
                         write!(
                             self.out,
-                            "{level}{rhs_type_name} divisor = metal::select(rhs, {lp}1{rp}, (lhs == "
+                            "{level}{rhs_type_name} divisor = metal::select(rhs, {lp}1{suffix}{rp}, (lhs == "
                         )?;
                         self.put_literal(min_val)?;
-                        writeln!(self.out, " & rhs == {lp}-1{rp}) | (rhs == {lp}0{rp}));")?;
+                        writeln!(
+                            self.out,
+                            " & rhs == {lp}-1{suffix}{rp}) | (rhs == {lp}0{suffix}{rp}));"
+                        )?;
                         writeln!(self.out, "{level}return lhs - (lhs / divisor) * divisor;")?
                     }
                     crate::ScalarKind::Uint => {
-                        let suffix = if scalar.width < 4 { "" } else { "u" };
+                        let suffix = match scalar.width {
+                            8 => "uL",
+                            4 => "u",
+                            _ => "",
+                        };
                         writeln!(
                             self.out,
                             "{level}return lhs % metal::select(rhs, {lp}1{suffix}{rp}, rhs == {lp}0{suffix}{rp});"

--- a/naga/tests/in/wgsl/int64-div.toml
+++ b/naga/tests/in/wgsl/int64-div.toml
@@ -1,0 +1,8 @@
+capabilities = "SHADER_INT64"
+targets = "METAL"
+
+[msl]
+fake_missing_bindings = true
+lang_version = [2, 3]
+spirv_cross_compatibility = false
+zero_initialize_workgroup_memory = true

--- a/naga/tests/in/wgsl/int64-div.wgsl
+++ b/naga/tests/in/wgsl/int64-div.wgsl
@@ -1,0 +1,21 @@
+@group(0) @binding(0) var<storage, read_write> out_u64_: u64;
+@group(0) @binding(1) var<storage, read_write> out_i64_: i64;
+@group(0) @binding(2) var<storage, read_write> out_vec_u64_: vec2<u64>;
+@group(0) @binding(3) var<storage, read_write> out_vec_i64_: vec2<i64>;
+
+@compute @workgroup_size(1)
+fn main() {
+    let a: u64 = 10lu;
+    let b: u64 = 3lu;
+    let c: i64 = -10li;
+    let d: i64 = 3li;
+    out_u64_ = (a / b) + (a % b);
+    out_i64_ = (c / d) + (c % d);
+
+    let va = vec2<u64>(a);
+    let vb = vec2<u64>(b);
+    let vc = vec2<i64>(c);
+    let vd = vec2<i64>(d);
+    out_vec_u64_ = (va / vb) + (va % vb);
+    out_vec_i64_ = (vc / vd) + (vc % vd);
+}

--- a/naga/tests/out/msl/wgsl-int64-div.metal
+++ b/naga/tests/out/msl/wgsl-int64-div.metal
@@ -1,0 +1,57 @@
+// language: metal2.3
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+
+ulong naga_div(ulong lhs, ulong rhs) {
+    return lhs / metal::select(rhs, 1uL, rhs == 0uL);
+}
+
+ulong naga_mod(ulong lhs, ulong rhs) {
+    return lhs % metal::select(rhs, 1uL, rhs == 0uL);
+}
+
+long naga_div(long lhs, long rhs) {
+    return lhs / metal::select(rhs, 1L, (lhs == (-9223372036854775807L - 1L) & rhs == -1L) | (rhs == 0L));
+}
+
+long naga_mod(long lhs, long rhs) {
+    long divisor = metal::select(rhs, 1L, (lhs == (-9223372036854775807L - 1L) & rhs == -1L) | (rhs == 0L));
+    return lhs - (lhs / divisor) * divisor;
+}
+
+metal::ulong2 naga_div(metal::ulong2 lhs, metal::ulong2 rhs) {
+    return lhs / metal::select(rhs, 1uL, rhs == 0uL);
+}
+
+metal::ulong2 naga_mod(metal::ulong2 lhs, metal::ulong2 rhs) {
+    return lhs % metal::select(rhs, 1uL, rhs == 0uL);
+}
+
+metal::long2 naga_div(metal::long2 lhs, metal::long2 rhs) {
+    return lhs / metal::select(rhs, 1L, (lhs == (-9223372036854775807L - 1L) & rhs == -1L) | (rhs == 0L));
+}
+
+metal::long2 naga_mod(metal::long2 lhs, metal::long2 rhs) {
+    metal::long2 divisor = metal::select(rhs, 1L, (lhs == (-9223372036854775807L - 1L) & rhs == -1L) | (rhs == 0L));
+    return lhs - (lhs / divisor) * divisor;
+}
+
+
+[[max_total_threads_per_threadgroup(1)]] kernel void main_(
+  device ulong& out_u64_ [[user(fake0)]]
+, device long& out_i64_ [[user(fake0)]]
+, device metal::ulong2& out_vec_u64_ [[user(fake0)]]
+, device metal::long2& out_vec_i64_ [[user(fake0)]]
+) {
+    out_u64_ = naga_div(10uL, 3uL) + naga_mod(10uL, 3uL);
+    out_i64_ = as_type<long>(as_type<ulong>(naga_div(-10L, 3L)) + as_type<ulong>(naga_mod(-10L, 3L)));
+    metal::ulong2 va = metal::ulong2(10uL);
+    metal::ulong2 vb = metal::ulong2(3uL);
+    metal::long2 vc = metal::long2(-10L);
+    metal::long2 vd = metal::long2(3L);
+    out_vec_u64_ = naga_div(va, vb) + naga_mod(va, vb);
+    out_vec_i64_ = as_type<metal::long2>(as_type<metal::ulong2>(naga_div(vc, vd)) + as_type<metal::ulong2>(naga_mod(vc, vd)));
+    return;
+}


### PR DESCRIPTION
# [naga msl-out] Fix ambiguous `metal::select` in 64-bit int div/rem guards

**Connections**
Fixes #10277.

**Description**

The MSL backend's division/remainder zero guards (`naga_div`/`naga_mod` in `write_wrapped_binary_op`) emitted 32-bit literals (`1`, `-1`, `0`, `1u`, `0u`) as the `metal::select` replacement value and comparison operands for all widths >= 4. For `long`/`ulong` operands this makes the call ambiguous — `metal::select` has an overload for every integer scalar type, no overload exactly matches `(ulong, uint, bool)`, and the integral conversions are implicit in both directions — so MSL generated for `i64`/`u64` `/` and `%` fails to compile with `call to 'select' is ambiguous`.

This PR emits `L`/`uL` suffixed literals for 64-bit operands, matching what `put_literal` already does for `Literal::I64`/`Literal::U64`. Before/after for the u64 helper:

```cpp
// before
return lhs / metal::select(rhs, 1u, rhs == 0u);
// after
return lhs / metal::select(rhs, 1uL, rhs == 0uL);
```

Sub-32-bit types already had typed wrappers (`short(1)` etc.) and are unchanged; 32-bit output is unchanged.

**Testing**

- New `int64-div` snapshot test (scalar and `vec2` `i64`/`u64` division and remainder, METAL target with `SHADER_INT64`); the new `wgsl-int64-div.metal` snapshot shows correctly typed guards.
- `cargo test -p naga --test naga`: 229 passed, 0 failed (trunk 9920c99).
- Compiled the snapshot with Apple's Metal compiler (`xcrun metal -c`, macOS 26 SDK): trunk's output for the same WGSL fails with `call to 'select' is ambiguous` (×3); the patched output compiles.

**Squash or Rebase?**

Squash.

**Checklist**

- [x] Run `cargo fmt`.
- [ ] Run `taplo format`.
- [x] Run `cargo clippy --tests` (no new warnings; a few pre-existing ones from a newer clippy than the pinned toolchain).
- [x] Run `cargo test`.
- [x] Add change to `CHANGELOG.md` (note: the entry's `@yourslug` / PR number placeholders need to be filled in before submitting).
