### PR TITLE
feat(types): add `serde` integration to `Compilation*` APIs

### DIFF
--- a/wgpu-types/src/compilation_info.rs
+++ b/wgpu-types/src/compilation_info.rs
@@ -1,11 +1,15 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 
+#[cfg(any(feature = "serde", test))]
+use serde::{Deserialize, Serialize};
+
 /// Compilation information for a shader module.
 ///
 /// Corresponds to [WebGPU `GPUCompilationInfo`](https://gpuweb.github.io/gpuweb/#gpucompilationinfo).
 /// The source locations use bytes, and index a UTF-8 encoded string.
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CompilationInfo {
     /// The messages from the shader compilation process.
     pub messages: Vec<CompilationMessage>,
@@ -16,6 +20,7 @@ pub struct CompilationInfo {
 /// Roughly corresponds to [`GPUCompilationMessage`](https://www.w3.org/TR/webgpu/#gpucompilationmessage),
 /// except that the location uses UTF-8 for all positions.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CompilationMessage {
     /// The text of the message.
     pub message: String,
@@ -27,6 +32,7 @@ pub struct CompilationMessage {
 
 /// The type of a compilation message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CompilationMessageType {
     /// An error message.
     Error,
@@ -45,6 +51,7 @@ pub enum CompilationMessageType {
 ///
 /// [gcm]: https://www.w3.org/TR/webgpu/#gpucompilationmessage
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SourceLocation {
     /// 1-based line number.
     pub line_number: u32,


### PR DESCRIPTION
**Connections**

- Firefox would like to use these, because we use `serde` for moving data over IPC between GPU and content process(es).

**Description**

Implement `serde::{Deserialize, Serialize}` for:

- `CompilationMessage`
- `CompilationMessageType`
- `CompilationInfo`

This seemed like an omission for a recently introduced API, rather than something intentional.

**Testing**

I've been consuming these changes locally for a revendor of wgpu into Firefox, and they seem to work as intended. This isn't really error-prone, so I didn't consider explicit tests necessary.

**Squash or Rebase?**

skoosh


**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] ~~`CHANGELOG.md` entries for the user-facing effects of this change are present.~~ These APIs haven't been released yet, so none needed. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [x] ~~(If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.~~
- [x] ~~(If applicable) Validation and feature gates are in place to confine behavioral changes.~~
- [x] ~~(If applicable) Tests demonstrate the validation and altered logic works.~~ <!-- See `docs/testing.md` -->
