### PR TITLE
fix(metal): Disable framebuffer-only for alternate surface views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Fix bind group resources for the task, mesh, fragment, and compute shader stages being bound from the wrong offsets whenever a bind group contained resources visible to the task or mesh stages, which could bind the wrong buffer, texture, or sampler to a shader slot. By @teoxoy in [#10043](https://github.com/gfx-rs/wgpu/issues/10043).
 - BREAKING: Advertise `CompositeAlphaMode::PreMultiplied` instead of `PostMultiplied`, matching the premultiplied alpha compositing that Core Animation actually performs for a non-opaque `CAMetalLayer`. By @nicoburns in [#9922](https://github.com/gfx-rs/wgpu/pull/9922).
   - If you previously hard-coded `PostMultiplied` to get a transparent macOS window, you will start receiving `UnsupportedAlphaMode` validation errors for this. Those affected should migrate to `PreMultiplied` instead.
+- Fix a crash when creating a declared alternate sRGB view of a render-attachment-only surface with Metal API Validation enabled. By @jinleili in [#10280](https://github.com/gfx-rs/wgpu/pull/10280).
 
 #### GLES
 

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -257,7 +257,12 @@ impl crate::Surface for super::Surface {
         *self.extent.write() = config.extent;
 
         let render_layer = self.render_layer.lock();
-        let framebuffer_only = config.usage == wgt::TextureUses::COLOR_TARGET;
+        // Metal forbids creating alternate-format views of framebuffer-only textures.
+        let framebuffer_only = config.usage == wgt::TextureUses::COLOR_TARGET
+            && config
+                .view_formats
+                .iter()
+                .all(|format| *format == config.format);
         let display_sync = match config.present_mode {
             wgt::PresentMode::Fifo => true,
             wgt::PresentMode::Immediate => false,


### PR DESCRIPTION
**Connections**

Fixes #9954.

**Description**

Creating a declared `Bgra8UnormSrgb` view of a `Bgra8Unorm` surface configured with only `RENDER_ATTACHMENT` aborts with Metal API Validation enabled:

> texture view creation not allowed from frameBufferOnly textures.

The Metal backend currently determines `framebufferOnly` from usage alone, without accounting for declared view formats.

Only enable `framebufferOnly` when the surface is used exclusively as a render target and no alternate view formats are declared. Empty view-format lists and declarations containing only the base format retain the existing optimization.

**Testing**

Tested locally on Apple M1 Max / macOS 26.6.2 using a separate native winit harness, not included in this PR.

With `MTL_DEBUG_LAYER=1`:
- The original reproducer passed three consecutive runs.
- Ten surface cases passed, covering alternate views in both directions, empty and redundant format declarations, reconfiguration, resize, and expected validation errors.
- Verified the actual layer property switches from `true` to `false` and back after reconfiguration.
- Alternate-view, reference, and resize rendering each completed 300 frames. The alternate sRGB view and sRGB surface reference produced identical captured content pixels.

Additional checks:
- `cargo fmt -p wgpu-hal --check`
- `cargo clippy -p wgpu-hal --features metal --tests`
- `WGPU_BACKEND=metal cargo xtask test -p wgpu-hal`: 13 passed.
- `cargo xtask cts --backend metal 'webgpu:api,validation,createView:format:*'`: 30 passed, 6 skipped due to unavailable features, 0 failed.