### PR TITLE
feat(types): mark `CompilationMessageType` as `repr(u8)`

### DIFF
--- a/wgpu-types/src/compilation_info.rs
+++ b/wgpu-types/src/compilation_info.rs
@@ -33,6 +33,7 @@ pub struct CompilationMessage {
 /// The type of a compilation message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(u8)]
 pub enum CompilationMessageType {
     /// An error message.
     Error,


### PR DESCRIPTION
**Connections**

- Firefox wants this to avoid needing a manual FFI interface by using `cbindgen` through this.

**Description**

\-

**Testing**

Not worth adding a test; it compiles, and it works downstream.

**Squash or Rebase?**

Squash.

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] ~~`CHANGELOG.md` entries for the user-facing effects of this change are present.~~ This type is not yet released, so it's not  <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [x] ~~(If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.~~
- [x] ~~(If applicable) Validation and feature gates are in place to confine behavioral changes.~~
- [x] ~~(If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md`~~ -->
