### PR TITLE
test: Reduce the texture height in clear_texture tests

### DIFF
--- a/tests/tests/wgpu-gpu/clear_texture.rs
+++ b/tests/tests/wgpu-gpu/clear_texture.rs
@@ -275,7 +275,7 @@ async fn clear_texture_tests(ctx: TestingContext, formats: &'static [wgpu::Textu
     for &format in formats {
         let (block_width, block_height) = format.block_dimensions();
         let rounded_width = block_width * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
-        let rounded_height = block_height * wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let rounded_height = block_height * 4;
 
         let is_compressed_or_depth_stencil_format =
             format.is_compressed() || format.is_depth_stencil_format();


### PR DESCRIPTION
An attempt at fixing CI timeouts like https://github.com/gfx-rs/wgpu/actions/runs/34277064747/job/102232586397

The BC tests (as in the above failure) could use 1024 x 1024 x 16. ASTC tests could be as much as 3072 x 3072 x 16. The Windows runners are supposed to have 16 GB of memory, so it doesn't seem like that should really reach OOM, but it also doesn't seem necessary to use textures of this size, so, let's reduce it and see if that helps. (The failures are relatively uncommon, so we'll need a fair amount of soak time to conclude anything.)

**Squash or Rebase?** Squash

