### PR TITLE
fix(metal): Explicitly set sRGB surface color space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - BREAKING: Advertise `CompositeAlphaMode::PreMultiplied` instead of `PostMultiplied`, matching the premultiplied alpha compositing that Core Animation actually performs for a non-opaque `CAMetalLayer`. By @nicoburns in [#9922](https://github.com/gfx-rs/wgpu/pull/9922).
   - If you previously hard-coded `PostMultiplied` to get a transparent macOS window, you will start receiving `UnsupportedAlphaMode` validation errors for this. Those affected should migrate to `PreMultiplied` instead.
 - Fix a crash when creating a declared alternate sRGB view of a render-attachment-only surface with Metal API Validation enabled. By @jinleili in [#10280](https://github.com/gfx-rs/wgpu/pull/10280).
+- Fix oversaturated sRGB surface colors on wide-gamut displays by explicitly setting the layer's sRGB color space. By @jinleili in [#10286](https://github.com/gfx-rs/wgpu/pull/10286).
 
 #### GLES
 

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -292,8 +292,7 @@ impl crate::Surface for super::Surface {
             wgt::SurfaceColorSpace::Auto => {
                 unreachable!("wgpu-core resolves `Auto` before configuring the surface")
             }
-            // Reset to the layer's default, which treats contents as sRGB.
-            wgt::SurfaceColorSpace::Srgb => None,
+            wgt::SurfaceColorSpace::Srgb => Some(unsafe { objc2_core_graphics::kCGColorSpaceSRGB }),
             wgt::SurfaceColorSpace::ExtendedSrgbLinear => {
                 Some(unsafe { objc2_core_graphics::kCGColorSpaceExtendedLinearSRGB })
             }


### PR DESCRIPTION
**Connections**

Fixes #10013.

**Description**

`SurfaceColorSpace::Srgb` currently sets `CAMetalLayer.colorspace` to `nil`, leaving the rendered content unmanaged. On wide-gamut displays, this causes sRGB content to appear oversaturated. Ordinary 8-bit surfaces configured with `Auto` are also affected because `Auto` resolves to `Srgb`.

Explicitly use `kCGColorSpaceSRGB` so Core Animation can color-match the surface contents to the display. Remove the incorrect comment claiming that the layer's default treats contents as sRGB.

This changes the presentation color-space declaration, not the texture's sRGB encoding behavior.

**Testing**

Tested on Apple M1 Max / macOS 26.6.2 with the built-in display and `MTL_DEBUG_LAYER=1`.

[Native wgpu test harness](https://github.com/jinleili/wgpu-in-app/blob/81ab15f6353cbf1722e486fd37dbf8232ab996c3/wgpu-in-app/examples/issue_10013.rs)

- Confirmed that the original implementation leaves the actual layer color space unset.
- Five scenarios each completed 240 frames: explicit sRGB, Auto, an sRGB texture format, Display-P3/sRGB reconfiguration, and resize.
- Inspected the actual layer color space during reconfiguration.
- All four sampled color patches matched an explicitly sRGB-tagged CGImage reference after the fix.
- Formatting and Clippy checks passed.
- HAL tests: 13 passed.
- Core surface-configuration tests: 8 passed.
- Canvas CTS: both selected cases were skipped because the local Deno runner cannot create a Canvas.

The before/after screenshots were captured on the same display and contain identical embedded ICC profiles. Before the fix, the captured values remain the raw source RGB values; after the fix, they match the color-managed reference.

before | after
-- | --
<img width="260" height="232" alt="before" src="https://github.com/user-attachments/assets/92a7ca23-2cf9-4131-87e4-089cc97b8439" /> |  <img width="260" height="232" alt="after" src="https://github.com/user-attachments/assets/6f72576c-a94d-420c-936e-7c71bb58356a" />


**Squash or Rebase?**

Squash.