### PR TITLE
[metal] advertise extended vertex formats and acceleration structure binding arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Fix crash on fence creation when running in a MacOS Seatbelt sandbox. By @wumpf in [#9415](https://github.com/gfx-rs/wgpu/pull/9415)
 - Fixed structure field names incorrectly ignoring reserved keywords in the Metal (MSL) backend. By @39ali [#9379](https://github.com/gfx-rs/wgpu/pull/9379).
 - Restore the `Queue::as_raw` method, which was removed without good reason in v29. It now returns `&ProtocolObject<dyn MTLCommandQueue>`. By @andyleiserson in [#9560](https://github.com/gfx-rs/wgpu/pull/9560).
+- Fixed missing synchronization between acceleration structure builds, which could cause TLAS builds to consume BLASes that were still building, producing incorrect intersection results or GPU hangs. By @jtbirdsell in [#9645](https://github.com/gfx-rs/wgpu/pull/9645).
 
 ### Dependency Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Unconditionally enable `Features::CLIP_DISTANCES`. By @ErichDonGubler in [#9270](https://github.com/gfx-rs/wgpu/pull/9270).
 - Added full support for mesh shaders, including in WGSL shaders. By @inner-daemons in [#8739](https://github.com/gfx-rs/wgpu/pull/8739).
 - Advertise `Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS`: Metal's geometry descriptors accept any `MTLAttributeFormat`, so `Float16x4`/`Snorm16x4`/`Float16x2`/`Snorm16x2`/`Float32x2` BLAS vertex formats work alongside `Float32x3`. Vertex strides are validated against the format size on Metal (which requires more than wgpu's cross-API minimum).
+- Advertise `Features::ACCELERATION_STRUCTURE_BINDING_ARRAY`: `binding_array<acceleration_structure>` is emitted as a `NagaArgumentBufferWrapper<instance_acceleration_structure>*` buffer binding and encoded through an `MTLArgumentEncoder` at bind group creation. `max_acceleration_structures_per_shader_stage` is now 8 (one buffer binding point each) and binding array limits are reported when ray tracing is supported.
 
 #### GLES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 - Unconditionally enable `Features::CLIP_DISTANCES`. By @ErichDonGubler in [#9270](https://github.com/gfx-rs/wgpu/pull/9270).
 - Added full support for mesh shaders, including in WGSL shaders. By @inner-daemons in [#8739](https://github.com/gfx-rs/wgpu/pull/8739).
+- Advertise `Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS`: Metal's geometry descriptors accept any `MTLAttributeFormat`, so `Float16x4`/`Snorm16x4`/`Float16x2`/`Snorm16x2`/`Float32x2` BLAS vertex formats work alongside `Float32x3`. Vertex strides are validated against the format size on Metal (which requires more than wgpu's cross-API minimum).
 
 #### GLES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,8 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 #### Metal
 
+- Wake Metal completion waits from native completed handlers instead of polling at one-millisecond intervals.
+- Order Metal acceleration-structure builds and ray-query passes with encoder fences, without serializing unrelated later submissions. Reserve native command-buffer capacity for internal submissions and report ray-query fence allocation failure during fallible encoder setup.
 - Fix crash on fence creation when running in a MacOS Seatbelt sandbox. By @wumpf in [#9415](https://github.com/gfx-rs/wgpu/pull/9415)
 - Fixed structure field names incorrectly ignoring reserved keywords in the Metal (MSL) backend. By @39ali [#9379](https://github.com/gfx-rs/wgpu/pull/9379).
 - Restore the `Queue::as_raw` method, which was removed without good reason in v29. It now returns `&ProtocolObject<dyn MTLCommandQueue>`. By @andyleiserson in [#9560](https://github.com/gfx-rs/wgpu/pull/9560).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,8 +138,8 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 - Unconditionally enable `Features::CLIP_DISTANCES`. By @ErichDonGubler in [#9270](https://github.com/gfx-rs/wgpu/pull/9270).
 - Added full support for mesh shaders, including in WGSL shaders. By @inner-daemons in [#8739](https://github.com/gfx-rs/wgpu/pull/8739).
-- Advertise `Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS`: Metal's geometry descriptors accept any `MTLAttributeFormat`, so `Float16x4`/`Snorm16x4`/`Float16x2`/`Snorm16x2`/`Float32x2` BLAS vertex formats work alongside `Float32x3`. Vertex strides are validated against the format size on Metal (which requires more than wgpu's cross-API minimum).
-- Advertise `Features::ACCELERATION_STRUCTURE_BINDING_ARRAY`: `binding_array<acceleration_structure>` is emitted as a `NagaArgumentBufferWrapper<instance_acceleration_structure>*` buffer binding and encoded through an `MTLArgumentEncoder` at bind group creation. `max_acceleration_structures_per_shader_stage` is now 8 (one buffer binding point each) and binding array limits are reported when ray tracing is supported.
+- Advertise `Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS`: Metal's geometry descriptors accept any `MTLAttributeFormat`, so `Float16x4`/`Snorm16x4`/`Float16x2`/`Snorm16x2`/`Float32x2` BLAS vertex formats work alongside `Float32x3`. Vertex strides are validated against the format size on Metal (which requires more than wgpu's cross-API minimum). By @acoliver in [#10289](https://github.com/gfx-rs/wgpu/pull/10289).
+- Advertise `Features::ACCELERATION_STRUCTURE_BINDING_ARRAY`: `binding_array<acceleration_structure>` is emitted as a `NagaArgumentBufferWrapper<instance_acceleration_structure>*` buffer binding and encoded through an `MTLArgumentEncoder` at bind group creation. `max_acceleration_structures_per_shader_stage` is now 8 (one buffer binding point each) and binding array limits are reported when ray tracing is supported. By @acoliver in [#10289](https://github.com/gfx-rs/wgpu/pull/10289).
 
 #### GLES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 #### naga
 
 - Fix SPIR-V ray-query helper caching so termination cannot replace the Boolean proceed function.
+- Reject non-uniform indexing of acceleration structure binding arrays unless the `ACCELERATION_STRUCTURE_BINDING_ARRAY` capability is enabled, instead of panicking.
 - Fixed atomic load and store operations being incorrectly generated as non-atomic memory accesses in GLSL and HLSL. By @CldStlkr in [#9242](https://github.com/gfx-rs/wgpu/pull/9242).
 - Fixed overflow detection and argument domain validation for `acosh`, `length`, `normalize`, and `pow` in constant evaluation. By @ecoricemon in [#9249](https://github.com/gfx-rs/wgpu/pull/9249).
 - Naga no longer allows derivative operations on `f16`. WGSL does not currently allow this, although [it may be added in the future](https://github.com/gpuweb/gpuweb/issues/5482). By @andyleiserson in [#9154](https://github.com/gfx-rs/wgpu/pull/9154).
@@ -244,8 +245,8 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 - Wake Metal completion waits from native completed handlers instead of polling at one-millisecond intervals.
 - Order Metal acceleration-structure builds and ray-query passes with encoder fences, without serializing unrelated later submissions. Reserve native command-buffer capacity for internal submissions and report ray-query fence allocation failure during fallible encoder setup.
--Respect row-major BLAS transforms and the no-duplicate-intersection flag. Ray queries require tvOS 18.1 or visionOS 2.1; macOS 15 and iOS 18 requirements are unchanged.
--Lower ray-query face and geometry culling flags in MSL, and protect invalid query initialization and traversal operations.
+- Respect row-major BLAS transforms and the no-duplicate-intersection flag. Ray queries require tvOS 18.1 or visionOS 2.1; macOS 15 and iOS 18 requirements are unchanged.
+- Lower ray-query face and geometry culling flags in MSL, and protect invalid query initialization and traversal operations.
 - Fix crash on fence creation when running in a MacOS Seatbelt sandbox. By @wumpf in [#9415](https://github.com/gfx-rs/wgpu/pull/9415)
 - Fixed structure field names incorrectly ignoring reserved keywords in the Metal (MSL) backend. By @39ali [#9379](https://github.com/gfx-rs/wgpu/pull/9379).
 - Restore the `Queue::as_raw` method, which was removed without good reason in v29. It now returns `&ProtocolObject<dyn MTLCommandQueue>`. By @andyleiserson in [#9560](https://github.com/gfx-rs/wgpu/pull/9560).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 #### naga
 
+- Fix SPIR-V ray-query helper caching so termination cannot replace the Boolean proceed function.
 - Fixed atomic load and store operations being incorrectly generated as non-atomic memory accesses in GLSL and HLSL. By @CldStlkr in [#9242](https://github.com/gfx-rs/wgpu/pull/9242).
 - Fixed overflow detection and argument domain validation for `acosh`, `length`, `normalize`, and `pow` in constant evaluation. By @ecoricemon in [#9249](https://github.com/gfx-rs/wgpu/pull/9249).
 - Naga no longer allows derivative operations on `f16`. WGSL does not currently allow this, although [it may be added in the future](https://github.com/gpuweb/gpuweb/issues/5482). By @andyleiserson in [#9154](https://github.com/gfx-rs/wgpu/pull/9154).
@@ -243,6 +244,8 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 - Wake Metal completion waits from native completed handlers instead of polling at one-millisecond intervals.
 - Order Metal acceleration-structure builds and ray-query passes with encoder fences, without serializing unrelated later submissions. Reserve native command-buffer capacity for internal submissions and report ray-query fence allocation failure during fallible encoder setup.
+-Respect row-major BLAS transforms and the no-duplicate-intersection flag. Ray queries require tvOS 18.1 or visionOS 2.1; macOS 15 and iOS 18 requirements are unchanged.
+-Lower ray-query face and geometry culling flags in MSL, and protect invalid query initialization and traversal operations.
 - Fix crash on fence creation when running in a MacOS Seatbelt sandbox. By @wumpf in [#9415](https://github.com/gfx-rs/wgpu/pull/9415)
 - Fixed structure field names incorrectly ignoring reserved keywords in the Metal (MSL) backend. By @39ali [#9379](https://github.com/gfx-rs/wgpu/pull/9379).
 - Restore the `Queue::as_raw` method, which was removed without good reason in v29. It now returns `&ProtocolObject<dyn MTLCommandQueue>`. By @andyleiserson in [#9560](https://github.com/gfx-rs/wgpu/pull/9560).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,6 +238,7 @@ objc2-metal = { version = "0.3.2", default-features = false, features = [
     "MTLDevice",
     "MTLDrawable",
     "MTLEvent",
+    "MTLFence",
     "MTLLibrary",
     "MTLPipeline",
     "MTLPixelFormat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,6 +222,8 @@ objc2-metal = { version = "0.3.2", default-features = false, features = [
     "std",
     "block2",
     "MTLAllocation",
+    "MTLArgument",
+    "MTLArgumentEncoder",
     "MTLBlitCommandEncoder",
     "MTLBlitPass",
     "MTLBuffer",

--- a/naga/src/back/msl/mod.rs
+++ b/naga/src/back/msl/mod.rs
@@ -902,6 +902,7 @@ pub fn supported_capabilities() -> crate::valid::Capabilities {
         // No EARLY_DEPTH_TEST
         | Caps::MULTISAMPLED_SHADING
         | Caps::RAY_QUERY
+        | Caps::ACCELERATION_STRUCTURE_BINDING_ARRAY
         | Caps::DUAL_SOURCE_BLENDING
         | Caps::CUBE_ARRAY_TEXTURES
         | Caps::SHADER_INT64

--- a/naga/src/back/msl/ray.rs
+++ b/naga/src/back/msl/ray.rs
@@ -23,9 +23,61 @@ pub(super) fn metal_intersector_ty() -> String {
     format!("{RT_NAMESPACE}::intersection_query<{RT_NAMESPACE}::instancing, {RT_NAMESPACE}::triangle_data>")
 }
 
+pub(super) const QUERY_TYPE: &str = "NagaRayQuery";
+
 pub(super) const INTERSECTION_FUNCTION_NAME: &str = "ray_query_get_intersection";
 
 impl<W: Write> Writer<W> {
+    pub(super) fn write_ray_query_type(&mut self) -> BackendResult {
+        // MSL 6.19.5 requires reset before traversal and a live candidate for
+        // candidate operations. Keep state with the query so pointer aliases agree.
+        writeln!(self.out, "struct {QUERY_TYPE} {{")?;
+        writeln!(self.out, "    thread {}& query;", metal_intersector_ty())?;
+        self.out.write_str(
+            r#"    bool initialized = false;
+    bool candidate = false;
+    bool finished = false;
+    float tmin = 0.0;
+    float tmax = 0.0;
+
+    bool next() thread {
+        if (!initialized || finished) return false;
+        candidate = query.next();
+        finished = !candidate;
+        return candidate;
+    }
+
+    void abort() thread {
+        if (candidate) {
+            query.abort();
+            candidate = false;
+            finished = true;
+        }
+    }
+
+    void commit_triangle_intersection() thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::triangle) {
+            query.commit_triangle_intersection();
+        }
+    }
+
+    void commit_bounding_box_intersection(float distance) thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::bounding_box) {
+            float closest = tmax;
+            if (query.get_committed_intersection_type() != metal::raytracing::intersection_type::none) {
+                closest = query.get_committed_distance();
+            }
+            if ((as_type<uint>(distance) & 0x7fffffffu) <= 0x7f800000u && distance >= tmin && distance <= closest) {
+                query.commit_bounding_box_intersection(distance);
+            }
+        }
+    }
+};
+"#
+        )?;
+        Ok(())
+    }
+
     /// Writes a function to get the current intersection from the ray query
     ///
     /// Like other backends, this is needed to have a single branch for constructing
@@ -55,14 +107,20 @@ impl<W: Write> Writer<W> {
         let level = back::Level(1);
         writeln!(
             self.out,
-            "{intersection} {INTERSECTION_FUNCTION_NAME}_{committed}({} intersector) {{",
-            metal_intersector_ty()
+            "{intersection} {INTERSECTION_FUNCTION_NAME}_{committed}(thread {QUERY_TYPE}& rq) {{"
         )?;
         // Initialize the intersection to its default values (which should be zero).
         writeln!(
             self.out,
             "{level}{intersection} intersection = {intersection} {{}};"
         )?;
+        let available = if committed {
+            "rq.finished"
+        } else {
+            "rq.candidate"
+        };
+        writeln!(self.out, "{level}if (!{available}) return intersection;")?;
+        writeln!(self.out, "{level}thread auto& intersector = rq.query;")?;
         writeln!(self.out, "{level}{RT_NAMESPACE}::intersection_type ty = intersector.get_{ty}_intersection_type();")?;
         // If the ray hit a triangle, call all methods that require that and set the intersection type.
         writeln!(
@@ -152,14 +210,11 @@ impl<W: Write> Writer<W> {
             return Err(Error::UnsupportedRayTracing);
         }
 
-        // TODO: check for misuse.
         match *fun {
             crate::RayQueryFunction::Initialize {
                 acceleration_structure,
                 descriptor,
             } => {
-                //TODO: how to deal with winding? Is it by default the same as the other APIs?
-
                 // Put everything in a block so that the variable names
                 // do not conflict with user variable names
                 writeln!(self.out, "{level}{{")?;
@@ -167,26 +222,51 @@ impl<W: Write> Writer<W> {
                 let inner_level = level.next();
 
                 let naga_ray_desc_ty = TypeContext {
-                    handle: context
-                        .expression
-                        .module
-                        .special_types
-                        .ray_desc
-                        .expect("ray desc is required as an argument so should be there"),
+                    handle: context.expression.module.special_types.ray_desc.expect(
+                        "ray naga_ray_query_desc is required as an argument so should be there",
+                    ),
                     gctx: context.expression.module.to_ctx(),
                     names: &self.names,
                     access: crate::StorageAccess::empty(),
                     first_time: false,
                 };
 
-                write!(self.out, "{inner_level}{naga_ray_desc_ty} desc = ")?;
+                write!(
+                    self.out,
+                    "{inner_level}{naga_ray_desc_ty} naga_ray_query_desc = "
+                )?;
                 self.put_expression(descriptor, &context.expression, false)?;
                 writeln!(self.out, ";")?;
+
+                write!(
+                    self.out,
+                    "{inner_level}thread {QUERY_TYPE}& naga_ray_query_ref = "
+                )?;
+                self.put_expression(query, &context.expression, true)?;
+                writeln!(self.out, ";")?;
+                writeln!(self.out, "{inner_level}naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;")?;
+                // Bit tests remain valid with Metal fast-math enabled, unlike isnan/isfinite.
+                writeln!(self.out, "{inner_level}bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);")?;
+                writeln!(self.out, "{inner_level}bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));")?;
+                writeln!(self.out, "{inner_level}bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;")?;
+                let opacity = (back::RayFlag::OPAQUE
+                    | back::RayFlag::NO_OPAQUE
+                    | back::RayFlag::CULL_OPAQUE
+                    | back::RayFlag::CULL_NO_OPAQUE)
+                    .bits();
+                let faces = (back::RayFlag::CULL_BACK_FACING
+                    | back::RayFlag::CULL_FRONT_FACING
+                    | back::RayFlag::SKIP_TRIANGLES)
+                    .bits();
+                let geometry = (back::RayFlag::SKIP_TRIANGLES | back::RayFlag::SKIP_AABBS).bits();
+                writeln!(self.out, "{inner_level}bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & {opacity}u) <= 1 && metal::popcount(naga_ray_query_desc.flags & {faces}u) <= 1 && metal::popcount(naga_ray_query_desc.flags & {geometry}u) <= 1;")?;
+                writeln!(self.out, "{inner_level}if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {{")?;
+                let inner_level = inner_level.next();
 
                 // Set up intersection parameters
                 writeln!(
                     self.out,
-                    "{inner_level}{RT_NAMESPACE}::intersection_params params;"
+                    "{inner_level}{RT_NAMESPACE}::intersection_params naga_ray_query_params;"
                 )?;
 
                 {
@@ -195,9 +275,9 @@ impl<W: Write> Writer<W> {
                     let f_no_opaque = back::RayFlag::CULL_NO_OPAQUE.bits();
                     writeln!(
                         self.out,
-                        "{inner_level}params.set_opacity_cull_mode(
-{inner_level}    (desc.flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::opaque : (
-{inner_level}        (desc.flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::non_opaque : {RT_NAMESPACE}::opacity_cull_mode::none
+                        "{inner_level}naga_ray_query_params.set_opacity_cull_mode(
+{inner_level}    (naga_ray_query_desc.flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::opaque : (
+{inner_level}        (naga_ray_query_desc.flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::opacity_cull_mode::non_opaque : {RT_NAMESPACE}::opacity_cull_mode::none
 {inner_level}    )
 {inner_level});"
                     )?;
@@ -206,9 +286,9 @@ impl<W: Write> Writer<W> {
                     // Determine whether to force a particular opacity
                     let f_opaque = back::RayFlag::OPAQUE.bits();
                     let f_no_opaque = back::RayFlag::NO_OPAQUE.bits();
-                    writeln!(self.out, "{inner_level}params.force_opacity(
-{inner_level}    (desc.flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::opaque : (
-{inner_level}        (desc.flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::non_opaque : {RT_NAMESPACE}::forced_opacity::none
+                    writeln!(self.out, "{inner_level}naga_ray_query_params.force_opacity(
+{inner_level}    (naga_ray_query_desc.flags & {f_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::opaque : (
+{inner_level}        (naga_ray_query_desc.flags & {f_no_opaque}) != 0 ? {RT_NAMESPACE}::forced_opacity::non_opaque : {RT_NAMESPACE}::forced_opacity::none
 {inner_level}    )
 {inner_level});")?;
                 }
@@ -216,23 +296,34 @@ impl<W: Write> Writer<W> {
                     let flag = back::RayFlag::TERMINATE_ON_FIRST_HIT.bits();
                     writeln!(
                         self.out,
-                        "{inner_level}params.accept_any_intersection((desc.flags & {flag}) != 0);"
+                        "{inner_level}naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & {flag}) != 0);"
                     )?;
                 }
 
+                let back = back::RayFlag::CULL_BACK_FACING.bits();
+                let front = back::RayFlag::CULL_FRONT_FACING.bits();
+                let triangles = back::RayFlag::SKIP_TRIANGLES.bits();
+                let aabbs = back::RayFlag::SKIP_AABBS.bits();
+                writeln!(self.out, "{inner_level}naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);")?;
+                writeln!(self.out, "{inner_level}naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & {back}u) != 0 ? {RT_NAMESPACE}::triangle_cull_mode::back : ((naga_ray_query_desc.flags & {front}u) != 0 ? {RT_NAMESPACE}::triangle_cull_mode::front : {RT_NAMESPACE}::triangle_cull_mode::none));")?;
+                writeln!(self.out, "{inner_level}naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & {triangles}u) != 0 ? {RT_NAMESPACE}::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & {aabbs}u) != 0 ? {RT_NAMESPACE}::geometry_cull_mode::bounding_box : {RT_NAMESPACE}::geometry_cull_mode::none));")?;
+
                 writeln!(
                     self.out,
-                    "{inner_level}{RT_NAMESPACE}::ray ray = {RT_NAMESPACE}::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);"
+                    "{inner_level}{RT_NAMESPACE}::ray naga_ray_query_ray = {RT_NAMESPACE}::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);"
                 )?;
 
-                write!(self.out, "{inner_level}")?;
-                // A ray query can by initialized in metal by either using a "non-default constructor"
-                // or by calling reset. Ray queries cannot be assigned to in metal, so reset needs to
-                // be called.
-                self.put_expression(query, &context.expression, true)?;
-                write!(self.out, ".reset(ray,")?;
+                write!(
+                    self.out,
+                    "{inner_level}naga_ray_query_ref.query.reset(naga_ray_query_ray,"
+                )?;
                 self.put_expression(acceleration_structure, &context.expression, true)?;
-                writeln!(self.out, ", desc.cull_mask, params);")?;
+                writeln!(
+                    self.out,
+                    ", naga_ray_query_desc.cull_mask, naga_ray_query_params);"
+                )?;
+                writeln!(self.out, "{inner_level}naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;")?;
+                writeln!(self.out, "{}}}", level.next())?;
                 writeln!(self.out, "{level}}}")?;
             }
             crate::RayQueryFunction::Proceed { result } => {
@@ -258,8 +349,6 @@ impl<W: Write> Writer<W> {
             crate::RayQueryFunction::Terminate => {
                 write!(self.out, "{level}")?;
                 self.put_expression(query, &context.expression, true)?;
-                // Terminate appears to map to abort in spirv-cross, but metal only documents
-                // the existence of this method, not what it does.
                 writeln!(self.out, ".abort();")?;
             }
         }

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -370,7 +370,7 @@ impl Display for TypeContext<'_> {
                 if vertex_return {
                     unimplemented!("metal does not support vertex ray hit return")
                 }
-                write!(out, "{}", super::ray::metal_intersector_ty())
+                write!(out, "{}", super::ray::QUERY_TYPE)
             }
             crate::TypeInner::BindingArray { base, .. } => {
                 let base_tyname = Self {
@@ -1090,6 +1090,26 @@ impl<W: Write> Writer<W> {
                 (name_key, ty, None)
             }))
         {
+            if matches!(
+                context.module.types[ty].inner,
+                crate::TypeInner::RayQuery { .. }
+            ) {
+                let name = &self.names[&name_key];
+                let raw_name = format!("naga_ray_query_{name}");
+                writeln!(
+                    self.out,
+                    "{}{} {raw_name};",
+                    back::INDENT,
+                    super::ray::metal_intersector_ty()
+                )?;
+                writeln!(
+                    self.out,
+                    "{}{} {name} = {{{raw_name}}};",
+                    back::INDENT,
+                    super::ray::QUERY_TYPE
+                )?;
+                continue;
+            }
             let ty_name = TypeContext {
                 handle: ty,
                 gctx: context.module.to_ctx(),
@@ -4373,6 +4393,8 @@ impl<W: Write> Writer<W> {
             &[
                 CLAMPED_LOD_LOAD_PREFIX,
                 super::ray::INTERSECTION_FUNCTION_NAME,
+                super::ray::QUERY_TYPE,
+                "naga_ray_query_",
             ],
             &mut self.names,
         );
@@ -4398,12 +4420,20 @@ impl<W: Write> Writer<W> {
             .iter()
             .any(|e| e.stage == crate::ShaderStage::Task && e.task_payload.is_some());
 
-        if module.special_types.ray_desc.is_some()
-            || module.special_types.ray_intersection.is_some()
+        let has_ray_queries = module
+            .types
+            .iter()
+            .any(|(_, ty)| matches!(ty.inner, crate::TypeInner::RayQuery { .. }));
+        if (has_ray_queries
+            || module.special_types.ray_desc.is_some()
+            || module.special_types.ray_intersection.is_some())
+            && options.lang_version < (2, 4)
         {
-            if options.lang_version < (2, 4) {
-                return Err(Error::UnsupportedRayTracing);
-            }
+            return Err(Error::UnsupportedRayTracing);
+        }
+
+        if has_ray_queries {
+            self.write_ray_query_type()?;
         }
 
         if options

--- a/naga/src/back/msl/writer.rs
+++ b/naga/src/back/msl/writer.rs
@@ -7503,6 +7503,15 @@ template <typename A>
                                         ));
                                     }
                                 },
+                                crate::TypeInner::AccelerationStructure { .. } => {
+                                    // Arrays of acceleration structures ride on ray
+                                    // tracing, which requires MSL 2.4.
+                                    if options.lang_version < (2, 4) {
+                                        return Err(Error::UnsupportedArrayOf(
+                                            "acceleration structures".to_string(),
+                                        ));
+                                    }
+                                }
                                 _ => {
                                     return Err(Error::UnsupportedArrayOfType(base));
                                 }

--- a/naga/src/back/spv/ray/query.rs
+++ b/naga/src/back/spv/ray/query.rs
@@ -1467,7 +1467,7 @@ impl Writer {
         function.to_words(&mut self.logical_layout.function_definitions);
 
         self.ray_query_functions
-            .insert(LookupRayQueryFunction::Proceed, func_id);
+            .insert(LookupRayQueryFunction::Terminate, func_id);
         func_id
     }
 }
@@ -1599,5 +1599,45 @@ impl BlockContext<'_> {
             &[query_id, tracker_id.initialized_tracker],
         ));
         func_call_id
+    }
+}
+
+#[test]
+fn terminate_and_proceed_helpers_have_distinct_cached_types() {
+    for tracking in [false, true] {
+        for terminate_first in [false, true] {
+            let mut writer = Writer::new(&super::super::Options::default()).unwrap();
+            writer.ray_query_initialization_tracking = tracking;
+            let (terminate, proceed) = if terminate_first {
+                let terminate = writer.write_ray_query_terminate();
+                (terminate, writer.write_ray_query_proceed())
+            } else {
+                let proceed = writer.write_ray_query_proceed();
+                (writer.write_ray_query_terminate(), proceed)
+            };
+            assert_ne!(terminate, proceed);
+            let before = writer.logical_layout.function_definitions.len();
+            assert_eq!(writer.write_ray_query_terminate(), terminate);
+            assert_eq!(writer.write_ray_query_proceed(), proceed);
+            assert_eq!(writer.logical_layout.function_definitions.len(), before);
+            let bool_type = writer.get_bool_type_id();
+            let mut words = writer.logical_layout.function_definitions.as_slice();
+            let mut functions = 0;
+            while let Some(&header) = words.first() {
+                let count = (header >> 16) as usize;
+                if header & 0xffff == spirv::Op::Function as u32 {
+                    let expected = if words[2] == terminate {
+                        writer.void_type
+                    } else {
+                        assert_eq!(words[2], proceed);
+                        bool_type
+                    };
+                    assert_eq!(words[1], expected);
+                    functions += 1;
+                }
+                words = &words[count..];
+            }
+            assert_eq!(functions, 2);
+        }
     }
 }

--- a/naga/src/valid/analyzer.rs
+++ b/naga/src/valid/analyzer.rs
@@ -575,6 +575,12 @@ impl FunctionInfo {
                             crate::TypeInner::Sampler { .. } => {
                                 super::Capabilities::TEXTURE_AND_SAMPLER_BINDING_ARRAY_NON_UNIFORM_INDEXING
                             }
+                            // Acceleration structure arrays don't have a weaker
+                            // form: the binding array capability itself is the
+                            // opt-in on every backend that supports them.
+                            crate::TypeInner::AccelerationStructure { .. } => {
+                                super::Capabilities::ACCELERATION_STRUCTURE_BINDING_ARRAY
+                            }
                             // If we're anything but an image or sampler, assume we're a buffer and use the address space.
                             _ => {
                                 if let E::GlobalVariable(global_handle) = expression_arena[base] {

--- a/naga/tests/in/wgsl/ray-query-binding-arrays.toml
+++ b/naga/tests/in/wgsl/ray-query-binding-arrays.toml
@@ -1,0 +1,35 @@
+capabilities = "RAY_QUERY | ACCELERATION_STRUCTURE_BINDING_ARRAY"
+targets = "METAL | SPIRV"
+
+[msl]
+fake_missing_bindings = true
+lang_version = [2, 4]
+spirv_cross_compatibility = false
+zero_initialize_workgroup_memory = false
+
+[msl.per_entry_point_map.main]
+resources = [
+    { bind_target = { binding_array_size = 10, buffer = 0, mutable = false }, resource_binding = { group = 0, binding = 0 } },
+    { bind_target = { binding_array_size = 10, buffer = 1, mutable = false }, resource_binding = { group = 0, binding = 1 } },
+    { bind_target = { buffer = 2, mutable = false }, resource_binding = { group = 0, binding = 2 } },
+    { bind_target = { buffer = 3, mutable = false }, resource_binding = { group = 0, binding = 3 } },
+]
+
+[spv]
+version = [1, 4]
+
+[[spv.binding_map]]
+bind_target = { descriptor_set = 0, binding = 0, binding_array_size = 10 }
+resource_binding = { group = 0, binding = 0 }
+
+[[spv.binding_map]]
+bind_target = { descriptor_set = 0, binding = 1, binding_array_size = 10 }
+resource_binding = { group = 0, binding = 1 }
+
+[[spv.binding_map]]
+bind_target = { descriptor_set = 0, binding = 2 }
+resource_binding = { group = 0, binding = 2 }
+
+[[spv.binding_map]]
+bind_target = { descriptor_set = 0, binding = 3 }
+resource_binding = { group = 0, binding = 3 }

--- a/naga/tests/in/wgsl/ray-query-binding-arrays.wgsl
+++ b/naga/tests/in/wgsl/ray-query-binding-arrays.wgsl
@@ -1,0 +1,38 @@
+enable wgpu_ray_query;
+enable wgpu_binding_array;
+
+struct UniformIndex {
+    index: u32,
+};
+
+@group(0) @binding(0)
+var tlas_array_bounded: binding_array<acceleration_structure, 4>;
+@group(0) @binding(1)
+var tlas_array_unbounded: binding_array<acceleration_structure>;
+@group(0) @binding(2)
+var<uniform> uni: UniformIndex;
+@group(0) @binding(3)
+var<storage, read_write> out: array<vec2<f32>>;
+
+@compute @workgroup_size(1)
+fn main() {
+    var rq: ray_query;
+
+    rayQueryInitialize(
+        &rq,
+        tlas_array_bounded[uni.index],
+        RayDesc(0x04u, 0xFFu, 0.1, 100.0, vec3<f32>(0.0, 0.0, -2.0), vec3<f32>(0.0, 0.0, 1.0)),
+    );
+    while (rayQueryProceed(&rq)) {}
+    let first = rayQueryGetCommittedIntersection(&rq);
+
+    rayQueryInitialize(
+        &rq,
+        tlas_array_unbounded[uni.index],
+        RayDesc(0x04u, 0xFFu, 0.1, 100.0, vec3<f32>(first.barycentrics, 0.0), vec3<f32>(0.0, 0.0, 1.0)),
+    );
+    while (rayQueryProceed(&rq)) {}
+    let second = rayQueryGetCommittedIntersection(&rq);
+
+    out[uni.index] = vec2<f32>(first.t, second.t);
+}

--- a/naga/tests/in/wgsl/ray-query-no-init-tracking.wgsl
+++ b/naga/tests/in/wgsl/ray-query-no-init-tracking.wgsl
@@ -97,3 +97,28 @@ fn main_candidate() {
         rayQueryTerminate(&rq);
     }
 }
+
+@compute @workgroup_size(1)
+fn runtime_flags_and_reinitialize() {
+    var rq: ray_query;
+    let query_ptr = &rq;
+    rayQueryProceed(query_ptr);
+    rayQueryConfirmIntersection(query_ptr);
+    rayQueryGenerateIntersection(query_ptr, 1.0);
+    rayQueryTerminate(query_ptr);
+    output.visible = rayQueryGetCandidateIntersection(query_ptr).kind;
+    rayQueryInitialize(query_ptr, acc_struct, RayDesc(output.visible, 255u, 0.0, 100.0, vec3f(0.0), vec3f(0.0, 0.0, 1.0)));
+    while rayQueryProceed(query_ptr) {
+        let hit = rayQueryGetCandidateIntersection(query_ptr);
+        if hit.kind == RAY_QUERY_INTERSECTION_TRIANGLE {
+            rayQueryConfirmIntersection(query_ptr);
+        } else {
+            rayQueryGenerateIntersection(query_ptr, 10.0);
+        }
+    }
+    output.visible = rayQueryGetCommittedIntersection(query_ptr).kind;
+    rayQueryProceed(query_ptr);
+    rayQueryInitialize(query_ptr, acc_struct, RayDesc(0u, 255u, 1.0, 0.0, vec3f(0.0), vec3f(0.0, 0.0, 1.0)));
+    rayQueryProceed(query_ptr);
+    output.visible += rayQueryGetCommittedIntersection(query_ptr).kind;
+}

--- a/naga/tests/in/wgsl/ray-query.wgsl
+++ b/naga/tests/in/wgsl/ray-query.wgsl
@@ -97,3 +97,28 @@ fn main_candidate() {
         rayQueryTerminate(&rq);
     }
 }
+
+@compute @workgroup_size(1)
+fn runtime_flags_and_reinitialize() {
+    var rq: ray_query;
+    let query_ptr = &rq;
+    rayQueryProceed(query_ptr);
+    rayQueryConfirmIntersection(query_ptr);
+    rayQueryGenerateIntersection(query_ptr, 1.0);
+    rayQueryTerminate(query_ptr);
+    output.visible = rayQueryGetCandidateIntersection(query_ptr).kind;
+    rayQueryInitialize(query_ptr, acc_struct, RayDesc(output.visible, 255u, 0.0, 100.0, vec3f(0.0), vec3f(0.0, 0.0, 1.0)));
+    while rayQueryProceed(query_ptr) {
+        let hit = rayQueryGetCandidateIntersection(query_ptr);
+        if hit.kind == RAY_QUERY_INTERSECTION_TRIANGLE {
+            rayQueryConfirmIntersection(query_ptr);
+        } else {
+            rayQueryGenerateIntersection(query_ptr, 10.0);
+        }
+    }
+    output.visible = rayQueryGetCommittedIntersection(query_ptr).kind;
+    rayQueryProceed(query_ptr);
+    rayQueryInitialize(query_ptr, acc_struct, RayDesc(0u, 255u, 1.0, 0.0, vec3f(0.0), vec3f(0.0, 0.0, 1.0)));
+    rayQueryProceed(query_ptr);
+    output.visible += rayQueryGetCommittedIntersection(query_ptr).kind;
+}

--- a/naga/tests/out/hlsl/wgsl-ray-query-no-init-tracking.hlsl
+++ b/naga/tests/out/hlsl/wgsl-ray-query-no-init-tracking.hlsl
@@ -81,19 +81,19 @@ RayIntersection GetCommittedIntersection(RayQuery<RAY_FLAG_NONE> rq, uint rq_tra
 
 RayIntersection query_loop(float3 pos, float3 dir, RaytracingAccelerationStructure acs)
 {
-    RayQuery<RAY_FLAG_NONE> rq_1;
-    uint naga_query_init_tracker_for_rq_1 = 0;
+    RayQuery<RAY_FLAG_NONE> rq_2;
+    uint naga_query_init_tracker_for_rq_2 = 0;
 
     {
         RayDesc_ naga_desc = ConstructRayDesc_(4u, 255u, 0.1, 100.0, pos, dir);
-        rq_1.TraceRayInline(acs, naga_desc.flags, naga_desc.cull_mask, RayDescFromRayDesc_(naga_desc));
+        rq_2.TraceRayInline(acs, naga_desc.flags, naga_desc.cull_mask, RayDescFromRayDesc_(naga_desc));
     }
     uint2 loop_bound = uint2(4294967295u, 4294967295u);
     while(true) {
         if (all(loop_bound == uint2(0u, 0u))) { break; }
         loop_bound -= uint2(loop_bound.y == 0u, 1u);
         bool _e9 = false;
-        _e9 = rq_1.Proceed();
+        _e9 = rq_2.Proceed();
         if (_e9) {
         } else {
             break;
@@ -101,7 +101,7 @@ RayIntersection query_loop(float3 pos, float3 dir, RaytracingAccelerationStructu
         {
         }
     }
-    const RayIntersection rayintersection = GetCommittedIntersection(rq_1, naga_query_init_tracker_for_rq_1);
+    const RayIntersection rayintersection = GetCommittedIntersection(rq_2, naga_query_init_tracker_for_rq_2);
     return rayintersection;
 }
 
@@ -171,4 +171,54 @@ void main_candidate()
             return;
         }
     }
+}
+
+[numthreads(1, 1, 1)]
+void runtime_flags_and_reinitialize()
+{
+    RayQuery<RAY_FLAG_NONE> rq_1;
+    uint naga_query_init_tracker_for_rq_1 = 0;
+
+    bool _e1 = false;
+    _e1 = rq_1.Proceed();
+    rq_1.CommitNonOpaqueTriangleHit();
+    rq_1.CommitProceduralPrimitiveHit(1.0);
+    rq_1.Abort();
+    output.Store(0, asuint(GetCandidateIntersection(rq_1, naga_query_init_tracker_for_rq_1).kind));
+    uint _e10 = asuint(output.Load(0));
+    {
+        RayDesc_ naga_desc = ConstructRayDesc_(_e10, 255u, 0.0, 100.0, (0.0).xxx, float3(0.0, 0.0, 1.0));
+        rq_1.TraceRayInline(acc_struct, naga_desc.flags, naga_desc.cull_mask, RayDescFromRayDesc_(naga_desc));
+    }
+    uint2 loop_bound_1 = uint2(4294967295u, 4294967295u);
+    while(true) {
+        if (all(loop_bound_1 == uint2(0u, 0u))) { break; }
+        loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
+        bool _e21 = false;
+        _e21 = rq_1.Proceed();
+        if (_e21) {
+        } else {
+            break;
+        }
+        {
+            RayIntersection hit = GetCandidateIntersection(rq_1, naga_query_init_tracker_for_rq_1);
+            if ((hit.kind == 1u)) {
+                rq_1.CommitNonOpaqueTriangleHit();
+            } else {
+                rq_1.CommitProceduralPrimitiveHit(10.0);
+            }
+        }
+    }
+    output.Store(0, asuint(GetCommittedIntersection(rq_1, naga_query_init_tracker_for_rq_1).kind));
+    bool _e31 = false;
+    _e31 = rq_1.Proceed();
+    {
+        RayDesc_ naga_desc = ConstructRayDesc_(0u, 255u, 1.0, 0.0, (0.0).xxx, float3(0.0, 0.0, 1.0));
+        rq_1.TraceRayInline(acc_struct, naga_desc.flags, naga_desc.cull_mask, RayDescFromRayDesc_(naga_desc));
+    }
+    bool _e44 = false;
+    _e44 = rq_1.Proceed();
+    uint _e47 = asuint(output.Load(0));
+    output.Store(0, asuint((_e47 + GetCommittedIntersection(rq_1, naga_query_init_tracker_for_rq_1).kind)));
+    return;
 }

--- a/naga/tests/out/hlsl/wgsl-ray-query-no-init-tracking.ron
+++ b/naga/tests/out/hlsl/wgsl-ray-query-no-init-tracking.ron
@@ -12,6 +12,10 @@
             entry_point:"main_candidate",
             target_profile:"cs_6_5",
         ),
+        (
+            entry_point:"runtime_flags_and_reinitialize",
+            target_profile:"cs_6_5",
+        ),
     ],
     task:[
     ],

--- a/naga/tests/out/hlsl/wgsl-ray-query.hlsl
+++ b/naga/tests/out/hlsl/wgsl-ray-query.hlsl
@@ -83,8 +83,8 @@ RayIntersection GetCommittedIntersection(RayQuery<RAY_FLAG_NONE> rq, uint rq_tra
 
 RayIntersection query_loop(float3 pos, float3 dir, RaytracingAccelerationStructure acs)
 {
-    RayQuery<RAY_FLAG_NONE> rq_1;
-    uint naga_query_init_tracker_for_rq_1 = 0;
+    RayQuery<RAY_FLAG_NONE> rq_2;
+    uint naga_query_init_tracker_for_rq_2 = 0;
 
     {
         RayDesc_ naga_desc = ConstructRayDesc_(4u, 255u, 0.1, 100.0, pos, dir);
@@ -109,8 +109,8 @@ RayIntersection query_loop(float3 pos, float3 dir, RaytracingAccelerationStructu
         bool naga_contains_skip_triangles_cull =  (naga_contains_cull_front && naga_contains_skip_triangles) || (naga_contains_cull_front && naga_contains_cull_back) || (naga_contains_cull_back && naga_contains_skip_triangles) ;
         bool naga_contains_multiple_opaque =  (naga_contains_cull_no_opaque && naga_contains_opaque) || (naga_contains_cull_no_opaque && naga_contains_no_opaque) || (naga_contains_cull_no_opaque && naga_contains_cull_opaque) || (naga_contains_cull_opaque && naga_contains_opaque) || (naga_contains_cull_opaque && naga_contains_no_opaque) || (naga_contains_no_opaque && naga_contains_opaque) ;
         if (naga_tmin_valid && naga_tmax_valid && naga_origin_valid && naga_dir_valid && !(naga_contains_skip_triangles_aabbs || naga_contains_skip_triangles_cull || naga_contains_multiple_opaque)) {
-            naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 1;
-            rq_1.TraceRayInline(acs, naga_desc.flags, naga_desc.cull_mask, RayDescFromRayDesc_(naga_desc));
+            naga_query_init_tracker_for_rq_2 = naga_query_init_tracker_for_rq_2 | 1;
+            rq_2.TraceRayInline(acs, naga_desc.flags, naga_desc.cull_mask, RayDescFromRayDesc_(naga_desc));
         }
     }
     uint2 loop_bound = uint2(4294967295u, 4294967295u);
@@ -119,12 +119,12 @@ RayIntersection query_loop(float3 pos, float3 dir, RaytracingAccelerationStructu
         loop_bound -= uint2(loop_bound.y == 0u, 1u);
         bool _e9 = false;
         {
-            bool naga_has_initialized = ((naga_query_init_tracker_for_rq_1 & 1) == 1);
-            bool naga_has_finished = ((naga_query_init_tracker_for_rq_1 & 4) == 4);
+            bool naga_has_initialized = ((naga_query_init_tracker_for_rq_2 & 1) == 1);
+            bool naga_has_finished = ((naga_query_init_tracker_for_rq_2 & 4) == 4);
             if (naga_has_initialized && !naga_has_finished) {
-                _e9 = rq_1.Proceed();
-                naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 2;
-                if (!_e9) { naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 4; }
+                _e9 = rq_2.Proceed();
+                naga_query_init_tracker_for_rq_2 = naga_query_init_tracker_for_rq_2 | 2;
+                if (!_e9) { naga_query_init_tracker_for_rq_2 = naga_query_init_tracker_for_rq_2 | 4; }
         }}
         if (_e9) {
         } else {
@@ -133,7 +133,7 @@ RayIntersection query_loop(float3 pos, float3 dir, RaytracingAccelerationStructu
         {
         }
     }
-    const RayIntersection rayintersection = GetCommittedIntersection(rq_1, naga_query_init_tracker_for_rq_1);
+    const RayIntersection rayintersection = GetCommittedIntersection(rq_2, naga_query_init_tracker_for_rq_2);
     return rayintersection;
 }
 
@@ -240,4 +240,150 @@ void main_candidate()
             return;
         }
     }
+}
+
+[numthreads(1, 1, 1)]
+void runtime_flags_and_reinitialize()
+{
+    RayQuery<RAY_FLAG_NONE> rq_1;
+    uint naga_query_init_tracker_for_rq_1 = 0;
+
+    bool _e1 = false;
+    {
+        bool naga_has_initialized = ((naga_query_init_tracker_for_rq_1 & 1) == 1);
+        bool naga_has_finished = ((naga_query_init_tracker_for_rq_1 & 4) == 4);
+        if (naga_has_initialized && !naga_has_finished) {
+            _e1 = rq_1.Proceed();
+            naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 2;
+            if (!_e1) { naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 4; }
+    }}
+    if (((naga_query_init_tracker_for_rq_1 & 2) == 2) && !((naga_query_init_tracker_for_rq_1 & 4) == 4)) {
+        CANDIDATE_TYPE naga_kind = rq_1.CandidateType();
+        if (naga_kind == CANDIDATE_NON_OPAQUE_TRIANGLE) {
+            rq_1.CommitNonOpaqueTriangleHit();
+    }}
+    if (((naga_query_init_tracker_for_rq_1 & 2) == 2) && !((naga_query_init_tracker_for_rq_1 & 4) == 4)) {
+        CANDIDATE_TYPE naga_kind = rq_1.CandidateType();
+        float naga_tmin = rq_1.RayTMin();
+        float naga_tcurrentmax = rq_1.CommittedRayT();
+        if ((naga_kind == CANDIDATE_PROCEDURAL_PRIMITIVE) && (naga_tmin <=1.0) && (1.0 <= naga_tcurrentmax)) {
+            rq_1.CommitProceduralPrimitiveHit(1.0);
+    }}
+    if (((naga_query_init_tracker_for_rq_1 & 1) == 1)) {
+        rq_1.Abort();
+    }
+    output.Store(0, asuint(GetCandidateIntersection(rq_1, naga_query_init_tracker_for_rq_1).kind));
+    uint _e10 = asuint(output.Load(0));
+    {
+        RayDesc_ naga_desc = ConstructRayDesc_(_e10, 255u, 0.0, 100.0, (0.0).xxx, float3(0.0, 0.0, 1.0));
+        float naga_tmin = naga_desc.tmin;
+        float naga_tmax = naga_desc.tmax;
+        float3 naga_origin = naga_desc.origin;
+        float3 naga_dir = naga_desc.dir;
+        uint naga_flags = naga_desc.flags;
+        bool naga_tmin_valid = (naga_tmin >= 0.0) && (naga_tmin <= naga_tmax) && !(((asuint(naga_tmin) & 2139095040) == 2139095040) && ((asuint(naga_tmin) & 0x7fffff) != 0));
+        bool naga_tmax_valid = !(((asuint(naga_tmax) & 2139095040) == 2139095040) && ((asuint(naga_tmax) & 0x7fffff) != 0));
+        bool naga_origin_valid = !any((((asuint(naga_origin) & 2139095040) == 2139095040) && ((asuint(naga_origin) & 0x7fffff) != 0)));
+        bool naga_dir_valid = !any((((asuint(naga_dir) & 2139095040) == 2139095040) && ((asuint(naga_dir) & 0x7fffff) != 0)));
+        bool naga_contains_opaque = ((naga_flags & 1) == 1);
+        bool naga_contains_no_opaque = ((naga_flags & 2) == 2);
+        bool naga_contains_cull_opaque = ((naga_flags & 64) == 64);
+        bool naga_contains_cull_no_opaque = ((naga_flags & 128) == 128);
+        bool naga_contains_cull_front = ((naga_flags & 32) == 32);
+        bool naga_contains_cull_back = ((naga_flags & 16) == 16);
+        bool naga_contains_skip_triangles = ((naga_flags & 256) == 256);
+        bool naga_contains_skip_aabbs = ((naga_flags & 512) == 512);
+        bool naga_contains_skip_triangles_aabbs =  (naga_contains_skip_aabbs && naga_contains_skip_triangles) ;
+        bool naga_contains_skip_triangles_cull =  (naga_contains_cull_front && naga_contains_skip_triangles) || (naga_contains_cull_front && naga_contains_cull_back) || (naga_contains_cull_back && naga_contains_skip_triangles) ;
+        bool naga_contains_multiple_opaque =  (naga_contains_cull_no_opaque && naga_contains_opaque) || (naga_contains_cull_no_opaque && naga_contains_no_opaque) || (naga_contains_cull_no_opaque && naga_contains_cull_opaque) || (naga_contains_cull_opaque && naga_contains_opaque) || (naga_contains_cull_opaque && naga_contains_no_opaque) || (naga_contains_no_opaque && naga_contains_opaque) ;
+        if (naga_tmin_valid && naga_tmax_valid && naga_origin_valid && naga_dir_valid && !(naga_contains_skip_triangles_aabbs || naga_contains_skip_triangles_cull || naga_contains_multiple_opaque)) {
+            naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 1;
+            rq_1.TraceRayInline(acc_struct, naga_desc.flags, naga_desc.cull_mask, RayDescFromRayDesc_(naga_desc));
+        }
+    }
+    uint2 loop_bound_1 = uint2(4294967295u, 4294967295u);
+    while(true) {
+        if (all(loop_bound_1 == uint2(0u, 0u))) { break; }
+        loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
+        bool _e21 = false;
+        {
+            bool naga_has_initialized = ((naga_query_init_tracker_for_rq_1 & 1) == 1);
+            bool naga_has_finished = ((naga_query_init_tracker_for_rq_1 & 4) == 4);
+            if (naga_has_initialized && !naga_has_finished) {
+                _e21 = rq_1.Proceed();
+                naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 2;
+                if (!_e21) { naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 4; }
+        }}
+        if (_e21) {
+        } else {
+            break;
+        }
+        {
+            RayIntersection hit = GetCandidateIntersection(rq_1, naga_query_init_tracker_for_rq_1);
+            if ((hit.kind == 1u)) {
+                if (((naga_query_init_tracker_for_rq_1 & 2) == 2) && !((naga_query_init_tracker_for_rq_1 & 4) == 4)) {
+                    CANDIDATE_TYPE naga_kind = rq_1.CandidateType();
+                    if (naga_kind == CANDIDATE_NON_OPAQUE_TRIANGLE) {
+                        rq_1.CommitNonOpaqueTriangleHit();
+                }}
+            } else {
+                if (((naga_query_init_tracker_for_rq_1 & 2) == 2) && !((naga_query_init_tracker_for_rq_1 & 4) == 4)) {
+                    CANDIDATE_TYPE naga_kind = rq_1.CandidateType();
+                    float naga_tmin = rq_1.RayTMin();
+                    float naga_tcurrentmax = rq_1.CommittedRayT();
+                    if ((naga_kind == CANDIDATE_PROCEDURAL_PRIMITIVE) && (naga_tmin <=10.0) && (10.0 <= naga_tcurrentmax)) {
+                        rq_1.CommitProceduralPrimitiveHit(10.0);
+                }}
+            }
+        }
+    }
+    output.Store(0, asuint(GetCommittedIntersection(rq_1, naga_query_init_tracker_for_rq_1).kind));
+    bool _e31 = false;
+    {
+        bool naga_has_initialized = ((naga_query_init_tracker_for_rq_1 & 1) == 1);
+        bool naga_has_finished = ((naga_query_init_tracker_for_rq_1 & 4) == 4);
+        if (naga_has_initialized && !naga_has_finished) {
+            _e31 = rq_1.Proceed();
+            naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 2;
+            if (!_e31) { naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 4; }
+    }}
+    {
+        RayDesc_ naga_desc = ConstructRayDesc_(0u, 255u, 1.0, 0.0, (0.0).xxx, float3(0.0, 0.0, 1.0));
+        float naga_tmin = naga_desc.tmin;
+        float naga_tmax = naga_desc.tmax;
+        float3 naga_origin = naga_desc.origin;
+        float3 naga_dir = naga_desc.dir;
+        uint naga_flags = naga_desc.flags;
+        bool naga_tmin_valid = (naga_tmin >= 0.0) && (naga_tmin <= naga_tmax) && !(((asuint(naga_tmin) & 2139095040) == 2139095040) && ((asuint(naga_tmin) & 0x7fffff) != 0));
+        bool naga_tmax_valid = !(((asuint(naga_tmax) & 2139095040) == 2139095040) && ((asuint(naga_tmax) & 0x7fffff) != 0));
+        bool naga_origin_valid = !any((((asuint(naga_origin) & 2139095040) == 2139095040) && ((asuint(naga_origin) & 0x7fffff) != 0)));
+        bool naga_dir_valid = !any((((asuint(naga_dir) & 2139095040) == 2139095040) && ((asuint(naga_dir) & 0x7fffff) != 0)));
+        bool naga_contains_opaque = ((naga_flags & 1) == 1);
+        bool naga_contains_no_opaque = ((naga_flags & 2) == 2);
+        bool naga_contains_cull_opaque = ((naga_flags & 64) == 64);
+        bool naga_contains_cull_no_opaque = ((naga_flags & 128) == 128);
+        bool naga_contains_cull_front = ((naga_flags & 32) == 32);
+        bool naga_contains_cull_back = ((naga_flags & 16) == 16);
+        bool naga_contains_skip_triangles = ((naga_flags & 256) == 256);
+        bool naga_contains_skip_aabbs = ((naga_flags & 512) == 512);
+        bool naga_contains_skip_triangles_aabbs =  (naga_contains_skip_aabbs && naga_contains_skip_triangles) ;
+        bool naga_contains_skip_triangles_cull =  (naga_contains_cull_front && naga_contains_skip_triangles) || (naga_contains_cull_front && naga_contains_cull_back) || (naga_contains_cull_back && naga_contains_skip_triangles) ;
+        bool naga_contains_multiple_opaque =  (naga_contains_cull_no_opaque && naga_contains_opaque) || (naga_contains_cull_no_opaque && naga_contains_no_opaque) || (naga_contains_cull_no_opaque && naga_contains_cull_opaque) || (naga_contains_cull_opaque && naga_contains_opaque) || (naga_contains_cull_opaque && naga_contains_no_opaque) || (naga_contains_no_opaque && naga_contains_opaque) ;
+        if (naga_tmin_valid && naga_tmax_valid && naga_origin_valid && naga_dir_valid && !(naga_contains_skip_triangles_aabbs || naga_contains_skip_triangles_cull || naga_contains_multiple_opaque)) {
+            naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 1;
+            rq_1.TraceRayInline(acc_struct, naga_desc.flags, naga_desc.cull_mask, RayDescFromRayDesc_(naga_desc));
+        }
+    }
+    bool _e44 = false;
+    {
+        bool naga_has_initialized = ((naga_query_init_tracker_for_rq_1 & 1) == 1);
+        bool naga_has_finished = ((naga_query_init_tracker_for_rq_1 & 4) == 4);
+        if (naga_has_initialized && !naga_has_finished) {
+            _e44 = rq_1.Proceed();
+            naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 2;
+            if (!_e44) { naga_query_init_tracker_for_rq_1 = naga_query_init_tracker_for_rq_1 | 4; }
+    }}
+    uint _e47 = asuint(output.Load(0));
+    output.Store(0, asuint((_e47 + GetCommittedIntersection(rq_1, naga_query_init_tracker_for_rq_1).kind)));
+    return;
 }

--- a/naga/tests/out/hlsl/wgsl-ray-query.ron
+++ b/naga/tests/out/hlsl/wgsl-ray-query.ron
@@ -12,6 +12,10 @@
             entry_point:"main_candidate",
             target_profile:"cs_6_5",
         ),
+        (
+            entry_point:"runtime_flags_and_reinitialize",
+            target_profile:"cs_6_5",
+        ),
     ],
     task:[
     ],

--- a/naga/tests/out/msl/wgsl-aliased-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-aliased-ray-query.metal
@@ -3,6 +3,47 @@
 #include <simd/simd.h>
 
 using metal::uint;
+struct NagaRayQuery {
+    thread metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data>& query;
+    bool initialized = false;
+    bool candidate = false;
+    bool finished = false;
+    float tmin = 0.0;
+    float tmax = 0.0;
+
+    bool next() thread {
+        if (!initialized || finished) return false;
+        candidate = query.next();
+        finished = !candidate;
+        return candidate;
+    }
+
+    void abort() thread {
+        if (candidate) {
+            query.abort();
+            candidate = false;
+            finished = true;
+        }
+    }
+
+    void commit_triangle_intersection() thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::triangle) {
+            query.commit_triangle_intersection();
+        }
+    }
+
+    void commit_bounding_box_intersection(float distance) thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::bounding_box) {
+            float closest = tmax;
+            if (query.get_committed_intersection_type() != metal::raytracing::intersection_type::none) {
+                closest = query.get_committed_distance();
+            }
+            if ((as_type<uint>(distance) & 0x7fffffffu) <= 0x7f800000u && distance >= tmin && distance <= closest) {
+                query.commit_bounding_box_intersection(distance);
+            }
+        }
+    }
+};
 
 struct RayDesc {
     uint flags;
@@ -26,8 +67,10 @@ struct RayIntersection {
     metal::float4x3 object_to_world;
     metal::float4x3 world_to_object;
 };
-RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> intersector) {
+RayIntersection ray_query_get_intersection_false(thread NagaRayQuery& rq) {
     RayIntersection intersection = RayIntersection {};
+    if (!rq.candidate) return intersection;
+    thread auto& intersector = rq.query;
     metal::raytracing::intersection_type ty = intersector.get_candidate_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
         intersection.kind = 1;
@@ -51,26 +94,39 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq_1 = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> naga_ray_query_rq_1;
+    NagaRayQuery rq_1 = {naga_ray_query_rq_1};
     metal::float3 pos = metal::float3(0.0);
     metal::float3 dir = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
-        RayDesc desc = _e12;
-        metal::raytracing::intersection_params params;
-        params.set_opacity_cull_mode(
-            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
-                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
-            )
-        );
-        params.force_opacity(
-            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
-                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
-            )
-        );
-        params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
-        rq_1.reset(ray,acc_struct, desc.cull_mask, params);
+        RayDesc naga_ray_query_desc = _e12;
+        thread NagaRayQuery& naga_ray_query_ref = rq_1;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,acc_struct, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
     }
     RayIntersection intersection = ray_query_get_intersection_false(rq_1);
     if (intersection.kind == 3u) {

--- a/naga/tests/out/msl/wgsl-overrides-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-overrides-ray-query.metal
@@ -3,6 +3,47 @@
 #include <simd/simd.h>
 
 using metal::uint;
+struct NagaRayQuery {
+    thread metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data>& query;
+    bool initialized = false;
+    bool candidate = false;
+    bool finished = false;
+    float tmin = 0.0;
+    float tmax = 0.0;
+
+    bool next() thread {
+        if (!initialized || finished) return false;
+        candidate = query.next();
+        finished = !candidate;
+        return candidate;
+    }
+
+    void abort() thread {
+        if (candidate) {
+            query.abort();
+            candidate = false;
+            finished = true;
+        }
+    }
+
+    void commit_triangle_intersection() thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::triangle) {
+            query.commit_triangle_intersection();
+        }
+    }
+
+    void commit_bounding_box_intersection(float distance) thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::bounding_box) {
+            float closest = tmax;
+            if (query.get_committed_intersection_type() != metal::raytracing::intersection_type::none) {
+                closest = query.get_committed_distance();
+            }
+            if ((as_type<uint>(distance) & 0x7fffffffu) <= 0x7f800000u && distance >= tmin && distance <= closest) {
+                query.commit_bounding_box_intersection(distance);
+            }
+        }
+    }
+};
 
 struct RayDesc {
     uint flags;
@@ -17,24 +58,37 @@ constant float o = 2.0;
 [[max_total_threads_per_threadgroup(1)]] kernel void main_(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> naga_ray_query_rq;
+    NagaRayQuery rq = {naga_ray_query_rq};
     RayDesc desc = RayDesc {4u, 255u, 34.0, 38.0, metal::float3(46.0), metal::float3(58.0, 62.0, 74.0)};
     {
-        RayDesc desc = desc;
-        metal::raytracing::intersection_params params;
-        params.set_opacity_cull_mode(
-            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
-                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
-            )
-        );
-        params.force_opacity(
-            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
-                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
-            )
-        );
-        params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
-        rq.reset(ray,acc_struct, desc.cull_mask, params);
+        RayDesc naga_ray_query_desc = desc;
+        thread NagaRayQuery& naga_ray_query_ref = rq;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,acc_struct, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
     }
     uint2 loop_bound = uint2(4294967295u);
     while(true) {

--- a/naga/tests/out/msl/wgsl-ray-query-binding-arrays.metal
+++ b/naga/tests/out/msl/wgsl-ray-query-binding-arrays.metal
@@ -1,0 +1,202 @@
+// language: metal2.4
+#include <metal_stdlib>
+#include <simd/simd.h>
+
+using metal::uint;
+struct NagaRayQuery {
+    thread metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data>& query;
+    bool initialized = false;
+    bool candidate = false;
+    bool finished = false;
+    float tmin = 0.0;
+    float tmax = 0.0;
+
+    bool next() thread {
+        if (!initialized || finished) return false;
+        candidate = query.next();
+        finished = !candidate;
+        return candidate;
+    }
+
+    void abort() thread {
+        if (candidate) {
+            query.abort();
+            candidate = false;
+            finished = true;
+        }
+    }
+
+    void commit_triangle_intersection() thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::triangle) {
+            query.commit_triangle_intersection();
+        }
+    }
+
+    void commit_bounding_box_intersection(float distance) thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::bounding_box) {
+            float closest = tmax;
+            if (query.get_committed_intersection_type() != metal::raytracing::intersection_type::none) {
+                closest = query.get_committed_distance();
+            }
+            if ((as_type<uint>(distance) & 0x7fffffffu) <= 0x7f800000u && distance >= tmin && distance <= closest) {
+                query.commit_bounding_box_intersection(distance);
+            }
+        }
+    }
+};
+
+struct _mslBufferSizes {
+    uint size3;
+};
+
+struct UniformIndex {
+    uint index;
+};
+template <typename T>
+struct NagaArgumentBufferWrapper {
+    T inner;
+};
+typedef metal::float2 type_6[1];
+struct RayDesc {
+    uint flags;
+    uint cull_mask;
+    float tmin;
+    float tmax;
+    metal::float3 origin;
+    metal::float3 dir;
+};
+struct RayIntersection {
+    uint kind;
+    float t;
+    uint instance_custom_data;
+    uint instance_index;
+    uint sbt_record_offset;
+    uint geometry_index;
+    uint primitive_index;
+    metal::float2 barycentrics;
+    bool front_face;
+    char _pad9[11];
+    metal::float4x3 object_to_world;
+    metal::float4x3 world_to_object;
+};
+RayIntersection ray_query_get_intersection_true(thread NagaRayQuery& rq) {
+    RayIntersection intersection = RayIntersection {};
+    if (!rq.finished) return intersection;
+    thread auto& intersector = rq.query;
+    metal::raytracing::intersection_type ty = intersector.get_committed_intersection_type();
+    if (ty == metal::raytracing::intersection_type::triangle) {
+        intersection.kind = 1;
+        intersection.barycentrics = intersector.get_committed_triangle_barycentric_coord();
+        intersection.front_face = intersector.is_committed_triangle_front_facing();
+    } else if (ty == metal::raytracing::intersection_type::bounding_box) {
+        intersection.kind = 2;
+    }
+    if (ty != metal::raytracing::intersection_type::none) {
+        intersection.t = intersector.get_committed_distance();
+        intersection.instance_custom_data = intersector.get_committed_user_instance_id();
+        intersection.instance_index = intersector.get_committed_instance_id();
+        intersection.geometry_index = intersector.get_committed_geometry_id();
+        intersection.primitive_index = intersector.get_committed_primitive_id();
+        intersection.object_to_world = intersector.get_committed_object_to_world_transform();
+        intersection.world_to_object = intersector.get_committed_world_to_object_transform();
+    }
+    return intersection;
+}
+
+[[max_total_threads_per_threadgroup(1)]] kernel void main_(
+  constant NagaArgumentBufferWrapper<metal::raytracing::instance_acceleration_structure>* tlas_array_bounded [[buffer(0)]]
+, constant NagaArgumentBufferWrapper<metal::raytracing::instance_acceleration_structure>* tlas_array_unbounded [[buffer(1)]]
+, constant UniformIndex& uni [[buffer(2)]]
+, device type_6& out [[buffer(3)]]
+, constant _mslBufferSizes& _buffer_sizes [[user(fake0)]]
+) {
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> naga_ray_query_rq;
+    NagaRayQuery rq = {naga_ray_query_rq};
+    uint _e4 = uni.index;
+    RayDesc _e18 = RayDesc {4u, 255u, 0.1, 100.0, metal::float3(0.0, 0.0, -2.0), metal::float3(0.0, 0.0, 1.0)};
+    {
+        RayDesc naga_ray_query_desc = _e18;
+        thread NagaRayQuery& naga_ray_query_ref = rq;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,tlas_array_bounded[_e4].inner, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
+    }
+    uint2 loop_bound = uint2(4294967295u);
+    while(true) {
+        if (metal::all(loop_bound == uint2(0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
+        bool _e19 = rq.next();
+        if (_e19) {
+        } else {
+            break;
+        }
+    }
+    RayIntersection first = ray_query_get_intersection_true(rq);
+    uint _e24 = uni.index;
+    RayDesc _e37 = RayDesc {4u, 255u, 0.1, 100.0, metal::float3(first.barycentrics, 0.0), metal::float3(0.0, 0.0, 1.0)};
+    {
+        RayDesc naga_ray_query_desc = _e37;
+        thread NagaRayQuery& naga_ray_query_ref = rq;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,tlas_array_unbounded[_e24].inner, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
+    }
+    uint2 loop_bound_1 = uint2(4294967295u);
+    while(true) {
+        if (metal::all(loop_bound_1 == uint2(0u))) { break; }
+        loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
+        bool _e38 = rq.next();
+        if (_e38) {
+        } else {
+            break;
+        }
+    }
+    RayIntersection second = ray_query_get_intersection_true(rq);
+    uint _e43 = uni.index;
+    out[_e43] = metal::float2(first.t, second.t);
+    return;
+}

--- a/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
+++ b/naga/tests/out/msl/wgsl-ray-query-no-init-tracking.metal
@@ -3,6 +3,47 @@
 #include <simd/simd.h>
 
 using metal::uint;
+struct NagaRayQuery {
+    thread metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data>& query;
+    bool initialized = false;
+    bool candidate = false;
+    bool finished = false;
+    float tmin = 0.0;
+    float tmax = 0.0;
+
+    bool next() thread {
+        if (!initialized || finished) return false;
+        candidate = query.next();
+        finished = !candidate;
+        return candidate;
+    }
+
+    void abort() thread {
+        if (candidate) {
+            query.abort();
+            candidate = false;
+            finished = true;
+        }
+    }
+
+    void commit_triangle_intersection() thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::triangle) {
+            query.commit_triangle_intersection();
+        }
+    }
+
+    void commit_bounding_box_intersection(float distance) thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::bounding_box) {
+            float closest = tmax;
+            if (query.get_committed_intersection_type() != metal::raytracing::intersection_type::none) {
+                closest = query.get_committed_distance();
+            }
+            if ((as_type<uint>(distance) & 0x7fffffffu) <= 0x7f800000u && distance >= tmin && distance <= closest) {
+                query.commit_bounding_box_intersection(distance);
+            }
+        }
+    }
+};
 
 struct RayIntersection {
     uint kind;
@@ -32,8 +73,10 @@ struct Output {
     metal::float3 normal;
 };
 
-RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> intersector) {
+RayIntersection ray_query_get_intersection_true(thread NagaRayQuery& rq) {
     RayIntersection intersection = RayIntersection {};
+    if (!rq.finished) return intersection;
+    thread auto& intersector = rq.query;
     metal::raytracing::intersection_type ty = intersector.get_committed_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
         intersection.kind = 1;
@@ -58,36 +101,49 @@ RayIntersection query_loop(
     metal::float3 dir,
     metal::raytracing::instance_acceleration_structure acs
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq_1 = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> naga_ray_query_rq_2;
+    NagaRayQuery rq_2 = {naga_ray_query_rq_2};
     RayDesc _e8 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
-        RayDesc desc = _e8;
-        metal::raytracing::intersection_params params;
-        params.set_opacity_cull_mode(
-            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
-                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
-            )
-        );
-        params.force_opacity(
-            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
-                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
-            )
-        );
-        params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
-        rq_1.reset(ray,acs, desc.cull_mask, params);
+        RayDesc naga_ray_query_desc = _e8;
+        thread NagaRayQuery& naga_ray_query_ref = rq_2;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,acs, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
     }
     uint2 loop_bound = uint2(4294967295u);
     while(true) {
         if (metal::all(loop_bound == uint2(0u))) { break; }
         loop_bound -= uint2(loop_bound.y == 0u, 1u);
-        bool _e9 = rq_1.next();
+        bool _e9 = rq_2.next();
         if (_e9) {
         } else {
             break;
         }
     }
-    return ray_query_get_intersection_true(rq_1);
+    return ray_query_get_intersection_true(rq_2);
 }
 
 metal::float3 get_torus_normal(
@@ -113,8 +169,10 @@ metal::float3 get_torus_normal(
     return;
 }
 
-RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> intersector) {
+RayIntersection ray_query_get_intersection_false(thread NagaRayQuery& rq) {
     RayIntersection intersection = RayIntersection {};
+    if (!rq.candidate) return intersection;
+    thread auto& intersector = rq.query;
     metal::raytracing::intersection_type ty = intersector.get_candidate_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
         intersection.kind = 1;
@@ -138,26 +196,39 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> naga_ray_query_rq;
+    NagaRayQuery rq = {naga_ray_query_rq};
     metal::float3 pos_2 = metal::float3(0.0);
     metal::float3 dir_2 = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos_2, dir_2};
     {
-        RayDesc desc = _e12;
-        metal::raytracing::intersection_params params;
-        params.set_opacity_cull_mode(
-            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
-                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
-            )
-        );
-        params.force_opacity(
-            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
-                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
-            )
-        );
-        params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
-        rq.reset(ray,acc_struct, desc.cull_mask, params);
+        RayDesc naga_ray_query_desc = _e12;
+        thread NagaRayQuery& naga_ray_query_ref = rq;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,acc_struct, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
     }
     RayIntersection intersection_1 = ray_query_get_intersection_false(rq);
     if (intersection_1.kind == 3u) {
@@ -172,4 +243,103 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
             return;
         }
     }
+}
+
+
+[[max_total_threads_per_threadgroup(1)]] kernel void runtime_flags_and_reinitialize(
+  metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
+, device Output& output [[user(fake0)]]
+) {
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> naga_ray_query_rq_1;
+    NagaRayQuery rq_1 = {naga_ray_query_rq_1};
+    bool _e1 = rq_1.next();
+    rq_1.commit_triangle_intersection();
+    rq_1.commit_bounding_box_intersection(1.0);
+    rq_1.abort();
+    output.visible = ray_query_get_intersection_false(rq_1).kind;
+    uint _e10 = output.visible;
+    RayDesc _e20 = RayDesc {_e10, 255u, 0.0, 100.0, metal::float3(0.0), metal::float3(0.0, 0.0, 1.0)};
+    {
+        RayDesc naga_ray_query_desc = _e20;
+        thread NagaRayQuery& naga_ray_query_ref = rq_1;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,acc_struct, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
+    }
+    uint2 loop_bound_1 = uint2(4294967295u);
+    while(true) {
+        if (metal::all(loop_bound_1 == uint2(0u))) { break; }
+        loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
+        bool _e21 = rq_1.next();
+        if (_e21) {
+        } else {
+            break;
+        }
+        {
+            RayIntersection hit = ray_query_get_intersection_false(rq_1);
+            if (hit.kind == 1u) {
+                rq_1.commit_triangle_intersection();
+            } else {
+                rq_1.commit_bounding_box_intersection(10.0);
+            }
+        }
+    }
+    output.visible = ray_query_get_intersection_true(rq_1).kind;
+    bool _e31 = rq_1.next();
+    RayDesc _e43 = RayDesc {0u, 255u, 1.0, 0.0, metal::float3(0.0), metal::float3(0.0, 0.0, 1.0)};
+    {
+        RayDesc naga_ray_query_desc = _e43;
+        thread NagaRayQuery& naga_ray_query_ref = rq_1;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,acc_struct, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
+    }
+    bool _e44 = rq_1.next();
+    uint _e47 = output.visible;
+    output.visible = _e47 + ray_query_get_intersection_true(rq_1).kind;
+    return;
 }

--- a/naga/tests/out/msl/wgsl-ray-query.metal
+++ b/naga/tests/out/msl/wgsl-ray-query.metal
@@ -3,6 +3,47 @@
 #include <simd/simd.h>
 
 using metal::uint;
+struct NagaRayQuery {
+    thread metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data>& query;
+    bool initialized = false;
+    bool candidate = false;
+    bool finished = false;
+    float tmin = 0.0;
+    float tmax = 0.0;
+
+    bool next() thread {
+        if (!initialized || finished) return false;
+        candidate = query.next();
+        finished = !candidate;
+        return candidate;
+    }
+
+    void abort() thread {
+        if (candidate) {
+            query.abort();
+            candidate = false;
+            finished = true;
+        }
+    }
+
+    void commit_triangle_intersection() thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::triangle) {
+            query.commit_triangle_intersection();
+        }
+    }
+
+    void commit_bounding_box_intersection(float distance) thread {
+        if (candidate && query.get_candidate_intersection_type() == metal::raytracing::intersection_type::bounding_box) {
+            float closest = tmax;
+            if (query.get_committed_intersection_type() != metal::raytracing::intersection_type::none) {
+                closest = query.get_committed_distance();
+            }
+            if ((as_type<uint>(distance) & 0x7fffffffu) <= 0x7f800000u && distance >= tmin && distance <= closest) {
+                query.commit_bounding_box_intersection(distance);
+            }
+        }
+    }
+};
 
 struct RayIntersection {
     uint kind;
@@ -32,8 +73,10 @@ struct Output {
     metal::float3 normal;
 };
 
-RayIntersection ray_query_get_intersection_true(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> intersector) {
+RayIntersection ray_query_get_intersection_true(thread NagaRayQuery& rq) {
     RayIntersection intersection = RayIntersection {};
+    if (!rq.finished) return intersection;
+    thread auto& intersector = rq.query;
     metal::raytracing::intersection_type ty = intersector.get_committed_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
         intersection.kind = 1;
@@ -58,36 +101,49 @@ RayIntersection query_loop(
     metal::float3 dir,
     metal::raytracing::instance_acceleration_structure acs
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq_1 = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> naga_ray_query_rq_2;
+    NagaRayQuery rq_2 = {naga_ray_query_rq_2};
     RayDesc _e8 = RayDesc {4u, 255u, 0.1, 100.0, pos, dir};
     {
-        RayDesc desc = _e8;
-        metal::raytracing::intersection_params params;
-        params.set_opacity_cull_mode(
-            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
-                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
-            )
-        );
-        params.force_opacity(
-            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
-                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
-            )
-        );
-        params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
-        rq_1.reset(ray,acs, desc.cull_mask, params);
+        RayDesc naga_ray_query_desc = _e8;
+        thread NagaRayQuery& naga_ray_query_ref = rq_2;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,acs, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
     }
     uint2 loop_bound = uint2(4294967295u);
     while(true) {
         if (metal::all(loop_bound == uint2(0u))) { break; }
         loop_bound -= uint2(loop_bound.y == 0u, 1u);
-        bool _e9 = rq_1.next();
+        bool _e9 = rq_2.next();
         if (_e9) {
         } else {
             break;
         }
     }
-    return ray_query_get_intersection_true(rq_1);
+    return ray_query_get_intersection_true(rq_2);
 }
 
 metal::float3 get_torus_normal(
@@ -113,8 +169,10 @@ metal::float3 get_torus_normal(
     return;
 }
 
-RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> intersector) {
+RayIntersection ray_query_get_intersection_false(thread NagaRayQuery& rq) {
     RayIntersection intersection = RayIntersection {};
+    if (!rq.candidate) return intersection;
+    thread auto& intersector = rq.query;
     metal::raytracing::intersection_type ty = intersector.get_candidate_intersection_type();
     if (ty == metal::raytracing::intersection_type::triangle) {
         intersection.kind = 1;
@@ -138,26 +196,39 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
 [[max_total_threads_per_threadgroup(1)]] kernel void main_candidate(
   metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
 ) {
-    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> rq = {};
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> naga_ray_query_rq;
+    NagaRayQuery rq = {naga_ray_query_rq};
     metal::float3 pos_2 = metal::float3(0.0);
     metal::float3 dir_2 = metal::float3(0.0, 1.0, 0.0);
     RayDesc _e12 = RayDesc {4u, 255u, 0.1, 100.0, pos_2, dir_2};
     {
-        RayDesc desc = _e12;
-        metal::raytracing::intersection_params params;
-        params.set_opacity_cull_mode(
-            (desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
-                (desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
-            )
-        );
-        params.force_opacity(
-            (desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
-                (desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
-            )
-        );
-        params.accept_any_intersection((desc.flags & 4) != 0);
-        metal::raytracing::ray ray = metal::raytracing::ray(desc.origin, desc.dir, desc.tmin, desc.tmax);
-        rq.reset(ray,acc_struct, desc.cull_mask, params);
+        RayDesc naga_ray_query_desc = _e12;
+        thread NagaRayQuery& naga_ray_query_ref = rq;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,acc_struct, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
     }
     RayIntersection intersection_1 = ray_query_get_intersection_false(rq);
     if (intersection_1.kind == 3u) {
@@ -172,4 +243,103 @@ RayIntersection ray_query_get_intersection_false(metal::raytracing::intersection
             return;
         }
     }
+}
+
+
+[[max_total_threads_per_threadgroup(1)]] kernel void runtime_flags_and_reinitialize(
+  metal::raytracing::instance_acceleration_structure acc_struct [[user(fake0)]]
+, device Output& output [[user(fake0)]]
+) {
+    metal::raytracing::intersection_query<metal::raytracing::instancing, metal::raytracing::triangle_data> naga_ray_query_rq_1;
+    NagaRayQuery rq_1 = {naga_ray_query_rq_1};
+    bool _e1 = rq_1.next();
+    rq_1.commit_triangle_intersection();
+    rq_1.commit_bounding_box_intersection(1.0);
+    rq_1.abort();
+    output.visible = ray_query_get_intersection_false(rq_1).kind;
+    uint _e10 = output.visible;
+    RayDesc _e20 = RayDesc {_e10, 255u, 0.0, 100.0, metal::float3(0.0), metal::float3(0.0, 0.0, 1.0)};
+    {
+        RayDesc naga_ray_query_desc = _e20;
+        thread NagaRayQuery& naga_ray_query_ref = rq_1;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,acc_struct, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
+    }
+    uint2 loop_bound_1 = uint2(4294967295u);
+    while(true) {
+        if (metal::all(loop_bound_1 == uint2(0u))) { break; }
+        loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
+        bool _e21 = rq_1.next();
+        if (_e21) {
+        } else {
+            break;
+        }
+        {
+            RayIntersection hit = ray_query_get_intersection_false(rq_1);
+            if (hit.kind == 1u) {
+                rq_1.commit_triangle_intersection();
+            } else {
+                rq_1.commit_bounding_box_intersection(10.0);
+            }
+        }
+    }
+    output.visible = ray_query_get_intersection_true(rq_1).kind;
+    bool _e31 = rq_1.next();
+    RayDesc _e43 = RayDesc {0u, 255u, 1.0, 0.0, metal::float3(0.0), metal::float3(0.0, 0.0, 1.0)};
+    {
+        RayDesc naga_ray_query_desc = _e43;
+        thread NagaRayQuery& naga_ray_query_ref = rq_1;
+        naga_ray_query_ref.initialized = false; naga_ray_query_ref.candidate = false; naga_ray_query_ref.finished = false;
+        bool naga_ray_query_valid_origin = metal::all((as_type<metal::uint3>(naga_ray_query_desc.origin) & 0x7f800000u) != 0x7f800000u);
+        bool naga_ray_query_valid_dir = metal::all((as_type<metal::uint3>(naga_ray_query_desc.dir) & 0x7f800000u) != 0x7f800000u) && metal::any(naga_ray_query_desc.dir != metal::float3(0.0));
+        bool naga_ray_query_valid_range = (as_type<uint>(naga_ray_query_desc.tmin) & 0x7f800000u) != 0x7f800000u && (as_type<uint>(naga_ray_query_desc.tmax) & 0x7fffffffu) <= 0x7f800000u && naga_ray_query_desc.tmin >= 0.0 && naga_ray_query_desc.tmax >= naga_ray_query_desc.tmin;
+        bool naga_ray_query_valid_flags = metal::popcount(naga_ray_query_desc.flags & 195u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 304u) <= 1 && metal::popcount(naga_ray_query_desc.flags & 768u) <= 1;
+        if (naga_ray_query_valid_origin && naga_ray_query_valid_dir && naga_ray_query_valid_range && naga_ray_query_valid_flags) {
+            metal::raytracing::intersection_params naga_ray_query_params;
+            naga_ray_query_params.set_opacity_cull_mode(
+                (naga_ray_query_desc.flags & 64) != 0 ? metal::raytracing::opacity_cull_mode::opaque : (
+                    (naga_ray_query_desc.flags & 128) != 0 ? metal::raytracing::opacity_cull_mode::non_opaque : metal::raytracing::opacity_cull_mode::none
+                )
+            );
+            naga_ray_query_params.force_opacity(
+                (naga_ray_query_desc.flags & 1) != 0 ? metal::raytracing::forced_opacity::opaque : (
+                    (naga_ray_query_desc.flags & 2) != 0 ? metal::raytracing::forced_opacity::non_opaque : metal::raytracing::forced_opacity::none
+                )
+            );
+            naga_ray_query_params.accept_any_intersection((naga_ray_query_desc.flags & 4) != 0);
+            naga_ray_query_params.set_triangle_front_facing_winding(metal::winding::clockwise);
+            naga_ray_query_params.set_triangle_cull_mode((naga_ray_query_desc.flags & 16u) != 0 ? metal::raytracing::triangle_cull_mode::back : ((naga_ray_query_desc.flags & 32u) != 0 ? metal::raytracing::triangle_cull_mode::front : metal::raytracing::triangle_cull_mode::none));
+            naga_ray_query_params.set_geometry_cull_mode((naga_ray_query_desc.flags & 256u) != 0 ? metal::raytracing::geometry_cull_mode::triangle : ((naga_ray_query_desc.flags & 512u) != 0 ? metal::raytracing::geometry_cull_mode::bounding_box : metal::raytracing::geometry_cull_mode::none));
+            metal::raytracing::ray naga_ray_query_ray = metal::raytracing::ray(naga_ray_query_desc.origin, naga_ray_query_desc.dir, naga_ray_query_desc.tmin, naga_ray_query_desc.tmax);
+            naga_ray_query_ref.query.reset(naga_ray_query_ray,acc_struct, naga_ray_query_desc.cull_mask, naga_ray_query_params);
+            naga_ray_query_ref.initialized = true; naga_ray_query_ref.tmin = naga_ray_query_desc.tmin; naga_ray_query_ref.tmax = naga_ray_query_desc.tmax;
+        }
+    }
+    bool _e44 = rq_1.next();
+    uint _e47 = output.visible;
+    output.visible = _e47 + ray_query_get_intersection_true(rq_1).kind;
+    return;
 }

--- a/naga/tests/out/spv/wgsl-ray-query-binding-arrays.spvasm
+++ b/naga/tests/out/spv/wgsl-ray-query-binding-arrays.spvasm
@@ -1,0 +1,389 @@
+; SPIR-V
+; Version: 1.4
+; Generator: rspirv
+; Bound: 275
+OpCapability Shader
+OpCapability RayQueryKHR
+OpExtension "SPV_KHR_ray_query"
+%1 = OpExtInstImport "GLSL.std.450"
+OpMemoryModel Logical GLSL450
+OpEntryPoint GLCompute %30 "main" %18 %22 %23 %26
+OpExecutionMode %30 LocalSize 1 1 1
+OpMemberDecorate %4 0 Offset 0
+OpDecorate %11 ArrayStride 8
+OpMemberDecorate %14 0 Offset 0
+OpMemberDecorate %14 1 Offset 4
+OpMemberDecorate %14 2 Offset 8
+OpMemberDecorate %14 3 Offset 12
+OpMemberDecorate %14 4 Offset 16
+OpMemberDecorate %14 5 Offset 32
+OpMemberDecorate %17 0 Offset 0
+OpMemberDecorate %17 1 Offset 4
+OpMemberDecorate %17 2 Offset 8
+OpMemberDecorate %17 3 Offset 12
+OpMemberDecorate %17 4 Offset 16
+OpMemberDecorate %17 5 Offset 20
+OpMemberDecorate %17 6 Offset 24
+OpMemberDecorate %17 7 Offset 28
+OpMemberDecorate %17 8 Offset 36
+OpMemberDecorate %17 9 Offset 48
+OpMemberDecorate %17 9 ColMajor
+OpMemberDecorate %17 9 MatrixStride 16
+OpMemberDecorate %17 10 Offset 112
+OpMemberDecorate %17 10 ColMajor
+OpMemberDecorate %17 10 MatrixStride 16
+OpDecorate %18 DescriptorSet 0
+OpDecorate %18 Binding 0
+OpDecorate %22 DescriptorSet 0
+OpDecorate %22 Binding 1
+OpDecorate %23 DescriptorSet 0
+OpDecorate %23 Binding 2
+OpDecorate %24 Block
+OpMemberDecorate %24 0 Offset 0
+OpDecorate %26 DescriptorSet 0
+OpDecorate %26 Binding 3
+OpDecorate %27 Block
+OpMemberDecorate %27 0 Offset 0
+%2 = OpTypeVoid
+%3 = OpTypeInt 32 0
+%4 = OpTypeStruct %3
+%5 = OpTypeAccelerationStructureKHR
+%7 = OpConstant  %3  4
+%6 = OpTypeArray %5 %7
+%8 = OpTypeRuntimeArray %5
+%9 = OpTypeFloat 32
+%10 = OpTypeVector %9 2
+%11 = OpTypeRuntimeArray %10
+%12 = OpTypeRayQueryKHR
+%13 = OpTypeVector %9 3
+%14 = OpTypeStruct %3 %3 %9 %9 %13 %13
+%15 = OpTypeBool
+%16 = OpTypeMatrix %13 4
+%17 = OpTypeStruct %3 %9 %3 %3 %3 %3 %3 %10 %15 %16 %16
+%20 = OpConstant  %3  10
+%19 = OpTypeArray %5 %20
+%21 = OpTypePointer UniformConstant %19
+%18 = OpVariable  %21  UniformConstant
+%22 = OpVariable  %21  UniformConstant
+%24 = OpTypeStruct %4
+%25 = OpTypePointer Uniform %24
+%23 = OpVariable  %25  Uniform
+%27 = OpTypeStruct %11
+%28 = OpTypePointer StorageBuffer %27
+%26 = OpVariable  %28  StorageBuffer
+%31 = OpTypeFunction %2
+%32 = OpTypePointer Uniform %4
+%33 = OpConstant  %3  0
+%35 = OpTypePointer StorageBuffer %11
+%37 = OpConstant  %3  255
+%38 = OpConstant  %9  0
+%39 = OpConstant  %9  -2
+%40 = OpConstantComposite  %13  %38 %38 %39
+%41 = OpConstant  %9  1
+%42 = OpConstantComposite  %13  %38 %38 %41
+%43 = OpConstant  %9  0.1
+%44 = OpConstant  %9  100
+%45 = OpConstantComposite  %14  %7 %37 %43 %44 %40 %42
+%47 = OpTypePointer Function %12
+%48 = OpTypePointer Function %3
+%50 = OpTypePointer Function %9
+%53 = OpTypePointer Uniform %3
+%56 = OpTypePointer UniformConstant %5
+%59 = OpTypeFunction %2 %47 %5 %14 %48 %50
+%67 = OpTypeVector %15 3
+%88 = OpConstant  %3  256
+%91 = OpConstant  %3  512
+%96 = OpConstant  %3  16
+%99 = OpConstant  %3  32
+%108 = OpConstant  %3  1
+%111 = OpConstant  %3  2
+%114 = OpConstant  %3  64
+%117 = OpConstant  %3  128
+%146 = OpTypeVector %3 2
+%147 = OpTypePointer Function %146
+%148 = OpTypeVector %15 2
+%149 = OpConstantComposite  %146  %33 %33
+%150 = OpConstant  %3  4294967295
+%151 = OpConstantComposite  %146  %150 %150
+%164 = OpTypePointer Function %15
+%165 = OpTypeFunction %15 %47 %48
+%171 = OpConstantFalse  %15
+%178 = OpConstant  %3  6
+%186 = OpTypePointer Function %17
+%187 = OpTypePointer Function %16
+%188 = OpTypePointer Function %10
+%189 = OpTypeFunction %17 %47 %48
+%194 = OpConstantNull  %17
+%217 = OpConstant  %3  3
+%220 = OpConstant  %3  5
+%223 = OpConstant  %3  9
+%233 = OpConstant  %3  7
+%235 = OpConstant  %3  8
+%270 = OpTypePointer StorageBuffer %10
+%60 = OpFunction  %2  None %59
+%61 = OpFunctionParameter  %47
+%62 = OpFunctionParameter  %5
+%63 = OpFunctionParameter  %14
+%64 = OpFunctionParameter  %48
+%65 = OpFunctionParameter  %50
+%66 = OpLabel
+%68 = OpCompositeExtract  %3  %63 0
+%69 = OpCompositeExtract  %3  %63 1
+%70 = OpCompositeExtract  %9  %63 2
+%71 = OpCompositeExtract  %9  %63 3
+%72 = OpCompositeExtract  %13  %63 4
+%73 = OpCompositeExtract  %13  %63 5
+%74 = OpFOrdLessThanEqual  %15  %70 %71
+%75 = OpFOrdGreaterThanEqual  %15  %70 %38
+%76 = OpIsInf  %67  %72
+%77 = OpAny  %15  %76
+%78 = OpIsNan  %67  %72
+%79 = OpAny  %15  %78
+%80 = OpLogicalOr  %15  %79 %77
+%81 = OpLogicalNot  %15  %80
+%82 = OpIsInf  %67  %73
+%83 = OpAny  %15  %82
+%84 = OpIsNan  %67  %73
+%85 = OpAny  %15  %84
+%86 = OpLogicalOr  %15  %85 %83
+%87 = OpLogicalNot  %15  %86
+%89 = OpBitwiseAnd  %3  %68 %88
+%90 = OpINotEqual  %15  %89 %33
+%92 = OpBitwiseAnd  %3  %68 %91
+%93 = OpINotEqual  %15  %92 %33
+%94 = OpLogicalAnd  %15  %93 %90
+%95 = OpLogicalNot  %15  %94
+%97 = OpBitwiseAnd  %3  %68 %96
+%98 = OpINotEqual  %15  %97 %33
+%100 = OpBitwiseAnd  %3  %68 %99
+%101 = OpINotEqual  %15  %100 %33
+%102 = OpLogicalAnd  %15  %101 %90
+%103 = OpLogicalAnd  %15  %101 %98
+%104 = OpLogicalAnd  %15  %98 %90
+%105 = OpLogicalOr  %15  %104 %102
+%106 = OpLogicalOr  %15  %105 %103
+%107 = OpLogicalNot  %15  %106
+%109 = OpBitwiseAnd  %3  %68 %108
+%110 = OpINotEqual  %15  %109 %33
+%112 = OpBitwiseAnd  %3  %68 %111
+%113 = OpINotEqual  %15  %112 %33
+%115 = OpBitwiseAnd  %3  %68 %114
+%116 = OpINotEqual  %15  %115 %33
+%118 = OpBitwiseAnd  %3  %68 %117
+%119 = OpINotEqual  %15  %118 %33
+%120 = OpLogicalAnd  %15  %119 %110
+%121 = OpLogicalAnd  %15  %119 %113
+%122 = OpLogicalAnd  %15  %119 %116
+%123 = OpLogicalAnd  %15  %116 %110
+%124 = OpLogicalAnd  %15  %116 %113
+%125 = OpLogicalAnd  %15  %113 %110
+%126 = OpLogicalOr  %15  %125 %120
+%127 = OpLogicalOr  %15  %126 %121
+%128 = OpLogicalOr  %15  %127 %122
+%129 = OpLogicalOr  %15  %128 %123
+%130 = OpLogicalOr  %15  %129 %124
+%131 = OpLogicalNot  %15  %130
+%132 = OpLogicalAnd  %15  %131 %74
+%133 = OpLogicalAnd  %15  %132 %75
+%134 = OpLogicalAnd  %15  %133 %81
+%135 = OpLogicalAnd  %15  %134 %87
+%136 = OpLogicalAnd  %15  %135 %95
+%137 = OpLogicalAnd  %15  %136 %107
+OpStore %65 %71
+OpSelectionMerge %138 None
+OpBranchConditional %137 %140 %139
+%140 = OpLabel
+OpRayQueryInitializeKHR %61 %62 %68 %69 %72 %70 %73 %71
+OpStore %64 %108
+OpBranch %138
+%139 = OpLabel
+OpBranch %138
+%138 = OpLabel
+OpReturn
+OpFunctionEnd
+%166 = OpFunction  %15  None %165
+%167 = OpFunctionParameter  %47
+%168 = OpFunctionParameter  %48
+%169 = OpLabel
+%170 = OpVariable  %164  Function %171
+%172 = OpLoad  %3  %168
+%175 = OpBitwiseAnd  %3  %172 %108
+%176 = OpINotEqual  %15  %175 %33
+OpSelectionMerge %173 None
+OpBranchConditional %176 %174 %173
+%174 = OpLabel
+%177 = OpRayQueryProceedKHR  %15  %167
+OpStore %170 %177
+%179 = OpSelect  %3  %177 %111 %178
+%180 = OpBitwiseOr  %3  %172 %179
+OpStore %168 %180
+OpBranch %173
+%173 = OpLabel
+%181 = OpLoad  %15  %170
+OpReturnValue %181
+OpFunctionEnd
+%190 = OpFunction  %17  None %189
+%191 = OpFunctionParameter  %47
+%192 = OpFunctionParameter  %48
+%193 = OpLabel
+%195 = OpVariable  %186  Function %194
+%196 = OpLoad  %3  %192
+%197 = OpBitwiseAnd  %3  %196 %111
+%198 = OpINotEqual  %15  %197 %33
+%199 = OpBitwiseAnd  %3  %196 %7
+%200 = OpINotEqual  %15  %199 %33
+%201 = OpLogicalAnd  %15  %200 %198
+OpSelectionMerge %203 None
+OpBranchConditional %201 %202 %203
+%202 = OpLabel
+%204 = OpRayQueryGetIntersectionTypeKHR  %3  %191 %108
+%205 = OpAccessChain  %48  %195 %33
+OpStore %205 %204
+%206 = OpINotEqual  %15  %204 %33
+OpSelectionMerge %208 None
+OpBranchConditional %206 %207 %208
+%207 = OpLabel
+%209 = OpRayQueryGetIntersectionInstanceCustomIndexKHR  %3  %191 %108
+%210 = OpRayQueryGetIntersectionInstanceIdKHR  %3  %191 %108
+%211 = OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR  %3  %191 %108
+%212 = OpRayQueryGetIntersectionGeometryIndexKHR  %3  %191 %108
+%213 = OpRayQueryGetIntersectionPrimitiveIndexKHR  %3  %191 %108
+%214 = OpRayQueryGetIntersectionObjectToWorldKHR  %16  %191 %108
+%215 = OpRayQueryGetIntersectionWorldToObjectKHR  %16  %191 %108
+%216 = OpAccessChain  %48  %195 %111
+OpStore %216 %209
+%218 = OpAccessChain  %48  %195 %217
+OpStore %218 %210
+%219 = OpAccessChain  %48  %195 %7
+OpStore %219 %211
+%221 = OpAccessChain  %48  %195 %220
+OpStore %221 %212
+%222 = OpAccessChain  %48  %195 %178
+OpStore %222 %213
+%224 = OpAccessChain  %187  %195 %223
+OpStore %224 %214
+%225 = OpAccessChain  %187  %195 %20
+OpStore %225 %215
+%226 = OpIEqual  %15  %204 %108
+%229 = OpRayQueryGetIntersectionTKHR  %9  %191 %108
+%230 = OpAccessChain  %50  %195 %108
+OpStore %230 %229
+OpSelectionMerge %228 None
+OpBranchConditional %206 %227 %228
+%227 = OpLabel
+%231 = OpRayQueryGetIntersectionBarycentricsKHR  %10  %191 %108
+%232 = OpRayQueryGetIntersectionFrontFaceKHR  %15  %191 %108
+%234 = OpAccessChain  %188  %195 %233
+OpStore %234 %231
+%236 = OpAccessChain  %164  %195 %235
+OpStore %236 %232
+OpBranch %228
+%228 = OpLabel
+OpBranch %208
+%208 = OpLabel
+OpBranch %203
+%203 = OpLabel
+%237 = OpLoad  %17  %195
+OpReturnValue %237
+OpFunctionEnd
+%30 = OpFunction  %2  None %31
+%29 = OpLabel
+%46 = OpVariable  %47  Function
+%49 = OpVariable  %48  Function %33
+%51 = OpVariable  %50  Function %38
+%152 = OpVariable  %147  Function %151
+%251 = OpVariable  %147  Function %151
+%34 = OpAccessChain  %32  %23 %33
+%36 = OpAccessChain  %35  %26 %33
+OpBranch %52
+%52 = OpLabel
+%54 = OpAccessChain  %53  %34 %33
+%55 = OpLoad  %3  %54
+%57 = OpAccessChain  %56  %18 %55
+%58 = OpLoad  %5  %57
+%141 = OpFunctionCall  %2  %60 %46 %58 %45 %49 %51
+OpBranch %142
+%142 = OpLabel
+OpLoopMerge %143 %145 None
+OpBranch %153
+%153 = OpLabel
+%154 = OpLoad  %146  %152
+%155 = OpIEqual  %148  %149 %154
+%156 = OpAll  %15  %155
+OpSelectionMerge %157 None
+OpBranchConditional %156 %143 %157
+%157 = OpLabel
+%158 = OpCompositeExtract  %3  %154 1
+%159 = OpIEqual  %15  %158 %33
+%160 = OpSelect  %3  %159 %108 %33
+%161 = OpCompositeConstruct  %146  %160 %108
+%162 = OpISub  %146  %154 %161
+OpStore %152 %162
+OpBranch %144
+%144 = OpLabel
+%163 = OpFunctionCall  %15  %166 %46 %49
+OpSelectionMerge %182 None
+OpBranchConditional %163 %182 %183
+%183 = OpLabel
+OpBranch %143
+%182 = OpLabel
+OpBranch %184
+%184 = OpLabel
+OpBranch %185
+%185 = OpLabel
+OpBranch %145
+%145 = OpLabel
+OpBranch %142
+%143 = OpLabel
+%238 = OpFunctionCall  %17  %190 %46 %49
+%239 = OpAccessChain  %53  %34 %33
+%240 = OpLoad  %3  %239
+%241 = OpAccessChain  %56  %22 %240
+%242 = OpLoad  %5  %241
+%243 = OpCompositeExtract  %10  %238 7
+%244 = OpCompositeConstruct  %13  %243 %38
+%245 = OpCompositeConstruct  %14  %7 %37 %43 %44 %244 %42
+%246 = OpFunctionCall  %2  %60 %46 %242 %245 %49 %51
+OpBranch %247
+%247 = OpLabel
+OpLoopMerge %248 %250 None
+OpBranch %252
+%252 = OpLabel
+%253 = OpLoad  %146  %251
+%254 = OpIEqual  %148  %149 %253
+%255 = OpAll  %15  %254
+OpSelectionMerge %256 None
+OpBranchConditional %255 %248 %256
+%256 = OpLabel
+%257 = OpCompositeExtract  %3  %253 1
+%258 = OpIEqual  %15  %257 %33
+%259 = OpSelect  %3  %258 %108 %33
+%260 = OpCompositeConstruct  %146  %259 %108
+%261 = OpISub  %146  %253 %260
+OpStore %251 %261
+OpBranch %249
+%249 = OpLabel
+%262 = OpFunctionCall  %15  %166 %46 %49
+OpSelectionMerge %263 None
+OpBranchConditional %262 %263 %264
+%264 = OpLabel
+OpBranch %248
+%263 = OpLabel
+OpBranch %265
+%265 = OpLabel
+OpBranch %266
+%266 = OpLabel
+OpBranch %250
+%250 = OpLabel
+OpBranch %247
+%248 = OpLabel
+%267 = OpFunctionCall  %17  %190 %46 %49
+%268 = OpAccessChain  %53  %34 %33
+%269 = OpLoad  %3  %268
+%271 = OpCompositeExtract  %9  %238 1
+%272 = OpCompositeExtract  %9  %267 1
+%273 = OpCompositeConstruct  %10  %271 %272
+%274 = OpAccessChain  %270  %36 %269
+OpStore %274 %273
+OpReturn
+OpFunctionEnd

--- a/naga/tests/out/spv/wgsl-ray-query-no-init-tracking.spvasm
+++ b/naga/tests/out/spv/wgsl-ray-query-no-init-tracking.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.4
 ; Generator: rspirv
-; Bound: 396
+; Bound: 457
 OpCapability Shader
 OpCapability RayQueryKHR
 OpExtension "SPV_KHR_ray_query"
@@ -9,8 +9,10 @@ OpExtension "SPV_KHR_ray_query"
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %242 "main" %15 %17
 OpEntryPoint GLCompute %262 "main_candidate" %15
+OpEntryPoint GLCompute %397 "runtime_flags_and_reinitialize" %15 %17
 OpExecutionMode %242 LocalSize 1 1 1
 OpExecutionMode %262 LocalSize 1 1 1
+OpExecutionMode %397 LocalSize 1 1 1
 OpMemberDecorate %10 0 Offset 0
 OpMemberDecorate %10 1 Offset 4
 OpMemberDecorate %10 2 Offset 8
@@ -112,6 +114,8 @@ OpMemberDecorate %18 0 Offset 0
 %265 = OpConstant  %3  10
 %322 = OpTypeFunction %2 %32 %33 %3 %36
 %363 = OpTypeFunction %2 %32 %33
+%400 = OpConstantComposite  %4  %38 %38 %227
+%401 = OpConstantComposite  %12  %35 %28 %227 %38 %247 %400
 %42 = OpFunction  %2  None %41
 %43 = OpFunctionParameter  %32
 %44 = OpFunctionParameter  %5
@@ -558,5 +562,88 @@ OpReturn
 %360 = OpLabel
 OpBranch %319
 %319 = OpLabel
+OpReturn
+OpFunctionEnd
+%397 = OpFunction  %2  None %243
+%396 = OpLabel
+%402 = OpVariable  %32  Function
+%403 = OpVariable  %33  Function %35
+%404 = OpVariable  %36  Function %38
+%421 = OpVariable  %129  Function %133
+%398 = OpLoad  %5  %15
+%399 = OpAccessChain  %245  %17 %35
+OpBranch %405
+%405 = OpLabel
+%406 = OpFunctionCall  %8  %148 %402 %403
+%407 = OpFunctionCall  %2  %364 %402 %403
+%408 = OpFunctionCall  %2  %323 %402 %403 %227 %404
+%409 = OpFunctionCall  %2  %383 %402 %403
+%410 = OpFunctionCall  %10  %271 %402 %403
+%411 = OpCompositeExtract  %6  %410 0
+%412 = OpAccessChain  %251  %399 %35
+OpStore %412 %411
+%413 = OpAccessChain  %251  %399 %35
+%414 = OpLoad  %6  %413
+%415 = OpCompositeConstruct  %12  %414 %28 %38 %30 %247 %400
+%416 = OpFunctionCall  %2  %42 %402 %398 %415 %403 %404
+OpBranch %417
+%417 = OpLabel
+OpLoopMerge %418 %420 None
+OpBranch %422
+%422 = OpLabel
+%423 = OpLoad  %128  %421
+%424 = OpIEqual  %130  %131 %423
+%425 = OpAll  %8  %424
+OpSelectionMerge %426 None
+OpBranchConditional %425 %418 %426
+%426 = OpLabel
+%427 = OpCompositeExtract  %6  %423 1
+%428 = OpIEqual  %8  %427 %35
+%429 = OpSelect  %6  %428 %90 %35
+%430 = OpCompositeConstruct  %128  %429 %90
+%431 = OpISub  %128  %423 %430
+OpStore %421 %431
+OpBranch %419
+%419 = OpLabel
+%432 = OpFunctionCall  %8  %148 %402 %403
+OpSelectionMerge %433 None
+OpBranchConditional %432 %433 %434
+%434 = OpLabel
+OpBranch %418
+%433 = OpLabel
+OpBranch %435
+%435 = OpLabel
+%437 = OpFunctionCall  %10  %271 %402 %403
+%438 = OpCompositeExtract  %6  %437 0
+%439 = OpIEqual  %8  %438 %90
+OpSelectionMerge %440 None
+OpBranchConditional %439 %441 %442
+%441 = OpLabel
+%443 = OpFunctionCall  %2  %364 %402 %403
+OpBranch %440
+%442 = OpLabel
+%444 = OpFunctionCall  %2  %323 %402 %403 %265 %404
+OpBranch %440
+%440 = OpLabel
+OpBranch %436
+%436 = OpLabel
+OpBranch %420
+%420 = OpLabel
+OpBranch %417
+%418 = OpLabel
+%445 = OpFunctionCall  %10  %172 %402 %403
+%446 = OpCompositeExtract  %6  %445 0
+%447 = OpAccessChain  %251  %399 %35
+OpStore %447 %446
+%448 = OpFunctionCall  %8  %148 %402 %403
+%449 = OpFunctionCall  %2  %42 %402 %398 %401 %403 %404
+%450 = OpFunctionCall  %8  %148 %402 %403
+%451 = OpAccessChain  %251  %399 %35
+%452 = OpLoad  %6  %451
+%453 = OpFunctionCall  %10  %172 %402 %403
+%454 = OpCompositeExtract  %6  %453 0
+%455 = OpIAdd  %6  %452 %454
+%456 = OpAccessChain  %251  %399 %35
+OpStore %456 %455
 OpReturn
 OpFunctionEnd

--- a/naga/tests/out/spv/wgsl-ray-query.spvasm
+++ b/naga/tests/out/spv/wgsl-ray-query.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.4
 ; Generator: rspirv
-; Bound: 396
+; Bound: 457
 OpCapability Shader
 OpCapability RayQueryKHR
 OpExtension "SPV_KHR_ray_query"
@@ -9,8 +9,10 @@ OpExtension "SPV_KHR_ray_query"
 OpMemoryModel Logical GLSL450
 OpEntryPoint GLCompute %242 "main" %15 %17
 OpEntryPoint GLCompute %262 "main_candidate" %15
+OpEntryPoint GLCompute %397 "runtime_flags_and_reinitialize" %15 %17
 OpExecutionMode %242 LocalSize 1 1 1
 OpExecutionMode %262 LocalSize 1 1 1
+OpExecutionMode %397 LocalSize 1 1 1
 OpMemberDecorate %10 0 Offset 0
 OpMemberDecorate %10 1 Offset 4
 OpMemberDecorate %10 2 Offset 8
@@ -112,6 +114,8 @@ OpMemberDecorate %18 0 Offset 0
 %265 = OpConstant  %3  10
 %322 = OpTypeFunction %2 %32 %33 %3 %36
 %363 = OpTypeFunction %2 %32 %33
+%400 = OpConstantComposite  %4  %38 %38 %227
+%401 = OpConstantComposite  %12  %35 %28 %227 %38 %247 %400
 %42 = OpFunction  %2  None %41
 %43 = OpFunctionParameter  %32
 %44 = OpFunctionParameter  %5
@@ -558,5 +562,88 @@ OpReturn
 %360 = OpLabel
 OpBranch %319
 %319 = OpLabel
+OpReturn
+OpFunctionEnd
+%397 = OpFunction  %2  None %243
+%396 = OpLabel
+%402 = OpVariable  %32  Function
+%403 = OpVariable  %33  Function %35
+%404 = OpVariable  %36  Function %38
+%421 = OpVariable  %129  Function %133
+%398 = OpLoad  %5  %15
+%399 = OpAccessChain  %245  %17 %35
+OpBranch %405
+%405 = OpLabel
+%406 = OpFunctionCall  %8  %148 %402 %403
+%407 = OpFunctionCall  %2  %364 %402 %403
+%408 = OpFunctionCall  %2  %323 %402 %403 %227 %404
+%409 = OpFunctionCall  %2  %383 %402 %403
+%410 = OpFunctionCall  %10  %271 %402 %403
+%411 = OpCompositeExtract  %6  %410 0
+%412 = OpAccessChain  %251  %399 %35
+OpStore %412 %411
+%413 = OpAccessChain  %251  %399 %35
+%414 = OpLoad  %6  %413
+%415 = OpCompositeConstruct  %12  %414 %28 %38 %30 %247 %400
+%416 = OpFunctionCall  %2  %42 %402 %398 %415 %403 %404
+OpBranch %417
+%417 = OpLabel
+OpLoopMerge %418 %420 None
+OpBranch %422
+%422 = OpLabel
+%423 = OpLoad  %128  %421
+%424 = OpIEqual  %130  %131 %423
+%425 = OpAll  %8  %424
+OpSelectionMerge %426 None
+OpBranchConditional %425 %418 %426
+%426 = OpLabel
+%427 = OpCompositeExtract  %6  %423 1
+%428 = OpIEqual  %8  %427 %35
+%429 = OpSelect  %6  %428 %90 %35
+%430 = OpCompositeConstruct  %128  %429 %90
+%431 = OpISub  %128  %423 %430
+OpStore %421 %431
+OpBranch %419
+%419 = OpLabel
+%432 = OpFunctionCall  %8  %148 %402 %403
+OpSelectionMerge %433 None
+OpBranchConditional %432 %433 %434
+%434 = OpLabel
+OpBranch %418
+%433 = OpLabel
+OpBranch %435
+%435 = OpLabel
+%437 = OpFunctionCall  %10  %271 %402 %403
+%438 = OpCompositeExtract  %6  %437 0
+%439 = OpIEqual  %8  %438 %90
+OpSelectionMerge %440 None
+OpBranchConditional %439 %441 %442
+%441 = OpLabel
+%443 = OpFunctionCall  %2  %364 %402 %403
+OpBranch %440
+%442 = OpLabel
+%444 = OpFunctionCall  %2  %323 %402 %403 %265 %404
+OpBranch %440
+%440 = OpLabel
+OpBranch %436
+%436 = OpLabel
+OpBranch %420
+%420 = OpLabel
+OpBranch %417
+%418 = OpLabel
+%445 = OpFunctionCall  %10  %172 %402 %403
+%446 = OpCompositeExtract  %6  %445 0
+%447 = OpAccessChain  %251  %399 %35
+OpStore %447 %446
+%448 = OpFunctionCall  %8  %148 %402 %403
+%449 = OpFunctionCall  %2  %42 %402 %398 %401 %403 %404
+%450 = OpFunctionCall  %8  %148 %402 %403
+%451 = OpAccessChain  %251  %399 %35
+%452 = OpLoad  %6  %451
+%453 = OpFunctionCall  %10  %172 %402 %403
+%454 = OpCompositeExtract  %6  %453 0
+%455 = OpIAdd  %6  %452 %454
+%456 = OpAccessChain  %251  %399 %35
+OpStore %456 %455
 OpReturn
 OpFunctionEnd

--- a/tests/tests/wgpu-gpu/binding_array/tlas.rs
+++ b/tests/tests/wgpu-gpu/binding_array/tlas.rs
@@ -1,6 +1,6 @@
-use std::{borrow::Cow, num::NonZeroU32};
+use std::{mem, num::NonZeroU32, time::Duration};
 
-use wgpu::util::DeviceExt;
+use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu::*;
 use wgpu_test::{
     gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
@@ -8,223 +8,453 @@ use wgpu_test::{
 
 pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
     tests.push(BINDING_ARRAY_TLAS);
+    tests.push(BINDING_ARRAY_TLAS_DYNAMIC_INDEX);
 }
 
+const RAY_QUERY_INTERSECTION_TRIANGLE: u32 = 1;
+
+/// Builds two TLAS over the same BLAS, binds them as a `binding_array`, traces
+/// a ray through element 1 of the array, and checks that the committed
+/// intersection lands at the expected distance.
 #[gpu_test]
 static BINDING_ARRAY_TLAS: GpuTestConfiguration = GpuTestConfiguration::new()
     .parameters(
         TestParameters::default()
-            .instance_flags(wgpu::InstanceFlags::GPU_BASED_VALIDATION)
-            // Ray queries + acceleration structure bindings are gated behind this experimental feature.
             .features(
-                Features::EXPERIMENTAL_RAY_QUERY | Features::ACCELERATION_STRUCTURE_BINDING_ARRAY,
+                wgpu::Features::EXPERIMENTAL_RAY_QUERY
+                    | wgpu::Features::ACCELERATION_STRUCTURE_BINDING_ARRAY,
             )
-            .limits(Limits {
+            .limits(wgpu::Limits {
                 max_binding_array_elements_per_shader_stage: 8,
                 max_acceleration_structures_per_shader_stage: 8,
                 max_binding_array_acceleration_structure_elements_per_shader_stage: 8,
-                ..Limits::default().using_minimum_supported_acceleration_structure_values()
+                ..wgpu::Limits::default().using_minimum_supported_acceleration_structure_values()
             }),
     )
-    .run_async(|ctx| async move { binding_array_tlas(ctx).await });
+    .run_async(binding_array_tlas);
 
 async fn binding_array_tlas(ctx: TestingContext) {
-    // Minimal shader that consumes a TLAS binding array.
-    //
-    // We don't need to actually "trace" anything for this test. We only need:
-    // - Pipeline compilation to accept `binding_array<acceleration_structure>`
-    // - Bind group creation to accept `BindingResource::AccelerationStructureArray`
-    // - Encoder to successfully set the bind group and submit.
-    //
-    // Creating a `ray_query` and initializing it against element 0 forces the binding to be used.
-    let shader = r#"
-        enable wgpu_ray_query;
-        enable wgpu_binding_array;
+    // One big triangle covering the xy origin at z = 2; the ray from
+    // (0, 0, -2) towards +z hits it at t = 4.
+    let vertices: [[f32; 3]; 3] = [[-2.0, -2.0, 2.0], [6.0, -2.0, 2.0], [-2.0, 6.0, 2.0]];
 
-        @group(0) @binding(0)
-        var tlas_array: binding_array<acceleration_structure>;
-
-        @compute
-        @workgroup_size(1, 1, 1)
-        fn main() {
-            var rq: ray_query;
-            rayQueryInitialize(
-                &rq,
-                tlas_array[0],
-                RayDesc(
-                    0u,
-                    0xffu,
-                    0.001,
-                    1000.0,
-                    vec3f(0.0, 0.0, 0.0),
-                    vec3f(0.0, 0.0, 1.0)
-                )
-            );
-        }
-    "#;
-
-    let module = ctx.device.create_shader_module(ShaderModuleDescriptor {
-        label: Some("Binding Array TLAS"),
-        source: ShaderSource::Wgsl(Cow::Borrowed(shader)),
+    let vertex_buffer = ctx.device.create_buffer_init(&BufferInitDescriptor {
+        label: Some("binding_array TLAS vertices"),
+        contents: bytemuck::cast_slice(&vertices),
+        usage: BufferUsages::BLAS_INPUT,
+    });
+    let index_buffer = ctx.device.create_buffer_init(&BufferInitDescriptor {
+        label: Some("binding_array TLAS indices"),
+        contents: bytemuck::cast_slice(&[0u32, 1, 2]),
+        usage: BufferUsages::BLAS_INPUT,
     });
 
-    // Build a minimal BLAS + two TLAS so we can bind an array of TLAS.
-    //
-    // This follows the shapes used in the ray tracing examples.
-    let vertex_data: [[f32; 3]; 3] = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
-    let index_data: [u16; 3] = [0, 1, 2];
-
-    let vertex_buf = ctx
-        .device
-        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("RT Vertex Buffer"),
-            contents: bytemuck::cast_slice(&vertex_data),
-            usage: BufferUsages::VERTEX | BufferUsages::BLAS_INPUT,
-        });
-
-    let index_buf = ctx
-        .device
-        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("RT Index Buffer"),
-            contents: bytemuck::cast_slice(&index_data),
-            usage: BufferUsages::INDEX | BufferUsages::BLAS_INPUT,
-        });
-
-    let blas_geo_size_desc = wgpu::BlasTriangleGeometrySizeDescriptor {
-        vertex_format: wgpu::VertexFormat::Float32x3,
-        vertex_count: vertex_data.len() as u32,
-        index_format: Some(wgpu::IndexFormat::Uint16),
-        index_count: Some(index_data.len() as u32),
-        flags: wgpu::AccelerationStructureGeometryFlags::OPAQUE,
+    let blas_size = BlasTriangleGeometrySizeDescriptor {
+        vertex_format: VertexFormat::Float32x3,
+        vertex_count: vertices.len() as u32,
+        index_format: Some(IndexFormat::Uint32),
+        index_count: Some(3),
+        flags: AccelerationStructureGeometryFlags::OPAQUE,
     };
-
     let blas = ctx.device.create_blas(
-        &wgpu::CreateBlasDescriptor {
-            label: Some("BLAS"),
-            flags: wgpu::AccelerationStructureFlags::PREFER_FAST_TRACE,
-            update_mode: wgpu::AccelerationStructureUpdateMode::Build,
+        &CreateBlasDescriptor {
+            label: Some("binding_array BLAS"),
+            flags: AccelerationStructureFlags::PREFER_FAST_TRACE,
+            update_mode: AccelerationStructureUpdateMode::Build,
         },
-        wgpu::BlasGeometrySizeDescriptors::Triangles {
-            descriptors: vec![blas_geo_size_desc.clone()],
+        BlasGeometrySizeDescriptors::Triangles {
+            descriptors: vec![blas_size.clone()],
         },
     );
 
-    let mut tlas_a = ctx.device.create_tlas(&wgpu::CreateTlasDescriptor {
-        label: Some("TLAS A"),
-        flags: wgpu::AccelerationStructureFlags::PREFER_FAST_TRACE,
-        update_mode: wgpu::AccelerationStructureUpdateMode::Build,
+    // Both TLAS reference the same BLAS with identity transforms.
+    let mut tlas_a = ctx.device.create_tlas(&CreateTlasDescriptor {
+        label: Some("binding_array TLAS A"),
         max_instances: 1,
+        flags: AccelerationStructureFlags::PREFER_FAST_TRACE,
+        update_mode: AccelerationStructureUpdateMode::Build,
+    });
+    let mut tlas_b = ctx.device.create_tlas(&CreateTlasDescriptor {
+        label: Some("binding_array TLAS B"),
+        max_instances: 1,
+        flags: AccelerationStructureFlags::PREFER_FAST_TRACE,
+        update_mode: AccelerationStructureUpdateMode::Build,
+    });
+    for tlas in [&mut tlas_a, &mut tlas_b] {
+        tlas[0] = Some(TlasInstance::new(
+            &blas,
+            [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            0,
+            0xFF,
+        ));
+    }
+
+    let output = ctx.device.create_buffer(&BufferDescriptor {
+        label: Some("binding_array output"),
+        size: mem::size_of::<[f32; 2]>() as u64,
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let readback = ctx.device.create_buffer(&BufferDescriptor {
+        label: Some("binding_array readback"),
+        size: mem::size_of::<[f32; 2]>() as u64,
+        usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
     });
 
-    let mut tlas_b = ctx.device.create_tlas(&wgpu::CreateTlasDescriptor {
-        label: Some("TLAS B"),
-        flags: wgpu::AccelerationStructureFlags::PREFER_FAST_TRACE,
-        update_mode: wgpu::AccelerationStructureUpdateMode::Build,
-        max_instances: 1,
-    });
-
-    // Put a single instance into each TLAS. Both reference the same BLAS.
-    //
-    // NOTE: This indexing API is how TLAS instances are populated in the examples.
-    tlas_a[0] = Some(wgpu::TlasInstance::new(
-        &blas,
-        [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-        0,
-        0xff,
-    ));
-    tlas_b[0] = Some(wgpu::TlasInstance::new(
-        &blas,
-        [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
-        0,
-        0xff,
-    ));
-
-    // Build BLAS and TLASes.
-    let mut encoder = ctx
+    let shader = ctx
         .device
-        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("RT Build"),
-        });
-
-    encoder.build_acceleration_structures(
-        std::iter::once(&wgpu::BlasBuildEntry {
-            blas: &blas,
-            geometry: wgpu::BlasGeometries::TriangleGeometries(vec![wgpu::BlasTriangleGeometry {
-                size: &blas_geo_size_desc,
-                vertex_buffer: &vertex_buf,
-                first_vertex: 0,
-                vertex_stride: std::mem::size_of::<[f32; 3]>() as u64,
-                index_buffer: Some(&index_buf),
-                first_index: Some(0),
-                transform_buffer: None,
-                transform_buffer_offset: None,
-            }]),
-        }),
-        [&tlas_a, &tlas_b],
-    );
-
-    ctx.queue.submit(Some(encoder.finish()));
-
-    // Bind group layout with a TLAS array binding.
+        .create_shader_module(wgpu::include_wgsl!("tlas.wgsl"));
+    // The reflected layout does not carry the array length for acceleration
+    // structure arrays, so declare it explicitly.
     let bgl = ctx
         .device
         .create_bind_group_layout(&BindGroupLayoutDescriptor {
-            label: Some("TLAS array BGL"),
-            entries: &[BindGroupLayoutEntry {
-                binding: 0,
-                visibility: ShaderStages::COMPUTE,
-                ty: BindingType::AccelerationStructure {
-                    vertex_return: false,
+            label: Some("binding_array BGL"),
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::AccelerationStructure {
+                        vertex_return: false,
+                    },
+                    count: Some(NonZeroU32::new(2).unwrap()),
                 },
-                count: Some(NonZeroU32::new(2).unwrap()),
-            }],
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
         });
-
-    let tlas_refs: [&Tlas; 2] = [&tlas_a, &tlas_b];
-
-    let bg = ctx.device.create_bind_group(&BindGroupDescriptor {
-        label: Some("TLAS array BG"),
-        layout: &bgl,
-        entries: &[BindGroupEntry {
-            binding: 0,
-            resource: BindingResource::AccelerationStructureArray(&tlas_refs),
-        }],
-    });
-
     let pipeline_layout = ctx
         .device
         .create_pipeline_layout(&PipelineLayoutDescriptor {
-            label: Some("TLAS array pipeline layout"),
+            label: Some("binding_array pipeline layout"),
             bind_group_layouts: &[Some(&bgl)],
             immediate_size: 0,
         });
-
     let pipeline = ctx
         .device
         .create_compute_pipeline(&ComputePipelineDescriptor {
-            label: Some("TLAS array pipeline"),
+            label: Some("binding_array pipeline"),
             layout: Some(&pipeline_layout),
-            module: &module,
+            module: &shader,
             entry_point: Some("main"),
             compilation_options: Default::default(),
             cache: None,
         });
 
+    let tlas_array: [&Tlas; 2] = [&tlas_a, &tlas_b];
+    let group = ctx.device.create_bind_group(&BindGroupDescriptor {
+        label: Some("binding_array bind group"),
+        layout: &bgl,
+        entries: &[
+            BindGroupEntry {
+                binding: 0,
+                resource: BindingResource::AccelerationStructureArray(&tlas_array),
+            },
+            BindGroupEntry {
+                binding: 1,
+                resource: output.as_entire_binding(),
+            },
+        ],
+    });
+
     let mut encoder = ctx
         .device
         .create_command_encoder(&CommandEncoderDescriptor {
-            label: Some("Dispatch"),
+            label: Some("binding_array build + trace"),
         });
-
+    encoder.build_acceleration_structures(
+        &[BlasBuildEntry {
+            blas: &blas,
+            geometry: BlasGeometries::TriangleGeometries(vec![BlasTriangleGeometry {
+                size: &blas_size,
+                vertex_buffer: &vertex_buffer,
+                first_vertex: 0,
+                vertex_stride: mem::size_of::<[f32; 3]>() as u64,
+                index_buffer: Some(&index_buffer),
+                first_index: Some(0),
+                transform_buffer: None,
+                transform_buffer_offset: None,
+            }]),
+        }],
+        [&tlas_a, &tlas_b],
+    );
     {
         let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor {
-            label: Some("Compute pass"),
+            label: Some("binding_array trace"),
             timestamp_writes: None,
         });
         pass.set_pipeline(&pipeline);
-        pass.set_bind_group(0, &bg, &[]);
+        pass.set_bind_group(0, &group, &[]);
         pass.dispatch_workgroups(1, 1, 1);
     }
+    encoder.copy_buffer_to_buffer(&output, 0, &readback, 0, output.size());
+    ctx.queue.submit([encoder.finish()]);
 
-    ctx.queue.submit(Some(encoder.finish()));
+    readback.slice(..).map_async(MapMode::Read, Result::unwrap);
+    ctx.async_poll(PollType::Wait {
+        submission_index: None,
+        timeout: Some(Duration::from_secs(30)),
+    })
+    .await
+    .unwrap();
+    let bytes = readback.slice(..).get_mapped_range().unwrap();
+    let (t, kind) = (
+        f32::from_le_bytes(bytes[0..4].try_into().unwrap()),
+        f32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+    );
+    drop(bytes);
+    readback.unmap();
+
+    assert_eq!(
+        kind as u32, RAY_QUERY_INTERSECTION_TRIANGLE,
+        "expected a triangle hit through tlas_array[1]"
+    );
+    assert!((t - 4.0).abs() < 1e-4, "hit at t = {t}, expected 4");
+}
+
+/// Builds two TLAS over the same BLAS with different instance transforms,
+/// binds them as a `binding_array`, and indexes the array with a value loaded
+/// from a storage buffer. The non-uniform index requires the
+/// `ACCELERATION_STRUCTURE_BINDING_ARRAY` capability and must select the
+/// structure whose transform was applied.
+#[gpu_test]
+static BINDING_ARRAY_TLAS_DYNAMIC_INDEX: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .features(
+                wgpu::Features::EXPERIMENTAL_RAY_QUERY
+                    | wgpu::Features::ACCELERATION_STRUCTURE_BINDING_ARRAY,
+            )
+            .limits(wgpu::Limits {
+                max_binding_array_elements_per_shader_stage: 8,
+                max_acceleration_structures_per_shader_stage: 8,
+                max_binding_array_acceleration_structure_elements_per_shader_stage: 8,
+                ..wgpu::Limits::default().using_minimum_supported_acceleration_structure_values()
+            }),
+    )
+    .run_async(binding_array_tlas_dynamic_index);
+
+async fn binding_array_tlas_dynamic_index(ctx: TestingContext) {
+    // One big triangle covering the xy origin at z = 2; the ray from
+    // (0, 0, -2) towards +z hits it at t = 4.
+    let vertices: [[f32; 3]; 3] = [[-2.0, -2.0, 2.0], [6.0, -2.0, 2.0], [-2.0, 6.0, 2.0]];
+
+    let vertex_buffer = ctx.device.create_buffer_init(&BufferInitDescriptor {
+        label: Some("dynamic index vertices"),
+        contents: bytemuck::cast_slice(&vertices),
+        usage: BufferUsages::BLAS_INPUT,
+    });
+    let index_buffer = ctx.device.create_buffer_init(&BufferInitDescriptor {
+        label: Some("dynamic index indices"),
+        contents: bytemuck::cast_slice(&[0u32, 1, 2]),
+        usage: BufferUsages::BLAS_INPUT,
+    });
+
+    let blas_size = BlasTriangleGeometrySizeDescriptor {
+        vertex_format: VertexFormat::Float32x3,
+        vertex_count: vertices.len() as u32,
+        index_format: Some(IndexFormat::Uint32),
+        index_count: Some(3),
+        flags: AccelerationStructureGeometryFlags::OPAQUE,
+    };
+    let blas = ctx.device.create_blas(
+        &CreateBlasDescriptor {
+            label: Some("dynamic index BLAS"),
+            flags: AccelerationStructureFlags::PREFER_FAST_TRACE,
+            update_mode: AccelerationStructureUpdateMode::Build,
+        },
+        BlasGeometrySizeDescriptors::Triangles {
+            descriptors: vec![blas_size.clone()],
+        },
+    );
+
+    // TLAS A keeps the identity transform (hit at t = 4); TLAS B's instance
+    // translates the geometry two units further away (hit at t = 6).
+    let mut tlas_a = ctx.device.create_tlas(&CreateTlasDescriptor {
+        label: Some("dynamic index TLAS A"),
+        max_instances: 1,
+        flags: AccelerationStructureFlags::PREFER_FAST_TRACE,
+        update_mode: AccelerationStructureUpdateMode::Build,
+    });
+    let mut tlas_b = ctx.device.create_tlas(&CreateTlasDescriptor {
+        label: Some("dynamic index TLAS B"),
+        max_instances: 1,
+        flags: AccelerationStructureFlags::PREFER_FAST_TRACE,
+        update_mode: AccelerationStructureUpdateMode::Build,
+    });
+    tlas_a[0] = Some(TlasInstance::new(
+        &blas,
+        [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        0,
+        0xFF,
+    ));
+    tlas_b[0] = Some(TlasInstance::new(
+        &blas,
+        [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0],
+        0,
+        0xFF,
+    ));
+
+    // The shader indexes tlas_array with this value, which is non-uniform
+    // because it is loaded from a storage buffer.
+    let select = ctx.device.create_buffer_init(&BufferInitDescriptor {
+        label: Some("dynamic index selector"),
+        contents: bytemuck::cast_slice(&[1u32]),
+        usage: BufferUsages::STORAGE,
+    });
+    let output = ctx.device.create_buffer(&BufferDescriptor {
+        label: Some("dynamic index output"),
+        size: mem::size_of::<[f32; 2]>() as u64,
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let readback = ctx.device.create_buffer(&BufferDescriptor {
+        label: Some("dynamic index readback"),
+        size: mem::size_of::<[f32; 2]>() as u64,
+        usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let shader = ctx
+        .device
+        .create_shader_module(wgpu::include_wgsl!("tlas.wgsl"));
+    // The reflected layout does not carry the array length for acceleration
+    // structure arrays, so declare it explicitly.
+    let bgl = ctx
+        .device
+        .create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("dynamic index BGL"),
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::AccelerationStructure {
+                        vertex_return: false,
+                    },
+                    count: Some(NonZeroU32::new(2).unwrap()),
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: BufferSize::new(4),
+                    },
+                    count: None,
+                },
+            ],
+        });
+    let pipeline_layout = ctx
+        .device
+        .create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("dynamic index pipeline layout"),
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+    let pipeline = ctx
+        .device
+        .create_compute_pipeline(&ComputePipelineDescriptor {
+            label: Some("dynamic index pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &shader,
+            entry_point: Some("dynamic_index"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+    let tlas_array: [&Tlas; 2] = [&tlas_a, &tlas_b];
+    let group = ctx.device.create_bind_group(&BindGroupDescriptor {
+        label: Some("dynamic index bind group"),
+        layout: &bgl,
+        entries: &[
+            BindGroupEntry {
+                binding: 0,
+                resource: BindingResource::AccelerationStructureArray(&tlas_array),
+            },
+            BindGroupEntry {
+                binding: 1,
+                resource: output.as_entire_binding(),
+            },
+            BindGroupEntry {
+                binding: 2,
+                resource: select.as_entire_binding(),
+            },
+        ],
+    });
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&CommandEncoderDescriptor {
+            label: Some("dynamic index build + trace"),
+        });
+    encoder.build_acceleration_structures(
+        &[BlasBuildEntry {
+            blas: &blas,
+            geometry: BlasGeometries::TriangleGeometries(vec![BlasTriangleGeometry {
+                size: &blas_size,
+                vertex_buffer: &vertex_buffer,
+                first_vertex: 0,
+                vertex_stride: mem::size_of::<[f32; 3]>() as u64,
+                index_buffer: Some(&index_buffer),
+                first_index: Some(0),
+                transform_buffer: None,
+                transform_buffer_offset: None,
+            }]),
+        }],
+        [&tlas_a, &tlas_b],
+    );
+    {
+        let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+            label: Some("dynamic index trace"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &group, &[]);
+        pass.dispatch_workgroups(1, 1, 1);
+    }
+    encoder.copy_buffer_to_buffer(&output, 0, &readback, 0, output.size());
+    ctx.queue.submit([encoder.finish()]);
+
+    readback.slice(..).map_async(MapMode::Read, Result::unwrap);
+    ctx.async_poll(PollType::Wait {
+        submission_index: None,
+        timeout: Some(Duration::from_secs(30)),
+    })
+    .await
+    .unwrap();
+    let bytes = readback.slice(..).get_mapped_range().unwrap();
+    let (t, kind) = (
+        f32::from_le_bytes(bytes[0..4].try_into().unwrap()),
+        f32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+    );
+    drop(bytes);
+    readback.unmap();
+
+    assert_eq!(
+        kind as u32, RAY_QUERY_INTERSECTION_TRIANGLE,
+        "expected a triangle hit through tlas_array[select]"
+    );
+    // The selected element is TLAS B, whose instance moved the triangle two
+    // units further from the ray origin.
+    assert!((t - 6.0).abs() < 1e-4, "hit at t = {t}, expected 6");
 }

--- a/tests/tests/wgpu-gpu/binding_array/tlas.wgsl
+++ b/tests/tests/wgpu-gpu/binding_array/tlas.wgsl
@@ -1,0 +1,44 @@
+enable wgpu_ray_query;
+enable wgpu_binding_array;
+
+@group(0) @binding(0)
+var tlas_array: binding_array<acceleration_structure>;
+
+@group(0) @binding(1)
+var<storage, read_write> out: array<vec2f>;
+
+@compute
+@workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3u) {
+    var query: ray_query;
+    rayQueryInitialize(
+        &query,
+        tlas_array[1],
+        RayDesc(0u, 0xFFu, 0.0, 100.0, vec3f(0.0, 0.0, -2.0), vec3f(0.0, 0.0, 1.0)),
+    );
+    // The geometry is opaque, so triangle intersections are committed directly.
+    while rayQueryProceed(&query) {}
+    let h = rayQueryGetCommittedIntersection(&query);
+    out[id.x] = vec2f(h.t, f32(h.kind));
+}
+
+@group(0) @binding(2)
+var<storage, read> select: array<u32>;
+
+@compute
+@workgroup_size(1)
+fn dynamic_index(@builtin(global_invocation_id) id: vec3u) {
+    // The index is loaded from a storage buffer, so it is not uniform and
+    // indexing the acceleration structure array requires the
+    // ACCELERATION_STRUCTURE_BINDING_ARRAY capability.
+    let i = select[id.x];
+    var query: ray_query;
+    rayQueryInitialize(
+        &query,
+        tlas_array[i],
+        RayDesc(0u, 0xFFu, 0.0, 100.0, vec3f(0.0, 0.0, -2.0), vec3f(0.0, 0.0, 1.0)),
+    );
+    while rayQueryProceed(&query) {}
+    let h = rayQueryGetCommittedIntersection(&query);
+    out[id.x] = vec2f(h.t, f32(h.kind));
+}

--- a/tests/tests/wgpu-gpu/main.rs
+++ b/tests/tests/wgpu-gpu/main.rs
@@ -11,6 +11,7 @@ mod regression {
     pub mod issue_6467;
     pub mod issue_6827;
     pub mod issue_9115;
+    pub mod issue_9215;
 }
 
 mod adapter;
@@ -140,6 +141,7 @@ fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     regression::issue_6467::all_tests(&mut tests);
     regression::issue_6827::all_tests(&mut tests);
     regression::issue_9115::all_tests(&mut tests);
+    regression::issue_9215::all_tests(&mut tests);
     render_pass_ownership::all_tests(&mut tests);
     render_target::all_tests(&mut tests);
     resource_descriptor_accessor::all_tests(&mut tests);

--- a/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/as_build.rs
@@ -759,7 +759,18 @@ static EXTRA_FORMAT_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
             )
             .enable_noop(),
     )
-    .run_sync(|ctx| test_as_build_format_stride(ctx, VertexFormat::Snorm16x4, 6, false));
+    .run_sync(|ctx| {
+        // Metal requires the stride to cover the full 8 byte format, so the
+        // DirectX-style packed 6 byte stride is rejected there.
+        let metal_packed_stride_rejected = ctx.adapter_info.backend == Backend::Metal;
+        test_as_build_format_stride(
+            &ctx,
+            VertexFormat::Snorm16x4,
+            6,
+            metal_packed_stride_rejected,
+        );
+        test_as_build_format_stride(&ctx, VertexFormat::Snorm16x4, 8, false);
+    });
 
 #[gpu_test]
 static MISALIGNED_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
@@ -771,7 +782,7 @@ static MISALIGNED_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
             .enable_noop(),
     )
     // Larger than the minimum size, but not aligned as required
-    .run_sync(|ctx| test_as_build_format_stride(ctx, VertexFormat::Float32x3, 13, true));
+    .run_sync(|ctx| test_as_build_format_stride(&ctx, VertexFormat::Float32x3, 13, true));
 
 #[gpu_test]
 static TOO_SMALL_STRIDE_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
@@ -783,17 +794,17 @@ static TOO_SMALL_STRIDE_BUILD: GpuTestConfiguration = GpuTestConfiguration::new(
             .enable_noop(),
     )
     // Aligned as required, but smaller than minimum size
-    .run_sync(|ctx| test_as_build_format_stride(ctx, VertexFormat::Float32x3, 8, true));
+    .run_sync(|ctx| test_as_build_format_stride(&ctx, VertexFormat::Float32x3, 8, true));
 
 fn test_as_build_format_stride(
-    ctx: TestingContext,
+    ctx: &TestingContext,
     format: VertexFormat,
     stride: BufferAddress,
     invalid_combination: bool,
 ) {
     let vertices = ctx.device.create_buffer_init(&BufferInitDescriptor {
         label: None,
-        contents: &vec![0; (format.min_acceleration_structure_vertex_stride() * 3) as usize],
+        contents: &vec![0; (stride * 3) as usize],
         usage: BufferUsages::BLAS_INPUT,
     });
 

--- a/tests/tests/wgpu-gpu/ray_tracing/extra_formats.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/extra_formats.rs
@@ -1,0 +1,304 @@
+use std::mem;
+use std::time::Duration;
+
+use wgpu::util::{BufferInitDescriptor, DeviceExt};
+use wgpu::*;
+use wgpu_test::{
+    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+use crate::ray_tracing::acceleration_structure_limits;
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.push(EXTRA_FORMATS_QUERY);
+}
+
+const RAY_QUERY_INTERSECTION_TRIANGLE: u32 = 1;
+
+/// Encodes a triangle vertex for a 4-component 16-bit float format.
+fn vertex_f16x4(x: f32, y: f32, z: f32) -> [u8; 8] {
+    let mut bytes = [0u8; 8];
+    for (i, v) in [x, y, z, 0.0].into_iter().enumerate() {
+        bytes[i * 2..i * 2 + 2].copy_from_slice(&half::f16::from_f32(v).to_le_bytes());
+    }
+    bytes
+}
+
+/// Encodes a triangle vertex for a 2-component 16-bit float format.
+/// The missing z component defaults to 0.
+fn vertex_f16x2(x: f32, y: f32) -> [u8; 4] {
+    let mut bytes = [0u8; 4];
+    for (i, v) in [x, y].into_iter().enumerate() {
+        bytes[i * 2..i * 2 + 2].copy_from_slice(&half::f16::from_f32(v).to_le_bytes());
+    }
+    bytes
+}
+
+/// Encodes a triangle vertex for a 2-component normalized 16-bit signed integer
+/// format. The missing z component defaults to 0.
+fn vertex_snorm16x2(x: f32, y: f32) -> [u8; 4] {
+    let mut bytes = [0u8; 4];
+    for (i, v) in [x, y].into_iter().enumerate() {
+        let snorm = (v.clamp(-1.0, 1.0) * 32767.0).round() as i16;
+        bytes[i * 2..i * 2 + 2].copy_from_slice(&snorm.to_le_bytes());
+    }
+    bytes
+}
+
+/// Encodes a triangle vertex for a 4-component normalized 16-bit signed integer
+/// format. The w component is ignored by the acceleration structure build.
+fn vertex_snorm16x4(x: f32, y: f32, z: f32) -> [u8; 8] {
+    let mut bytes = [0u8; 8];
+    for (i, v) in [x, y, z, 1.0].into_iter().enumerate() {
+        let snorm = (v.clamp(-1.0, 1.0) * 32767.0).round() as i16;
+        bytes[i * 2..i * 2 + 2].copy_from_slice(&snorm.to_le_bytes());
+    }
+    bytes
+}
+
+fn vertex_f32x2(x: f32, y: f32) -> [u8; 8] {
+    let mut bytes = [0u8; 8];
+    for (i, v) in [x, y].into_iter().enumerate() {
+        bytes[i * 4..i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+    }
+    bytes
+}
+
+fn vertex_f32x3(x: f32, y: f32, z: f32) -> [u8; 12] {
+    let mut bytes = [0u8; 12];
+    for (i, v) in [x, y, z].into_iter().enumerate() {
+        bytes[i * 4..i * 4 + 4].copy_from_slice(&v.to_le_bytes());
+    }
+    bytes
+}
+
+/// Traces a ray down the z axis from `z = -2` against triangles encoded in
+/// every vertex format allowed for acceleration structure builds, and checks
+/// that the committed intersection lands at the expected distance.
+#[gpu_test]
+static EXTRA_FORMATS_QUERY: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(
+                wgpu::Features::EXPERIMENTAL_RAY_QUERY
+                    | wgpu::Features::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS,
+            ),
+    )
+    .run_async(extra_formats_query);
+
+async fn extra_formats_query(ctx: TestingContext) {
+    // Each triangle covers the xy origin. Signed normalized formats cannot
+    // leave the [-1, 1] cube, so their triangles sit at z = 1 instead of z = 2,
+    // and 2-component formats default the missing z to 0.
+    let cases: &[(
+        &str,
+        VertexFormat,
+        Box<dyn Fn() -> Vec<u8> + Send + Sync>,
+        f32,
+    )] = &[
+        (
+            "Float32x3",
+            VertexFormat::Float32x3,
+            Box::new(|| {
+                [(-2.0, -2.0, 2.0), (6.0, -2.0, 2.0), (-2.0, 6.0, 2.0)]
+                    .map(|(x, y, z)| vertex_f32x3(x, y, z))
+                    .concat()
+            }),
+            4.0,
+        ),
+        (
+            "Float16x4",
+            VertexFormat::Float16x4,
+            Box::new(|| {
+                [(-2.0, -2.0, 2.0), (6.0, -2.0, 2.0), (-2.0, 6.0, 2.0)]
+                    .map(|(x, y, z)| vertex_f16x4(x, y, z))
+                    .concat()
+            }),
+            4.0,
+        ),
+        (
+            "Snorm16x4",
+            VertexFormat::Snorm16x4,
+            Box::new(|| {
+                [(-1.0, -1.0, 1.0), (1.0, -1.0, 1.0), (-1.0, 1.0, 1.0)]
+                    .map(|(x, y, z)| vertex_snorm16x4(x, y, z))
+                    .concat()
+            }),
+            3.0,
+        ),
+        (
+            "Float16x2",
+            VertexFormat::Float16x2,
+            Box::new(|| {
+                [(-2.0, -2.0), (6.0, -2.0), (-2.0, 6.0)]
+                    .map(|(x, y)| vertex_f16x2(x, y))
+                    .concat()
+            }),
+            2.0,
+        ),
+        (
+            "Snorm16x2",
+            VertexFormat::Snorm16x2,
+            Box::new(|| {
+                [(-1.0, -1.0), (1.0, -1.0), (-1.0, 1.0)]
+                    .map(|(x, y)| vertex_snorm16x2(x, y))
+                    .concat()
+            }),
+            2.0,
+        ),
+        (
+            "Float32x2",
+            VertexFormat::Float32x2,
+            Box::new(|| {
+                [(-2.0, -2.0), (6.0, -2.0), (-2.0, 6.0)]
+                    .map(|(x, y)| vertex_f32x2(x, y))
+                    .concat()
+            }),
+            2.0,
+        ),
+    ];
+
+    let shader = ctx
+        .device
+        .create_shader_module(wgpu::include_wgsl!("extra_formats.wgsl"));
+    let pipeline = ctx
+        .device
+        .create_compute_pipeline(&ComputePipelineDescriptor {
+            label: None,
+            layout: None,
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+    let layout = pipeline.get_bind_group_layout(0);
+
+    for (name, format, encode, expected_t) in cases {
+        let vertices = ctx.device.create_buffer_init(&BufferInitDescriptor {
+            label: Some(*name),
+            contents: &encode(),
+            usage: BufferUsages::BLAS_INPUT,
+        });
+        let stride = format.size();
+
+        let blas_size = BlasTriangleGeometrySizeDescriptor {
+            vertex_format: *format,
+            vertex_count: 3,
+            index_format: Some(IndexFormat::Uint32),
+            index_count: Some(3),
+            flags: AccelerationStructureGeometryFlags::OPAQUE,
+        };
+        let blas = ctx.device.create_blas(
+            &CreateBlasDescriptor {
+                label: Some(*name),
+                flags: AccelerationStructureFlags::PREFER_FAST_TRACE,
+                update_mode: AccelerationStructureUpdateMode::Build,
+            },
+            BlasGeometrySizeDescriptors::Triangles {
+                descriptors: vec![blas_size.clone()],
+            },
+        );
+        let mut tlas = ctx.device.create_tlas(&CreateTlasDescriptor {
+            label: Some(*name),
+            max_instances: 1,
+            flags: AccelerationStructureFlags::PREFER_FAST_TRACE,
+            update_mode: AccelerationStructureUpdateMode::Build,
+        });
+        tlas[0] = Some(TlasInstance::new(
+            &blas,
+            [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            0,
+            0xFF,
+        ));
+
+        let indices = ctx.device.create_buffer_init(&BufferInitDescriptor {
+            label: Some(*name),
+            contents: bytemuck::cast_slice(&[0u32, 1, 2]),
+            usage: BufferUsages::BLAS_INPUT,
+        });
+
+        let output = ctx.device.create_buffer(&BufferDescriptor {
+            label: Some(*name),
+            size: mem::size_of::<[f32; 2]>() as u64,
+            usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let readback = ctx.device.create_buffer(&BufferDescriptor {
+            label: Some(*name),
+            size: mem::size_of::<[f32; 2]>() as u64,
+            usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let group = ctx.device.create_bind_group(&BindGroupDescriptor {
+            label: Some(*name),
+            layout: &layout,
+            entries: &[
+                BindGroupEntry {
+                    binding: 0,
+                    resource: tlas.as_binding(),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: output.as_entire_binding(),
+                },
+            ],
+        });
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor { label: Some(*name) });
+        encoder.build_acceleration_structures(
+            &[BlasBuildEntry {
+                blas: &blas,
+                geometry: BlasGeometries::TriangleGeometries(vec![BlasTriangleGeometry {
+                    size: &blas_size,
+                    vertex_buffer: &vertices,
+                    first_vertex: 0,
+                    vertex_stride: stride,
+                    index_buffer: Some(&indices),
+                    first_index: Some(0),
+                    transform_buffer: None,
+                    transform_buffer_offset: None,
+                }]),
+            }],
+            [&tlas],
+        );
+        {
+            let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+                label: Some(*name),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+        encoder.copy_buffer_to_buffer(&output, 0, &readback, 0, output.size());
+        ctx.queue.submit([encoder.finish()]);
+
+        readback.slice(..).map_async(MapMode::Read, Result::unwrap);
+        ctx.async_poll(PollType::Wait {
+            submission_index: None,
+            timeout: Some(Duration::from_secs(30)),
+        })
+        .await
+        .unwrap();
+        let bytes = readback.slice(..).get_mapped_range().unwrap();
+        let (t, kind) = (
+            f32::from_le_bytes(bytes[0..4].try_into().unwrap()),
+            f32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+        );
+        drop(bytes);
+        readback.unmap();
+
+        assert_eq!(
+            kind as u32, RAY_QUERY_INTERSECTION_TRIANGLE,
+            "{name}: expected a triangle hit"
+        );
+        assert!(
+            (t - expected_t).abs() < 1e-4,
+            "{name}: hit at t = {t}, expected {expected_t}"
+        );
+    }
+}

--- a/tests/tests/wgpu-gpu/ray_tracing/extra_formats.wgsl
+++ b/tests/tests/wgpu-gpu/ray_tracing/extra_formats.wgsl
@@ -1,0 +1,18 @@
+enable wgpu_ray_query;
+
+@group(0) @binding(0) var scene: acceleration_structure;
+@group(0) @binding(1) var<storage, read_write> out: array<vec2f>;
+
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3u) {
+    var query: ray_query;
+    rayQueryInitialize(
+        &query,
+        scene,
+        RayDesc(0u, 0xFFu, 0.0, 100.0, vec3f(0.0, 0.0, -2.0), vec3f(0.0, 0.0, 1.0)),
+    );
+    // The geometry is opaque, so triangle intersections are committed directly.
+    while rayQueryProceed(&query) {}
+    let h = rayQueryGetCommittedIntersection(&query);
+    out[id.x] = vec2f(h.t, f32(h.kind));
+}

--- a/tests/tests/wgpu-gpu/ray_tracing/mod.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/mod.rs
@@ -15,6 +15,7 @@ mod as_aabb;
 mod as_build;
 mod as_create;
 mod as_use_after_free;
+mod extra_formats;
 mod limits;
 mod scene;
 mod semantics;
@@ -27,6 +28,7 @@ pub fn all_tests(tests: &mut Vec<wgpu_test::GpuTestInitializer>) {
     as_use_after_free::all_tests(tests);
     limits::all_tests(tests);
     scene::all_tests(tests);
+    extra_formats::all_tests(tests);
     semantics::all_tests(tests);
     shader::all_tests(tests);
 }

--- a/tests/tests/wgpu-gpu/ray_tracing/mod.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/mod.rs
@@ -17,6 +17,7 @@ mod as_create;
 mod as_use_after_free;
 mod limits;
 mod scene;
+mod semantics;
 mod shader;
 
 pub fn all_tests(tests: &mut Vec<wgpu_test::GpuTestInitializer>) {
@@ -26,6 +27,7 @@ pub fn all_tests(tests: &mut Vec<wgpu_test::GpuTestInitializer>) {
     as_use_after_free::all_tests(tests);
     limits::all_tests(tests);
     scene::all_tests(tests);
+    semantics::all_tests(tests);
     shader::all_tests(tests);
 }
 
@@ -81,7 +83,7 @@ impl AsBuildContext {
 
         tlas[0] = Some(TlasInstance::new(
             &blas,
-            [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
             0,
             0xFF,
         ));

--- a/tests/tests/wgpu-gpu/ray_tracing/semantics.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/semantics.rs
@@ -1,0 +1,680 @@
+use std::time::Duration;
+
+use wgpu::util::{BufferInitDescriptor, DeviceExt};
+use wgpu::*;
+use wgpu_test::{
+    gpu_test, GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext,
+};
+
+pub fn all_tests(tests: &mut Vec<GpuTestInitializer>) {
+    tests.push(TRANSFORMED_QUERY_SEMANTICS);
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct Probe {
+    origin: [f32; 3],
+    flags: u32,
+    direction: [f32; 3],
+    mask: u32,
+    near: f32,
+    far: f32,
+    accept: u32,
+    padding: u32,
+}
+
+fn with_flags(probe: Probe, flags: u32) -> Probe {
+    Probe { flags, ..probe }
+}
+
+#[gpu_test]
+static TRANSFORMED_QUERY_SEMANTICS: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(super::acceleration_structure_limits())
+            .features(Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(transformed_query_semantics);
+
+async fn transformed_query_semantics(ctx: TestingContext) {
+    let device = &ctx.device;
+    let queue = &ctx.queue;
+    let mut upload = device.create_command_encoder(&Default::default());
+    let mut input = |label, bytes: &[u8]| {
+        let staging = device.create_buffer(&BufferDescriptor {
+            label: Some(label),
+            size: bytes.len() as u64,
+            usage: BufferUsages::COPY_SRC | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        // Pending writes and an earlier non-AS submission both precede the first build.
+        queue.write_buffer(&staging, 0, bytes);
+        let buffer = device.create_buffer(&BufferDescriptor {
+            label: Some(label),
+            size: bytes.len() as u64,
+            usage: BufferUsages::BLAS_INPUT | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        upload.copy_buffer_to_buffer(&staging, 0, &buffer, 0, bytes.len() as u64);
+        buffer
+    };
+    let vertices = input(
+        "vertices",
+        bytemuck::cast_slice(&[[0_f32, 0., 0.], [2., 0., 0.], [0., 2., 0.]]),
+    );
+    let indices = input("indices", bytemuck::cast_slice(&[0_u32, 1, 2]));
+    let mut matrices = vec![0_f32; 4];
+    matrices.extend([2., 0.5, 0., 1., 0., 3., 0., -2., 0., 0., 1., 4.]);
+    let transform = input(
+        "row-major transform at byte 16",
+        bytemuck::cast_slice(&matrices),
+    );
+    let aabbs = input("aabb", bytemuck::cast_slice(&[-1_f32, -1., 2., 1., 1., 4.]));
+    queue.submit([upload.finish()]);
+
+    let triangle_size = BlasTriangleGeometrySizeDescriptor {
+        vertex_format: VertexFormat::Float32x3,
+        vertex_count: 3,
+        index_format: Some(IndexFormat::Uint32),
+        index_count: Some(3),
+        flags: AccelerationStructureGeometryFlags::empty(),
+    };
+    let aabb_size = BlasAABBGeometrySizeDescriptor {
+        primitive_count: 1,
+        flags: AccelerationStructureGeometryFlags::empty(),
+    };
+    let descriptor = CreateBlasDescriptor {
+        label: None,
+        flags: AccelerationStructureFlags::PREFER_FAST_BUILD,
+        update_mode: AccelerationStructureUpdateMode::Build,
+    };
+    let triangle = device.create_blas(
+        &CreateBlasDescriptor {
+            flags: descriptor.flags | AccelerationStructureFlags::USE_TRANSFORM,
+            ..descriptor
+        },
+        BlasGeometrySizeDescriptors::Triangles {
+            descriptors: vec![triangle_size.clone()],
+        },
+    );
+    let sphere = device.create_blas(
+        &descriptor,
+        BlasGeometrySizeDescriptors::AABBs {
+            descriptors: vec![aabb_size.clone()],
+        },
+    );
+    let opaque_triangle_size = BlasTriangleGeometrySizeDescriptor {
+        flags: AccelerationStructureGeometryFlags::OPAQUE,
+        ..triangle_size.clone()
+    };
+    let opaque_aabb_size = BlasAABBGeometrySizeDescriptor {
+        flags: AccelerationStructureGeometryFlags::OPAQUE,
+        ..aabb_size.clone()
+    };
+    let opaque_triangle = device.create_blas(
+        &CreateBlasDescriptor {
+            flags: descriptor.flags | AccelerationStructureFlags::USE_TRANSFORM,
+            ..descriptor
+        },
+        BlasGeometrySizeDescriptors::Triangles {
+            descriptors: vec![opaque_triangle_size.clone()],
+        },
+    );
+    let opaque_sphere = device.create_blas(
+        &descriptor,
+        BlasGeometrySizeDescriptors::AABBs {
+            descriptors: vec![opaque_aabb_size.clone()],
+        },
+    );
+    let mut tlas = device.create_tlas(&CreateTlasDescriptor {
+        label: None,
+        max_instances: 5,
+        flags: AccelerationStructureFlags::PREFER_FAST_BUILD,
+        update_mode: AccelerationStructureUpdateMode::Build,
+    });
+    tlas[0] = Some(TlasInstance::new(
+        &triangle,
+        [0., -1., 0., 3., 2., 0., 0., 1., 0., 0., 0.5, 2.],
+        37,
+        1,
+    ));
+    tlas[1] = Some(TlasInstance::new(
+        &sphere,
+        [1., 0., 0., 10., 0., 1., 0., 0., 0., 0., 1., 0.],
+        91,
+        2,
+    ));
+    tlas[2] = Some(TlasInstance::new(
+        &triangle,
+        [-1., 0., 0., -4., 0., 1., 0., 0., 0., 0., 1., 0.],
+        53,
+        4,
+    ));
+
+    tlas[3] = Some(TlasInstance::new(
+        &opaque_triangle,
+        [0., -1., 0., 3., 2., 0., 0., 1., 0., 0., 0.5, 2.],
+        137,
+        8,
+    ));
+    tlas[4] = Some(TlasInstance::new(
+        &opaque_sphere,
+        [1., 0., 0., 10., 0., 1., 0., 0., 0., 0., 1., 0.],
+        191,
+        16,
+    ));
+
+    let triangle_entry = BlasBuildEntry {
+        blas: &triangle,
+        geometry: BlasGeometries::TriangleGeometries(vec![BlasTriangleGeometry {
+            size: &triangle_size,
+            vertex_buffer: &vertices,
+            first_vertex: 0,
+            vertex_stride: 12,
+            index_buffer: Some(&indices),
+            first_index: Some(0),
+            transform_buffer: Some(&transform),
+            transform_buffer_offset: Some(16),
+        }]),
+    };
+    let sphere_entry = BlasBuildEntry {
+        blas: &sphere,
+        geometry: BlasGeometries::AabbGeometries(vec![BlasAabbGeometry {
+            size: &aabb_size,
+            stride: 24,
+            aabb_buffer: &aabbs,
+            primitive_offset: 0,
+        }]),
+    };
+    let opaque_triangle_entry = BlasBuildEntry {
+        blas: &opaque_triangle,
+        geometry: BlasGeometries::TriangleGeometries(vec![BlasTriangleGeometry {
+            size: &opaque_triangle_size,
+            vertex_buffer: &vertices,
+            first_vertex: 0,
+            vertex_stride: 12,
+            index_buffer: Some(&indices),
+            first_index: Some(0),
+            transform_buffer: Some(&transform),
+            transform_buffer_offset: Some(16),
+        }]),
+    };
+    let opaque_sphere_entry = BlasBuildEntry {
+        blas: &opaque_sphere,
+        geometry: BlasGeometries::AabbGeometries(vec![BlasAabbGeometry {
+            size: &opaque_aabb_size,
+            stride: 24,
+            aabb_buffer: &aabbs,
+            primitive_offset: 0,
+        }]),
+    };
+    let mut build = device.create_command_encoder(&Default::default());
+    build.build_acceleration_structures(
+        [
+            &triangle_entry,
+            &sphere_entry,
+            &opaque_triangle_entry,
+            &opaque_sphere_entry,
+        ],
+        [&tlas],
+    );
+    queue.submit([build.finish()]);
+
+    let base = Probe {
+        origin: [3.5, 5.5, 0.],
+        flags: 0,
+        direction: [0., 0., 1.],
+        mask: 1,
+        near: 0.,
+        far: 10.,
+        accept: 1,
+        padding: 0,
+    };
+    let sphere_probe = Probe {
+        origin: [10., 0., 0.],
+        mask: 2,
+        ..base
+    };
+    let opaque_probe = Probe { mask: 8, ..base };
+    let opaque_sphere_probe = Probe {
+        mask: 16,
+        ..sphere_probe
+    };
+    // Flags follow SPIR-V Ray Flags, as required by Naga's RayDesc contract.
+    let cases = [
+        ("triangle", base, 1, 4., 37, 0),
+        ("mask disjoint", Probe { mask: 2, ..base }, 0, 0., 0, 0),
+        ("mask zero", Probe { mask: 0, ..base }, 0, 0., 0, 0),
+        ("too near", Probe { far: 3.5, ..base }, 0, 0., 0, 0),
+        ("too far", Probe { near: 4.5, ..base }, 0, 0., 0, 0),
+        ("reject triangle", Probe { accept: 0, ..base }, 0, 0., 0, 0),
+        (
+            "force opaque",
+            Probe {
+                flags: 1,
+                accept: 0,
+                ..base
+            },
+            1,
+            4.,
+            37,
+            0,
+        ),
+        ("force nonopaque", with_flags(base, 2), 1, 4., 37, 0),
+        ("cull back", with_flags(base, 0x10), 0, 0., 0, 0),
+        ("cull front", with_flags(base, 0x20), 1, 4., 37, 0),
+        (
+            "front ray culled",
+            Probe {
+                flags: 0x20,
+                origin: [3.5, 5.5, 8.],
+                direction: [0., 0., -1.],
+                ..base
+            },
+            0,
+            0.,
+            0,
+            0,
+        ),
+        (
+            "front ray accepted",
+            Probe {
+                flags: 0x10,
+                origin: [3.5, 5.5, 8.],
+                direction: [0., 0., -1.],
+                ..base
+            },
+            1,
+            4.,
+            37,
+            0,
+        ),
+        ("opaque triangle control", opaque_probe, 1, 4., 137, 3),
+        (
+            "opaque triangle forced nonopaque rejects",
+            Probe {
+                flags: 2,
+                accept: 0,
+                ..opaque_probe
+            },
+            0,
+            0.,
+            0,
+            0,
+        ),
+        ("cull opaque", with_flags(opaque_probe, 0x40), 0, 0., 0, 0),
+        ("cull nonopaque", with_flags(base, 0x80), 0, 0., 0, 0),
+        ("skip triangles", with_flags(base, 0x100), 0, 0., 0, 0),
+        (
+            "skip aabbs keeps triangle",
+            with_flags(base, 0x200),
+            1,
+            4.,
+            37,
+            0,
+        ),
+        (
+            "mirrored instance",
+            Probe {
+                origin: [-6.25, -0.5, 0.],
+                mask: 4,
+                ..base
+            },
+            1,
+            4.,
+            53,
+            2,
+        ),
+        ("generated sphere", sphere_probe, 2, 2., 91, 1),
+        ("opaque sphere control", opaque_sphere_probe, 2, 2., 191, 4),
+        (
+            "opaque sphere forced nonopaque",
+            with_flags(opaque_sphere_probe, 2),
+            2,
+            2.,
+            191,
+            4,
+        ),
+        (
+            "forced opaque sphere",
+            with_flags(sphere_probe, 1),
+            2,
+            2.,
+            91,
+            1,
+        ),
+        (
+            "opaque sphere culled",
+            with_flags(opaque_sphere_probe, 0x40),
+            0,
+            0.,
+            0,
+            0,
+        ),
+        (
+            "nonopaque sphere culled",
+            with_flags(sphere_probe, 0x80),
+            0,
+            0.,
+            0,
+            0,
+        ),
+        (
+            "back cull keeps sphere",
+            with_flags(sphere_probe, 0x10),
+            2,
+            2.,
+            91,
+            1,
+        ),
+        (
+            "front cull keeps sphere",
+            with_flags(sphere_probe, 0x20),
+            2,
+            2.,
+            91,
+            1,
+        ),
+        (
+            "opaque cull keeps nonopaque",
+            with_flags(base, 0x40),
+            1,
+            4.,
+            37,
+            0,
+        ),
+        (
+            "reject sphere",
+            Probe {
+                accept: 0,
+                ..sphere_probe
+            },
+            0,
+            0.,
+            0,
+            0,
+        ),
+        ("skip aabbs", with_flags(sphere_probe, 0x200), 0, 0., 0, 0),
+        (
+            "skip triangles keeps aabb",
+            with_flags(sphere_probe, 0x100),
+            2,
+            2.,
+            91,
+            1,
+        ),
+        ("terminate first", with_flags(sphere_probe, 4), 2, 2., 91, 1),
+    ];
+    for (label, probe, ..) in &cases {
+        assert!(
+            (probe.flags & 0xc3).count_ones() <= 1,
+            "{label}: opacity flags"
+        );
+        assert!(
+            (probe.flags & 0x30).count_ones() <= 1,
+            "{label}: face flags"
+        );
+        assert!(
+            (probe.flags & 0x300).count_ones() <= 1,
+            "{label}: geometry flags"
+        );
+        assert!(
+            probe.flags & 0x100 == 0 || probe.flags & 0x30 == 0,
+            "{label}: skip and face flags"
+        );
+    }
+    let probes: Vec<_> = cases.iter().map(|c| c.1).collect();
+    let probes = device.create_buffer_init(&BufferInitDescriptor {
+        label: None,
+        contents: bytemuck::cast_slice(&probes),
+        usage: BufferUsages::STORAGE,
+    });
+    let output = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: cases.len() as u64 * 32,
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let readback = device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: output.size(),
+        usage: BufferUsages::COPY_DST | BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let shader = device.create_shader_module(include_wgsl!("semantics.wgsl"));
+    let pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
+        label: None,
+        layout: None,
+        module: &shader,
+        entry_point: Some("compute"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+    let group = device.create_bind_group(&BindGroupDescriptor {
+        label: None,
+        layout: &pipeline.get_bind_group_layout(0),
+        entries: &[
+            BindGroupEntry {
+                binding: 0,
+                resource: tlas.as_binding(),
+            },
+            BindGroupEntry {
+                binding: 1,
+                resource: probes.as_entire_binding(),
+            },
+            BindGroupEntry {
+                binding: 2,
+                resource: output.as_entire_binding(),
+            },
+        ],
+    });
+    for rebuild in [false, true] {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        if rebuild {
+            encoder.build_acceleration_structures(
+                [
+                    &triangle_entry,
+                    &sphere_entry,
+                    &opaque_triangle_entry,
+                    &opaque_sphere_entry,
+                ],
+                [&tlas],
+            );
+        }
+        {
+            let mut pass = encoder.begin_compute_pass(&Default::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &group, &[]);
+            pass.dispatch_workgroups(cases.len() as u32, 1, 1);
+        }
+        encoder.copy_buffer_to_buffer(&output, 0, &readback, 0, output.size());
+        queue.submit([encoder.finish()]);
+        readback.slice(..).map_async(MapMode::Read, Result::unwrap);
+        ctx.async_poll(PollType::Wait {
+            submission_index: None,
+            timeout: Some(Duration::from_secs(30)),
+        })
+        .await
+        .unwrap();
+        {
+            let bytes = readback.slice(..).get_mapped_range().unwrap();
+            let words: &[u32] = bytemuck::cast_slice(&bytes);
+            let (hits, remainder) = words.as_chunks::<8>();
+            assert!(remainder.is_empty());
+            assert_eq!(hits.len(), cases.len());
+            for (case, hit) in cases.iter().zip(hits) {
+                let (label, _, kind, distance, custom, instance) = case;
+                assert_eq!(hit[0], *kind, "{label}, rebuild={rebuild}");
+                if *kind == 0 {
+                    assert_eq!(*hit, [0; 8], "{label}: miss output");
+                } else {
+                    assert!(
+                        (f32::from_bits(hit[1]) - distance).abs() < 1e-4,
+                        "{label}: distance"
+                    );
+                    assert_eq!(&hit[2..6], &[*custom, *instance, 0, 0], "{label}: IDs");
+                    if *kind == 1 {
+                        for &b in &hit[6..8] {
+                            assert!(
+                                (f32::from_bits(b) - 0.25).abs() < 1e-4,
+                                "{label}: barycentrics"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        readback.unmap();
+        for vertex_query in [false, true] {
+            let count = if vertex_query { 1 } else { cases.len() as u32 };
+            let actual = render_queries(&ctx, &shader, &tlas, &probes, count, vertex_query).await;
+            let (hits, remainder) = actual.as_chunks::<4>();
+            assert!(remainder.is_empty());
+            assert_eq!(hits.len(), count as usize);
+            for (case, hit) in cases.iter().zip(hits) {
+                assert_eq!(hit[0], case.2, "{}: render kind", case.0);
+                if case.2 == 0 {
+                    assert_eq!(*hit, [0; 4], "{}: render miss output", case.0);
+                } else {
+                    assert!(
+                        (f32::from_bits(hit[1]) - case.3).abs() < 1e-4,
+                        "{}: render distance",
+                        case.0
+                    );
+                    assert_eq!(&hit[2..4], &[case.4, case.5], "{}: render IDs", case.0);
+                }
+            }
+        }
+    }
+}
+
+async fn render_queries(
+    ctx: &TestingContext,
+    shader: &ShaderModule,
+    tlas: &Tlas,
+    probes: &Buffer,
+    count: u32,
+    vertex_query: bool,
+) -> Vec<u32> {
+    let pipeline = ctx
+        .device
+        .create_render_pipeline(&RenderPipelineDescriptor {
+            label: None,
+            layout: None,
+            vertex: VertexState {
+                module: shader,
+                entry_point: Some(if vertex_query {
+                    "vertex_query"
+                } else {
+                    "vertex"
+                }),
+                compilation_options: Default::default(),
+                buffers: &[],
+            },
+            fragment: Some(FragmentState {
+                module: shader,
+                entry_point: Some(if vertex_query {
+                    "fragment_vertex"
+                } else {
+                    "fragment"
+                }),
+                compilation_options: Default::default(),
+                targets: &[Some(ColorTargetState {
+                    format: TextureFormat::Rgba32Uint,
+                    blend: None,
+                    write_mask: ColorWrites::ALL,
+                })],
+            }),
+            primitive: Default::default(),
+            depth_stencil: None,
+            multisample: Default::default(),
+            multiview_mask: None,
+            cache: None,
+        });
+    let group = ctx.device.create_bind_group(&BindGroupDescriptor {
+        label: None,
+        layout: &pipeline.get_bind_group_layout(0),
+        entries: &[
+            BindGroupEntry {
+                binding: 0,
+                resource: tlas.as_binding(),
+            },
+            BindGroupEntry {
+                binding: 1,
+                resource: probes.as_entire_binding(),
+            },
+        ],
+    });
+    let extent = Extent3d {
+        width: count,
+        height: 1,
+        depth_or_array_layers: 1,
+    };
+    let texture = ctx.device.create_texture(&TextureDescriptor {
+        label: None,
+        size: extent,
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: TextureDimension::D2,
+        format: TextureFormat::Rgba32Uint,
+        usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&Default::default());
+    let readback = ctx.device.create_buffer(&BufferDescriptor {
+        label: None,
+        size: 512,
+        usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut encoder = ctx.device.create_command_encoder(&Default::default());
+    {
+        let attachments = [Some(RenderPassColorAttachment {
+            view: &view,
+            depth_slice: None,
+            resolve_target: None,
+            ops: Operations {
+                load: LoadOp::Clear(Color::BLACK),
+                store: StoreOp::Store,
+            },
+        })];
+        let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+            label: None,
+            color_attachments: &attachments,
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &group, &[]);
+        pass.draw(0..3, 0..1);
+    }
+    encoder.copy_texture_to_buffer(
+        texture.as_image_copy(),
+        TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(512),
+                rows_per_image: Some(1),
+            },
+        },
+        extent,
+    );
+    ctx.queue.submit([encoder.finish()]);
+    readback.slice(..).map_async(MapMode::Read, Result::unwrap);
+    ctx.async_poll(PollType::Wait {
+        submission_index: None,
+        timeout: Some(Duration::from_secs(30)),
+    })
+    .await
+    .unwrap();
+    let words = {
+        let view = readback.slice(..).get_mapped_range().unwrap();
+        bytemuck::cast_slice::<u8, u32>(&view[..count as usize * 16]).to_vec()
+    };
+    readback.unmap();
+    words
+}

--- a/tests/tests/wgpu-gpu/ray_tracing/semantics.wgsl
+++ b/tests/tests/wgpu-gpu/ray_tracing/semantics.wgsl
@@ -1,0 +1,84 @@
+enable wgpu_ray_query;
+
+struct Probe {
+    origin: vec3f,
+    flags: u32,
+    direction: vec3f,
+    mask: u32,
+    near: f32,
+    far: f32,
+    accept: u32,
+    padding: u32,
+}
+struct Hit {
+    kind: u32,
+    t: f32,
+    custom: u32,
+    instance: u32,
+    geometry: u32,
+    primitive: u32,
+    barycentrics: vec2f,
+}
+@group(0) @binding(0) var scene: acceleration_structure;
+@group(0) @binding(1) var<storage> probes: array<Probe>;
+@group(0) @binding(2) var<storage, read_write> hits: array<Hit>;
+
+fn trace(index: u32) -> Hit {
+    let p = probes[index];
+    var query: ray_query;
+    rayQueryInitialize(&query, scene, RayDesc(p.flags, p.mask, p.near, p.far, p.origin, p.direction));
+    while rayQueryProceed(&query) {
+        let candidate = rayQueryGetCandidateIntersection(&query);
+        if p.accept != 0u {
+            if candidate.kind == RAY_QUERY_INTERSECTION_TRIANGLE {
+                rayQueryConfirmIntersection(&query);
+            } else if candidate.kind == RAY_QUERY_INTERSECTION_AABB {
+                // This probe passes through the sphere centre along its z axis.
+                let t = (2.0 - p.origin.z) / p.direction.z;
+                if t >= p.near && t <= p.far {
+                    rayQueryGenerateIntersection(&query, t);
+                }
+            }
+        }
+    }
+    let h = rayQueryGetCommittedIntersection(&query);
+    var out: Hit;
+    out.kind = h.kind;
+    if h.kind != 0u {
+        out = Hit(h.kind, h.t, h.instance_custom_data, h.instance_index,
+            h.geometry_index, h.primitive_index, h.barycentrics);
+    }
+    return out;
+}
+
+@compute @workgroup_size(1)
+fn compute(@builtin(global_invocation_id) id: vec3u) {
+    hits[id.x] = trace(id.x);
+}
+struct VertexHit {
+    @builtin(position) position: vec4f,
+    @location(0) @interpolate(flat) hit: vec4u,
+}
+@vertex
+fn vertex_query(@builtin(vertex_index) index: u32) -> VertexHit {
+    let h = trace(0u);
+    let p = array<vec2f, 3>(vec2f(-1.0, -1.0), vec2f(3.0, -1.0), vec2f(-1.0, 3.0));
+    return VertexHit(vec4f(p[index], 0.0, 1.0), vec4u(h.kind, bitcast<u32>(h.t), h.custom, h.instance));
+}
+@fragment
+fn fragment_vertex(input: VertexHit) -> @location(0) vec4u {
+    return input.hit;
+}
+
+
+@vertex
+fn vertex(@builtin(vertex_index) index: u32) -> @builtin(position) vec4f {
+    let p = array<vec2f, 3>(vec2f(-1.0, -1.0), vec2f(3.0, -1.0), vec2f(-1.0, 3.0));
+    return vec4f(p[index], 0.0, 1.0);
+}
+
+@fragment
+fn fragment(@builtin(position) p: vec4f) -> @location(0) vec4u {
+    let h = trace(u32(p.x));
+    return vec4u(h.kind, bitcast<u32>(h.t), h.custom, h.instance);
+}

--- a/tests/tests/wgpu-gpu/ray_tracing/shader.rs
+++ b/tests/tests/wgpu-gpu/ray_tracing/shader.rs
@@ -1,12 +1,12 @@
 use crate::ray_tracing::{acceleration_structure_limits, AsBuildContext};
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu::{
-    include_wgsl, Backends, BindGroupDescriptor, BindGroupEntry, BindingResource, BufferDescriptor,
+    include_wgsl, BindGroupDescriptor, BindGroupEntry, BindingResource, BufferDescriptor,
     CommandEncoderDescriptor, ComputePassDescriptor, ComputePipelineDescriptor, InstanceFlags,
 };
 use wgpu::{AccelerationStructureFlags, BufferUsages};
 use wgpu_macros::gpu_test;
-use wgpu_test::{FailureCase, GpuTestInitializer};
+use wgpu_test::GpuTestInitializer;
 use wgpu_test::{GpuTestConfiguration, TestParameters, TestingContext};
 
 const STRUCT_SIZE: wgpu::BufferAddress = 176;
@@ -103,7 +103,13 @@ fn access_all_struct_members(ctx: TestingContext) {
         pass.dispatch_workgroups(1, 1, 1)
     }
 
-    ctx.queue.submit([encoder_compute.finish()]);
+    let submission = ctx.queue.submit([encoder_compute.finish()]);
+    ctx.device
+        .poll(wgpu::PollType::Wait {
+            submission_index: Some(submission),
+            timeout: Some(std::time::Duration::from_secs(30)),
+        })
+        .unwrap();
 }
 
 #[gpu_test]
@@ -114,9 +120,7 @@ static PREVENT_INVALID_RAY_QUERY_CALLS: GpuTestConfiguration = GpuTestConfigurat
             .limits(acceleration_structure_limits())
             .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY)
             // Otherwise, mistakes in the generated code won't be caught.
-            .instance_flags(InstanceFlags::GPU_BASED_VALIDATION)
-            // not yet implemented in metal
-            .skip(FailureCase::backend(Backends::METAL)),
+            .instance_flags(InstanceFlags::GPU_BASED_VALIDATION),
     )
     .run_sync(prevent_invalid_ray_query_calls);
 
@@ -197,5 +201,11 @@ fn prevent_invalid_ray_query_calls(ctx: TestingContext) {
         pass.dispatch_workgroups(1, 1, 1)
     }
 
-    ctx.queue.submit([encoder_compute.finish()]);
+    let submission = ctx.queue.submit([encoder_compute.finish()]);
+    ctx.device
+        .poll(wgpu::PollType::Wait {
+            submission_index: Some(submission),
+            timeout: Some(std::time::Duration::from_secs(30)),
+        })
+        .unwrap();
 }

--- a/tests/tests/wgpu-gpu/regression/issue_9215.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_9215.rs
@@ -1,0 +1,709 @@
+use std::mem::size_of;
+
+use wgpu::util::{BufferInitDescriptor, DeviceExt};
+use wgpu_macros::gpu_test;
+use wgpu_test::{GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext};
+
+fn acceleration_structure_limits() -> wgpu::Limits {
+    wgpu::Limits::default().using_minimum_supported_acceleration_structure_values()
+}
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(BLAS_AND_TLAS_IN_SAME_COMMAND_BUFFER);
+    vec.push(BLAS_AND_TLAS_IN_SEPARATE_COMMAND_BUFFERS);
+    vec.push(ENCODER_DISCARDED_AFTER_BLAS_BUILD);
+    vec.push(COMMAND_BUFFER_DROPPED_WITHOUT_SUBMIT);
+    vec.push(BLIT_BETWEEN_BUILDS_IN_SAME_COMMAND_BUFFER);
+    vec.push(COMPUTE_PASS_BETWEEN_BUILDS_IN_SAME_COMMAND_BUFFER);
+    vec.push(COMPACTED_BLAS_IN_PENDING_WRITES);
+    vec.push(ENCODER_DISCARDED_AFTER_PUBLISHED_CLOSE);
+    vec.push(COMMAND_BUFFER_DROPPED_AFTER_PUBLISHED_CLOSE);
+}
+
+// The failures are races, so a pass is evidence rather than proof. On the
+// hardware this bug reproduces on (Apple M4 Max), the unfixed failure rate of
+// the affected configurations is tens of percent per iteration, which 40
+// repetitions turn into a strong signal while keeping the test fast.
+const ITERATIONS: u32 = 40;
+
+// `rayQueryGetCommittedIntersection().kind` for a committed triangle hit.
+const TRIANGLE_HIT_KIND: u32 = 1;
+
+// On Metal, acceleration structure builds are not ordered against each other
+// within an encoder, nor across command buffers committed back to back, so a
+// TLAS build could consume a BLAS that is still building. The ray query below
+// then commits no intersection (kind 0) instead of the triangle (kind 1).
+//
+// Each iteration builds a fresh BLAS and a TLAS referencing it, traces a ray
+// straight up through the triangle, and reads back the committed intersection
+// kind.
+//
+// See <https://github.com/gfx-rs/wgpu/issues/9215>.
+
+struct TraceSetup {
+    vertex_buffer: wgpu::Buffer,
+    blas_size: wgpu::BlasTriangleGeometrySizeDescriptor,
+    blas: wgpu::Blas,
+    tlas: wgpu::Tlas,
+    hit_buffer: wgpu::Buffer,
+    read_back: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+}
+
+fn create_trace_setup(ctx: &TestingContext, pipeline: &wgpu::ComputePipeline) -> TraceSetup {
+    let vertex_buffer = ctx.device.create_buffer_init(&BufferInitDescriptor {
+        label: Some("BLAS vertices"),
+        contents: bytemuck::cast_slice(&[[1.0_f32, 1.0, 0.0], [-1.0, 1.0, -1.0], [-1.0, 1.0, 1.0]]),
+        usage: wgpu::BufferUsages::BLAS_INPUT,
+    });
+
+    let blas_size = wgpu::BlasTriangleGeometrySizeDescriptor {
+        vertex_format: wgpu::VertexFormat::Float32x3,
+        vertex_count: 3,
+        index_format: None,
+        index_count: None,
+        flags: wgpu::AccelerationStructureGeometryFlags::OPAQUE,
+    };
+
+    let blas_flags = wgpu::AccelerationStructureFlags::PREFER_FAST_BUILD;
+    let blas = ctx.device.create_blas(
+        &wgpu::CreateBlasDescriptor {
+            label: None,
+            flags: blas_flags,
+            update_mode: wgpu::AccelerationStructureUpdateMode::Build,
+        },
+        wgpu::BlasGeometrySizeDescriptors::Triangles {
+            descriptors: vec![blas_size.clone()],
+        },
+    );
+    let mut tlas = ctx.device.create_tlas(&wgpu::CreateTlasDescriptor {
+        label: None,
+        max_instances: 1,
+        flags: wgpu::AccelerationStructureFlags::PREFER_FAST_BUILD,
+        update_mode: wgpu::AccelerationStructureUpdateMode::Build,
+    });
+
+    tlas[0] = Some(wgpu::TlasInstance::new(
+        &blas,
+        [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0,
+        ],
+        0,
+        0xff,
+    ));
+
+    let hit_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("hit kind"),
+        size: size_of::<u32>() as wgpu::BufferAddress,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    let read_back = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("hit kind readback"),
+        size: hit_buffer.size(),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: None,
+        layout: &pipeline.get_bind_group_layout(0),
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: tlas.as_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: hit_buffer.as_entire_binding(),
+            },
+        ],
+    });
+
+    TraceSetup {
+        vertex_buffer,
+        blas_size,
+        blas,
+        tlas,
+        hit_buffer,
+        read_back,
+        bind_group,
+    }
+}
+
+fn blas_build_entry(setup: &TraceSetup) -> wgpu::BlasBuildEntry<'_> {
+    wgpu::BlasBuildEntry {
+        blas: &setup.blas,
+        geometry: wgpu::BlasGeometries::TriangleGeometries(vec![wgpu::BlasTriangleGeometry {
+            size: &setup.blas_size,
+            vertex_buffer: &setup.vertex_buffer,
+            first_vertex: 0,
+            vertex_stride: 12,
+            index_buffer: None,
+            first_index: None,
+            transform_buffer: None,
+            transform_buffer_offset: None,
+        }]),
+    }
+}
+
+// Records the TLAS build, the ray query, and the readback copy onto `encoder`.
+fn record_tlas_trace_and_copy(
+    setup: &TraceSetup,
+    pipeline: &wgpu::ComputePipeline,
+    encoder: &mut wgpu::CommandEncoder,
+) {
+    encoder.build_acceleration_structures([], [&setup.tlas]);
+
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, &setup.bind_group, &[]);
+        pass.dispatch_workgroups(1, 1, 1);
+    }
+
+    encoder.copy_buffer_to_buffer(
+        &setup.hit_buffer,
+        0,
+        &setup.read_back,
+        0,
+        setup.hit_buffer.size(),
+    );
+}
+
+async fn read_hit_kind(ctx: &TestingContext, setup: &TraceSetup) -> u32 {
+    let slice = setup.read_back.slice(..);
+    slice.map_async(wgpu::MapMode::Read, Result::unwrap);
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
+
+    let hit_kind = {
+        let view = slice.get_mapped_range().unwrap();
+        u32::from_ne_bytes(view[..size_of::<u32>()].try_into().unwrap())
+    };
+    setup.read_back.unmap();
+    hit_kind
+}
+
+fn create_ray_query_pipeline(ctx: &TestingContext) -> wgpu::ComputePipeline {
+    let shader = ctx
+        .device
+        .create_shader_module(wgpu::include_wgsl!("issue_9215.wgsl"));
+    ctx.device
+        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: None,
+            layout: None,
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        })
+}
+
+async fn run_iterations(ctx: TestingContext, separate_command_buffers: bool) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    for i in 0..ITERATIONS {
+        let setup = create_trace_setup(&ctx, &pipeline);
+
+        if separate_command_buffers {
+            let mut blas_encoder = ctx
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            let blas_entry = blas_build_entry(&setup);
+            blas_encoder.build_acceleration_structures([&blas_entry], []);
+
+            let mut tlas_encoder = ctx
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            record_tlas_trace_and_copy(&setup, &pipeline, &mut tlas_encoder);
+
+            ctx.queue
+                .submit([blas_encoder.finish(), tlas_encoder.finish()]);
+        } else {
+            let mut encoder = ctx
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            let blas_entry = blas_build_entry(&setup);
+            encoder.build_acceleration_structures([&blas_entry], []);
+            record_tlas_trace_and_copy(&setup, &pipeline, &mut encoder);
+
+            ctx.queue.submit([encoder.finish()]);
+        }
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+// A BLAS build is recorded and then thrown away: either by discarding the
+// encoder, or by finishing and dropping the command buffer without submitting
+// it. The consumer below is fully encoded before the producer goes away, but
+// the producer's encoder is not: wgpu-core recycles hal command encoders, so
+// any per-command-buffer state the producer leaves behind is handed to a
+// later recording. The submission here must run its own acceleration
+// structure work correctly regardless of what the abandoned recording did.
+async fn run_iterations_with_abandoned_producer(ctx: TestingContext, discard_encoder: bool) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    for i in 0..ITERATIONS {
+        let setup = create_trace_setup(&ctx, &pipeline);
+
+        let mut producer = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        producer.build_acceleration_structures([&blas_entry], []);
+
+        let mut consumer = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        consumer.build_acceleration_structures([&blas_entry], []);
+        record_tlas_trace_and_copy(&setup, &pipeline, &mut consumer);
+
+        if discard_encoder {
+            drop(producer);
+        } else {
+            drop(producer.finish());
+        }
+
+        ctx.queue.submit([consumer.finish()]);
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+// A BLAS build followed by a blit is recorded and then thrown away: either by
+// discarding the encoder, or by finishing and dropping the command buffer
+// without submitting it. The blit forces the published close of the build's
+// acceleration structure encoder, so the abandoned recording leaves behind
+// encoder state saying a fence was updated and acceleration structure
+// commands are present, with no consumer left in the recording. The consumer
+// is only recorded after the producer is gone, so it records on the
+// producer's recycled encoder: leftover state would make its first
+// acceleration structure encoder wait on a fence whose update was never
+// committed. The submission must still produce a triangle hit.
+async fn run_iterations_with_published_then_abandoned_producer(
+    ctx: TestingContext,
+    discard_encoder: bool,
+) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    let blit_src = ctx.device.create_buffer_init(&BufferInitDescriptor {
+        label: Some("producer blit source"),
+        contents: &[0; 16],
+        usage: wgpu::BufferUsages::COPY_SRC,
+    });
+    let blit_dst = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("producer blit destination"),
+        size: blit_src.size(),
+        usage: wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    for i in 0..ITERATIONS {
+        let setup = create_trace_setup(&ctx, &pipeline);
+
+        let mut producer = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        producer.build_acceleration_structures([&blas_entry], []);
+        producer.copy_buffer_to_buffer(&blit_src, 0, &blit_dst, 0, blit_src.size());
+
+        if discard_encoder {
+            drop(producer);
+        } else {
+            drop(producer.finish());
+        }
+
+        // Recorded only after the producer is gone, on the producer's
+        // recycled encoder.
+        let mut consumer = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        consumer.build_acceleration_structures([&blas_entry], []);
+        record_tlas_trace_and_copy(&setup, &pipeline, &mut consumer);
+
+        ctx.queue.submit([consumer.finish()]);
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+// A blit encoded between two builds closes the acceleration structure encoder
+// they would otherwise share; the builds must still be ordered.
+async fn run_iterations_with_blit_between_builds(ctx: TestingContext) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    let blit_src = ctx.device.create_buffer_init(&BufferInitDescriptor {
+        label: Some("blit source"),
+        contents: &[0; 16],
+        usage: wgpu::BufferUsages::COPY_SRC,
+    });
+    let blit_dst = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("blit destination"),
+        size: blit_src.size(),
+        usage: wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    for i in 0..ITERATIONS {
+        let setup = create_trace_setup(&ctx, &pipeline);
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        encoder.build_acceleration_structures([&blas_entry], []);
+
+        encoder.copy_buffer_to_buffer(&blit_src, 0, &blit_dst, 0, blit_src.size());
+
+        encoder.build_acceleration_structures([], [&setup.tlas]);
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &setup.bind_group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+        encoder.copy_buffer_to_buffer(
+            &setup.hit_buffer,
+            0,
+            &setup.read_back,
+            0,
+            setup.hit_buffer.size(),
+        );
+
+        ctx.queue.submit([encoder.finish()]);
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+// A compute pass encoded between two builds closes the acceleration structure
+// encoder they would otherwise share; the builds must still be ordered.
+async fn run_iterations_with_compute_pass_between_builds(ctx: TestingContext) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    let filler_pipeline = {
+        let shader = ctx
+            .device
+            .create_shader_module(wgpu::include_wgsl!("issue_9215_fill.wgsl"));
+        ctx.device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: None,
+                layout: None,
+                module: &shader,
+                entry_point: Some("main"),
+                compilation_options: Default::default(),
+                cache: None,
+            })
+    };
+    let scratch = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("filler scratch"),
+        size: size_of::<u32>() as wgpu::BufferAddress,
+        usage: wgpu::BufferUsages::STORAGE,
+        mapped_at_creation: false,
+    });
+    let filler_bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: None,
+        layout: &filler_pipeline.get_bind_group_layout(0),
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: scratch.as_entire_binding(),
+        }],
+    });
+
+    for i in 0..ITERATIONS {
+        let setup = create_trace_setup(&ctx, &pipeline);
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        encoder.build_acceleration_structures([&blas_entry], []);
+
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&filler_pipeline);
+            pass.set_bind_group(0, &filler_bind_group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+
+        encoder.build_acceleration_structures([], [&setup.tlas]);
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &setup.bind_group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+        encoder.copy_buffer_to_buffer(
+            &setup.hit_buffer,
+            0,
+            &setup.read_back,
+            0,
+            setup.hit_buffer.size(),
+        );
+
+        ctx.queue.submit([encoder.finish()]);
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+// A compacted BLAS is produced through the queue's pending writes: the
+// compaction copy is encoded onto the internal pending-writes encoder, which
+// is committed ahead of the command buffers of the next submission. A queue
+// write encoded onto the same encoder closes the acceleration structure
+// encoder the compaction copy leaves open, and the consuming TLAS build in
+// the next submission must be ordered after the copy.
+async fn run_iterations_with_compacted_blas_in_pending_writes(ctx: TestingContext) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    let scratch = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("queue write scratch"),
+        size: 16,
+        usage: wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    for i in 0..ITERATIONS {
+        let mut setup = create_trace_setup(&ctx, &pipeline);
+
+        // The BLAS must allow compaction for `compact_blas` to accept it.
+        let blas = ctx.device.create_blas(
+            &wgpu::CreateBlasDescriptor {
+                label: None,
+                flags: wgpu::AccelerationStructureFlags::PREFER_FAST_BUILD
+                    | wgpu::AccelerationStructureFlags::ALLOW_COMPACTION,
+                update_mode: wgpu::AccelerationStructureUpdateMode::Build,
+            },
+            wgpu::BlasGeometrySizeDescriptors::Triangles {
+                descriptors: vec![setup.blas_size.clone()],
+            },
+        );
+        setup.blas = blas;
+        setup.tlas[0] = Some(wgpu::TlasInstance::new(
+            &setup.blas,
+            [
+                1.0, 0.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, 0.0, //
+                0.0, 0.0, 1.0, 0.0,
+            ],
+            0,
+            0xff,
+        ));
+
+        // Build the BLAS and wait for it so it can be prepared for compaction.
+        let mut blas_encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        blas_encoder.build_acceleration_structures([&blas_entry], []);
+        ctx.queue.submit([blas_encoder.finish()]);
+
+        let (send, recv) = std::sync::mpsc::channel();
+        setup.blas.prepare_compaction_async(move |res| {
+            res.unwrap();
+            send.send(()).unwrap();
+        });
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
+        recv.recv().unwrap();
+        assert!(setup.blas.ready_for_compaction());
+
+        // Encodes the compaction copy onto the pending-writes encoder.
+        let compacted = ctx.queue.compact_blas(&setup.blas);
+
+        // Encodes a blit onto the same pending-writes encoder, closing the
+        // acceleration structure encoder the compaction copy left open.
+        ctx.queue
+            .write_buffer(&scratch, 0, bytemuck::cast_slice(&[0_u32; 4]));
+
+        let mut tlas = ctx.device.create_tlas(&wgpu::CreateTlasDescriptor {
+            label: None,
+            max_instances: 1,
+            flags: wgpu::AccelerationStructureFlags::PREFER_FAST_BUILD,
+            update_mode: wgpu::AccelerationStructureUpdateMode::Build,
+        });
+        tlas[0] = Some(wgpu::TlasInstance::new(
+            &compacted,
+            [
+                1.0, 0.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, 0.0, //
+                0.0, 0.0, 1.0, 0.0,
+            ],
+            0,
+            0xff,
+        ));
+
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &pipeline.get_bind_group_layout(0),
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: tlas.as_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: setup.hit_buffer.as_entire_binding(),
+                },
+            ],
+        });
+
+        let mut consumer = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        consumer.build_acceleration_structures([], [&tlas]);
+        {
+            let mut pass = consumer.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+        consumer.copy_buffer_to_buffer(
+            &setup.hit_buffer,
+            0,
+            &setup.read_back,
+            0,
+            setup.hit_buffer.size(),
+        );
+
+        // Commits the pending writes (compaction copy and queue write) ahead
+        // of the consumer command buffer.
+        ctx.queue.submit([consumer.finish()]);
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+#[gpu_test]
+static BLAS_AND_TLAS_IN_SAME_COMMAND_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move { run_iterations(ctx, false).await });
+
+#[gpu_test]
+static BLAS_AND_TLAS_IN_SEPARATE_COMMAND_BUFFERS: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .limits(acceleration_structure_limits())
+                .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+        )
+        .run_async(|ctx| async move { run_iterations(ctx, true).await });
+
+#[gpu_test]
+static ENCODER_DISCARDED_AFTER_BLAS_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move { run_iterations_with_abandoned_producer(ctx, true).await });
+
+#[gpu_test]
+static COMMAND_BUFFER_DROPPED_WITHOUT_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move { run_iterations_with_abandoned_producer(ctx, false).await });
+
+#[gpu_test]
+static ENCODER_DISCARDED_AFTER_PUBLISHED_CLOSE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move {
+        run_iterations_with_published_then_abandoned_producer(ctx, true).await
+    });
+
+#[gpu_test]
+static COMMAND_BUFFER_DROPPED_AFTER_PUBLISHED_CLOSE: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .limits(acceleration_structure_limits())
+                .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+        )
+        .run_async(|ctx| async move {
+            run_iterations_with_published_then_abandoned_producer(ctx, false).await
+        });
+
+#[gpu_test]
+static BLIT_BETWEEN_BUILDS_IN_SAME_COMMAND_BUFFER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .limits(acceleration_structure_limits())
+                .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+        )
+        .run_async(|ctx| async move { run_iterations_with_blit_between_builds(ctx).await });
+
+#[gpu_test]
+static COMPUTE_PASS_BETWEEN_BUILDS_IN_SAME_COMMAND_BUFFER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .limits(acceleration_structure_limits())
+                .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+        )
+        .run_async(|ctx| async move { run_iterations_with_compute_pass_between_builds(ctx).await });
+
+#[gpu_test]
+static COMPACTED_BLAS_IN_PENDING_WRITES: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(
+        |ctx| async move { run_iterations_with_compacted_blas_in_pending_writes(ctx).await },
+    );

--- a/tests/tests/wgpu-gpu/regression/issue_9215.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_9215.rs
@@ -1,4 +1,4 @@
-use std::mem::size_of;
+use std::{mem::size_of, time::Duration};
 
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu_macros::gpu_test;
@@ -18,6 +18,9 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.push(COMPACTED_BLAS_IN_PENDING_WRITES);
     vec.push(ENCODER_DISCARDED_AFTER_PUBLISHED_CLOSE);
     vec.push(COMMAND_BUFFER_DROPPED_AFTER_PUBLISHED_CLOSE);
+    vec.push(RECORD_CONSUMER_BEFORE_PRODUCER);
+    vec.push(REJECT_CONSUMER_SUBMITTED_BEFORE_PRODUCER);
+    vec.push(FIRST_BUILD_AFTER_COMPUTE_UPLOAD);
 }
 
 // The failures are races, so a pass is evidence rather than proof. On the
@@ -96,7 +99,7 @@ fn create_trace_setup(ctx: &TestingContext, pipeline: &wgpu::ComputePipeline) ->
 
     let hit_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("hit kind"),
-        size: size_of::<u32>() as wgpu::BufferAddress,
+        size: 64,
         usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
         mapped_at_creation: false,
     });
@@ -177,13 +180,25 @@ fn record_tlas_trace_and_copy(
 async fn read_hit_kind(ctx: &TestingContext, setup: &TraceSetup) -> u32 {
     let slice = setup.read_back.slice(..);
     slice.map_async(wgpu::MapMode::Read, Result::unwrap);
-    ctx.async_poll(wgpu::PollType::wait_indefinitely())
-        .await
-        .unwrap();
+    ctx.async_poll(wgpu::PollType::Wait {
+        submission_index: None,
+        timeout: Some(Duration::from_secs(30)),
+    })
+    .await
+    .unwrap();
 
     let hit_kind = {
         let view = slice.get_mapped_range().unwrap();
-        u32::from_ne_bytes(view[..size_of::<u32>()].try_into().unwrap())
+        let words: &[u32] = bytemuck::cast_slice(&view);
+        assert_eq!(words[8], 0, "known-miss control");
+        if words[0] == TRIANGLE_HIT_KIND {
+            assert!((f32::from_bits(words[1]) - 1.0).abs() < 1e-5);
+            assert_eq!(&words[2..6], &[0, 0, 0, 0], "hit identifiers");
+            for &barycentric in &words[6..8] {
+                assert!((f32::from_bits(barycentric) - 0.25).abs() < 1e-5);
+            }
+        }
+        words[0]
     };
     setup.read_back.unmap();
     hit_kind
@@ -532,10 +547,13 @@ async fn run_iterations_with_compacted_blas_in_pending_writes(ctx: TestingContex
             res.unwrap();
             send.send(()).unwrap();
         });
-        ctx.async_poll(wgpu::PollType::wait_indefinitely())
-            .await
-            .unwrap();
-        recv.recv().unwrap();
+        ctx.async_poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: Some(Duration::from_secs(30)),
+        })
+        .await
+        .unwrap();
+        recv.recv_timeout(Duration::from_secs(30)).unwrap();
         assert!(setup.blas.ready_for_compaction());
 
         // Encodes the compaction copy onto the pending-writes encoder.
@@ -545,6 +563,25 @@ async fn run_iterations_with_compacted_blas_in_pending_writes(ctx: TestingContex
         // acceleration structure encoder the compaction copy left open.
         ctx.queue
             .write_buffer(&scratch, 0, bytemuck::cast_slice(&[0_u32; 4]));
+
+        // Exercise pending-writes-only retirement as well as same-submit consumption.
+        if i % 2 == 0 {
+            let submission = ctx.queue.submit([]);
+            if i % 4 == 2 {
+                let (send, recv) = std::sync::mpsc::channel();
+                ctx.queue
+                    .on_submitted_work_done(move || send.send(()).unwrap());
+                ctx.async_poll(wgpu::PollType::Wait {
+                    submission_index: Some(submission),
+                    timeout: Some(Duration::from_secs(30)),
+                })
+                .await
+                .unwrap();
+                recv.recv_timeout(Duration::from_secs(30)).unwrap();
+                setup.tlas[0] = None;
+                drop(std::mem::replace(&mut setup.blas, compacted.clone()));
+            }
+        }
 
         let mut tlas = ctx.device.create_tlas(&wgpu::CreateTlasDescriptor {
             label: None,
@@ -707,3 +744,140 @@ static COMPACTED_BLAS_IN_PENDING_WRITES: GpuTestConfiguration = GpuTestConfigura
     .run_async(
         |ctx| async move { run_iterations_with_compacted_blas_in_pending_writes(ctx).await },
     );
+
+#[gpu_test]
+static RECORD_CONSUMER_BEFORE_PRODUCER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move {
+        let pipeline = create_ray_query_pipeline(&ctx);
+        for separate_submits in [false, true] {
+            for abandon_finished in [false, true] {
+                let setup = create_trace_setup(&ctx, &pipeline);
+                let mut abandoned = ctx.device.create_command_encoder(&Default::default());
+                abandoned.build_acceleration_structures([&blas_build_entry(&setup)], []);
+                let mut consumer = ctx.device.create_command_encoder(&Default::default());
+                record_tlas_trace_and_copy(&setup, &pipeline, &mut consumer);
+                let consumer = consumer.finish();
+                if abandon_finished {
+                    drop(abandoned.finish());
+                } else {
+                    drop(abandoned);
+                }
+                let mut producer = ctx.device.create_command_encoder(&Default::default());
+                producer.build_acceleration_structures([&blas_build_entry(&setup)], []);
+                let producer = producer.finish();
+                if separate_submits {
+                    ctx.queue.submit([producer]);
+                    ctx.queue.submit([consumer]);
+                } else {
+                    ctx.queue.submit([producer, consumer]);
+                }
+                assert_eq!(read_hit_kind(&ctx, &setup).await, TRIANGLE_HIT_KIND);
+
+                // This submission consumes the AS but contains no build commands.
+                let mut query = ctx.device.create_command_encoder(&Default::default());
+                {
+                    let mut pass = query.begin_compute_pass(&Default::default());
+                    pass.set_pipeline(&pipeline);
+                    pass.set_bind_group(0, &setup.bind_group, &[]);
+                    pass.dispatch_workgroups(1, 1, 1);
+                }
+                query.copy_buffer_to_buffer(&setup.hit_buffer, 0, &setup.read_back, 0, 64);
+                ctx.queue.submit([query.finish()]);
+                assert_eq!(read_hit_kind(&ctx, &setup).await, TRIANGLE_HIT_KIND);
+            }
+        }
+    });
+
+#[gpu_test]
+static REJECT_CONSUMER_SUBMITTED_BEFORE_PRODUCER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .limits(acceleration_structure_limits())
+                .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+        )
+        .run_sync(|ctx| {
+            let pipeline = create_ray_query_pipeline(&ctx);
+            for separate_submits in [false, true] {
+                let setup = create_trace_setup(&ctx, &pipeline);
+                let mut consumer = ctx.device.create_command_encoder(&Default::default());
+                consumer.build_acceleration_structures([], [&setup.tlas]);
+                let consumer = consumer.finish();
+                let mut producer = ctx.device.create_command_encoder(&Default::default());
+                producer.build_acceleration_structures([&blas_build_entry(&setup)], []);
+                let producer = producer.finish();
+                // Noop's zero scratch sizes omit build actions, so this needs a native backend.
+                wgpu_test::fail(
+                    &ctx.device,
+                    || {
+                        if separate_submits {
+                            ctx.queue.submit([consumer]);
+                            drop(producer);
+                        } else {
+                            ctx.queue.submit([consumer, producer]);
+                        }
+                    },
+                    Some("is used before it is built"),
+                );
+            }
+        });
+
+#[gpu_test]
+static FIRST_BUILD_AFTER_COMPUTE_UPLOAD: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move {
+        let pipeline = create_ray_query_pipeline(&ctx);
+        let mut setup = create_trace_setup(&ctx, &pipeline);
+        setup.vertex_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("compute generated AS vertices"),
+            size: 36,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::BLAS_INPUT,
+            mapped_at_creation: false,
+        });
+        let shader = ctx
+            .device
+            .create_shader_module(wgpu::include_wgsl!("issue_9215_fill.wgsl"));
+        let generate = ctx
+            .device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: None,
+                layout: None,
+                module: &shader,
+                entry_point: Some("generate_vertices"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+        let group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &generate.get_bind_group_layout(0),
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: setup.vertex_buffer.as_entire_binding(),
+            }],
+        });
+        let mut upload = ctx.device.create_command_encoder(&Default::default());
+        {
+            let mut pass = upload.begin_compute_pass(&Default::default());
+            pass.set_pipeline(&generate);
+            pass.set_bind_group(0, &group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+        ctx.queue.submit([upload.finish()]);
+        let mut build = ctx.device.create_command_encoder(&Default::default());
+        build.build_acceleration_structures([&blas_build_entry(&setup)], []);
+        record_tlas_trace_and_copy(&setup, &pipeline, &mut build);
+        ctx.queue.submit([build.finish()]);
+        assert_eq!(read_hit_kind(&ctx, &setup).await, TRIANGLE_HIT_KIND);
+    });

--- a/tests/tests/wgpu-gpu/regression/issue_9215.wgsl
+++ b/tests/tests/wgpu-gpu/regression/issue_9215.wgsl
@@ -3,18 +3,35 @@ enable wgpu_ray_query;
 @group(0) @binding(0)
 var acc: acceleration_structure;
 
+struct Hit {
+    kind: u32,
+    t: f32,
+    custom: u32,
+    instance: u32,
+    geometry: u32,
+    primitive: u32,
+    barycentrics: vec2f,
+}
+
 @group(0) @binding(1)
-var<storage, read_write> hit_kind: u32;
+var<storage, read_write> hits: array<Hit, 2>;
 
 @compute
 @workgroup_size(1)
 fn main() {
-    var query: ray_query;
-    rayQueryInitialize(
-        &query,
-        acc,
-        RayDesc(0u, 0xffu, 0.0, 10.0, vec3(0.0), vec3(0.0, 1.0, 0.0))
-    );
-    while (rayQueryProceed(&query)) {}
-    hit_kind = rayQueryGetCommittedIntersection(&query).kind;
+    for (var i = 0u; i < 2u; i++) {
+        var query: ray_query;
+        rayQueryInitialize(
+            &query,
+            acc,
+            RayDesc(0u, 0xffu, 0.0, 10.0, vec3f(f32(i) * 4.0, 0.0, 0.0), vec3f(0.0, 1.0, 0.0))
+        );
+        while (rayQueryProceed(&query)) {}
+        let hit = rayQueryGetCommittedIntersection(&query);
+        hits[i].kind = hit.kind;
+        if (hit.kind != 0u) {
+            hits[i] = Hit(hit.kind, hit.t, hit.instance_custom_data, hit.instance_index,
+                hit.geometry_index, hit.primitive_index, hit.barycentrics);
+        }
+    }
 }

--- a/tests/tests/wgpu-gpu/regression/issue_9215.wgsl
+++ b/tests/tests/wgpu-gpu/regression/issue_9215.wgsl
@@ -1,0 +1,20 @@
+enable wgpu_ray_query;
+
+@group(0) @binding(0)
+var acc: acceleration_structure;
+
+@group(0) @binding(1)
+var<storage, read_write> hit_kind: u32;
+
+@compute
+@workgroup_size(1)
+fn main() {
+    var query: ray_query;
+    rayQueryInitialize(
+        &query,
+        acc,
+        RayDesc(0u, 0xffu, 0.0, 10.0, vec3(0.0), vec3(0.0, 1.0, 0.0))
+    );
+    while (rayQueryProceed(&query)) {}
+    hit_kind = rayQueryGetCommittedIntersection(&query).kind;
+}

--- a/tests/tests/wgpu-gpu/regression/issue_9215_fill.wgsl
+++ b/tests/tests/wgpu-gpu/regression/issue_9215_fill.wgsl
@@ -1,0 +1,8 @@
+@group(0) @binding(0)
+var<storage, read_write> scratch: u32;
+
+@compute
+@workgroup_size(1)
+fn main() {
+    scratch = 1u;
+}

--- a/tests/tests/wgpu-gpu/regression/issue_9215_fill.wgsl
+++ b/tests/tests/wgpu-gpu/regression/issue_9215_fill.wgsl
@@ -6,3 +6,14 @@ var<storage, read_write> scratch: u32;
 fn main() {
     scratch = 1u;
 }
+
+@group(0) @binding(0)
+var<storage, read_write> vertices: array<f32>;
+
+@compute @workgroup_size(1)
+fn generate_vertices() {
+    let triangle = array<f32, 9>(1.0, 1.0, 0.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0);
+    for (var i = 0u; i < 9u; i++) {
+        vertices[i] = triangle[i];
+    }
+}

--- a/wgpu-core/src/command/ray_tracing.rs
+++ b/wgpu-core/src/command/ray_tracing.rs
@@ -648,16 +648,20 @@ fn iter_blas<'snatch_guard: 'buffers, 'buffers>(
                         ));
                     }
 
-                    if size_desc
-                        .vertex_format
-                        .min_acceleration_structure_vertex_stride()
-                        > mesh.vertex_stride
-                    {
+                    // While DirectX allows packed 6 byte strides for 4-component
+                    // 16-bit formats, Metal requires the stride to cover the full
+                    // attribute size, so the backend minimum diverges there.
+                    let min_vertex_stride = if state.device.backend() == wgt::Backend::Metal {
+                        size_desc.vertex_format.size()
+                    } else {
+                        size_desc
+                            .vertex_format
+                            .min_acceleration_structure_vertex_stride()
+                    };
+                    if min_vertex_stride > mesh.vertex_stride {
                         return Err(BuildAccelerationStructureError::VertexStrideTooSmall(
                             blas.error_ident(),
-                            size_desc
-                                .vertex_format
-                                .min_acceleration_structure_vertex_stride(),
+                            min_vertex_stride,
                             mesh.vertex_stride,
                         ));
                     }

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1280,7 +1280,13 @@ impl super::CapabilitiesQuery {
             features.insert(F::MULTIVIEW);
         }
 
-        features.set(F::EXPERIMENTAL_RAY_QUERY, self.supports_raytracing);
+        features.set(
+            F::EXPERIMENTAL_RAY_QUERY
+                // Metal's geometry descriptors accept any MTLAttributeFormat, so the
+                // extended BLAS vertex formats come along with ray query support.
+                | F::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS,
+            self.supports_raytracing,
+        );
 
         features.set(F::MULTISAMPLE_ARRAY, self.supports_multisample_array);
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -45,6 +45,9 @@ fn device_class_responds_to(device: &ProtocolObject<dyn MTLDevice>, sel: Sel) ->
 ///
 /// [new command buffer]: https://developer.apple.com/documentation/metal/mtlcommandqueue/makecommandbuffer()?language=objc
 pub(super) const MAX_COMMAND_BUFFERS: usize = 4096;
+// Internal allocations are serialized through commit and need one native slot
+// even when all admitted user recordings remain unsubmitted.
+pub(super) const MAX_UNSUBMITTED_COMMAND_BUFFERS: usize = MAX_COMMAND_BUFFERS - 1;
 
 // Metal has a single buffer limit that we must split across 3 WebGPU limits:
 // The Metal limit is: 31 "Maximum number of entries in the buffer argument table, per graphics or kernel function".
@@ -124,7 +127,7 @@ impl crate::Adapter for super::Adapter {
                 queue: super::Queue {
                     shared: Arc::new(QueueShared {
                         raw: queue,
-                        command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
+                        command_buffer_created_not_submitted: Arc::new(atomic::AtomicUsize::new(0)),
                         acceleration_structure_sync: Mutex::default(),
                     }),
                     timestamp_period,

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -11,6 +11,7 @@ use wgt::{AstcBlock, AstcChannel};
 
 use alloc::{string::ToString as _, sync::Arc, vec::Vec};
 use core::sync::atomic;
+use parking_lot::Mutex;
 
 use crate::metal::QueueShared;
 
@@ -124,6 +125,7 @@ impl crate::Adapter for super::Adapter {
                     shared: Arc::new(QueueShared {
                         raw: queue,
                         command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
+                        acceleration_structure_sync: Mutex::default(),
                     }),
                     timestamp_period,
                 },

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1123,12 +1123,12 @@ impl super::CapabilitiesQuery {
             supports_cooperative_matrix: family_check
                 && (device.supportsFamily(MTLGPUFamily::Apple7)
                     || device.supportsFamily(MTLGPUFamily::Mac2)),
-            // https://developer.apple.com/documentation/metal/mtlresidencyset
+            // Residency sets and row-major BLAS transformation matrices.
             supports_raytracing: if available!(
                 macos = 15.0,
                 ios = 18.0,
-                tvos = 18.0,
-                visionos = 2.0,
+                tvos = 18.1,
+                visionos = 2.1,
             ) {
                 device_class_responds_to(device, sel!(supportsRaytracing))
                     && device.supportsRaytracing()

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -62,7 +62,7 @@ pub(super) const MAX_UNSUBMITTED_COMMAND_BUFFERS: usize = MAX_COMMAND_BUFFERS - 
 const MAX_STORAGE_BUFFERS_PER_SHADER_STAGE: u32 = 8;
 const MAX_UNIFORM_BUFFERS_PER_SHADER_STAGE: u32 = 12;
 const MAX_VERTEX_BUFFERS: u32 = 8;
-const MAX_ACCELERATION_STRUCTURES_PER_SHADER_STAGE: u32 = 1;
+const MAX_ACCELERATION_STRUCTURES_PER_SHADER_STAGE: u32 = 8;
 // Use the end of the range for vertex buffers.
 pub const VERTEX_BUFFER_SLOT_START: u32 = 31 - 8;
 
@@ -1284,7 +1284,10 @@ impl super::CapabilitiesQuery {
             F::EXPERIMENTAL_RAY_QUERY
                 // Metal's geometry descriptors accept any MTLAttributeFormat, so the
                 // extended BLAS vertex formats come along with ray query support.
-                | F::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS,
+                | F::EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS
+                // Acceleration structures are passed as regular buffer bindings,
+                // so binding arrays of them ride on the same mechanism.
+                | F::ACCELERATION_STRUCTURE_BINDING_ARRAY,
             self.supports_raytracing,
         );
 
@@ -1388,7 +1391,13 @@ impl super::CapabilitiesQuery {
             max_binding_array_elements_per_shader_stage: self.max_binding_array_elements,
             max_binding_array_sampler_elements_per_shader_stage: self
                 .max_sampler_binding_array_elements,
-            max_binding_array_acceleration_structure_elements_per_shader_stage: 0,
+            max_binding_array_acceleration_structure_elements_per_shader_stage: if self
+                .supports_raytracing
+            {
+                self.max_binding_array_elements
+            } else {
+                0
+            },
 
             // from https://developer.apple.com/documentation/metal/mtlaccelerationstructureusage/extendedlimits
             max_blas_primitive_count: 1 << 28,

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -34,6 +34,9 @@ impl Default for super::CommandState {
         Self {
             blit: None,
             acceleration_structure_builder: None,
+            acceleration_structure_fence: None,
+            pending_acceleration_structure_fence_wait: false,
+            acceleration_structure_builder_has_builds: false,
             render: None,
             compute: None,
             raw_primitive_type: MTLPrimitiveType::Point,
@@ -273,6 +276,14 @@ impl super::CommandEncoder {
                 self.state.acceleration_structure_builder =
                     cmd_buf.accelerationStructureCommandEncoder().to_owned();
             });
+            if self.state.pending_acceleration_structure_fence_wait {
+                self.state.pending_acceleration_structure_fence_wait = false;
+                self.state
+                    .acceleration_structure_builder
+                    .as_ref()
+                    .unwrap()
+                    .waitForFence(self.state.acceleration_structure_fence.as_ref().unwrap());
+            }
         }
         self.state.acceleration_structure_builder.clone().unwrap()
     }
@@ -280,6 +291,27 @@ impl super::CommandEncoder {
     pub(super) fn leave_acceleration_structure_builder(&mut self) {
         if let Some(encoder) = self.state.acceleration_structure_builder.take() {
             encoder.endEncoding();
+            self.state.acceleration_structure_builder_has_builds = false;
+        }
+    }
+
+    /// Ends the current acceleration structure encoder, if any, after
+    /// updating [`super::CommandState::acceleration_structure_fence`], which
+    /// the next acceleration structure encoder then waits on (see
+    /// [`Self::enter_acceleration_structure_builder`]). Metal does not order
+    /// acceleration structure commands encoded on the same encoder, and
+    /// fences are only defined across encoder boundaries, so this is how
+    /// commands later in the command buffer are ordered after prior builds.
+    fn split_acceleration_structure_builder(&mut self) {
+        if let Some(encoder) = self.state.acceleration_structure_builder.take() {
+            let fence = self
+                .state
+                .acceleration_structure_fence
+                .get_or_insert_with(|| self.shared.device.newFence().unwrap());
+            encoder.updateFence(fence);
+            encoder.endEncoding();
+            self.state.pending_acceleration_structure_fence_wait = true;
+            self.state.acceleration_structure_builder_has_builds = false;
         }
     }
 
@@ -498,6 +530,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     unsafe fn discard_encoding(&mut self) {
         self.leave_blit();
         self.leave_acceleration_structure_builder();
+        self.state.pending_acceleration_structure_fence_wait = false;
         // when discarding, we don't have a guarantee that
         // everything is in a good state, so check carefully
         if let Some(encoder) = self.state.render.take() {
@@ -526,6 +559,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
         self.leave_blit();
         self.leave_acceleration_structure_builder();
+        self.state.pending_acceleration_structure_fence_wait = false;
         debug_assert!(self.state.render.is_none());
         debug_assert!(self.state.compute.is_none());
         debug_assert!(self.state.pending_timer_queries.is_empty());
@@ -1816,6 +1850,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         >,
     {
         let command_encoder = self.enter_acceleration_structure_builder();
+        self.state.acceleration_structure_builder_has_builds = true;
         for descriptor in descriptors {
             let acceleration_structure_descriptor =
                 conv::map_acceleration_structure_descriptor(descriptor.entries, descriptor.flags);
@@ -1844,8 +1879,16 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn place_acceleration_structure_barrier(
         &mut self,
-        _barriers: crate::AccelerationStructureBarrier,
+        _barrier: crate::AccelerationStructureBarrier,
     ) {
+        // wgpu-core emits an acceleration structure barrier at every point
+        // where ordering between acceleration structure commands is required,
+        // so rather than interpret the usage flags, split any open encoder
+        // unconditionally. An encoder is only open here if it encoded prior
+        // acceleration structure commands, so this never splits needlessly,
+        // and not relying on the flags keeps this correct if wgpu-core's
+        // barrier emission changes.
+        self.split_acceleration_structure_builder();
     }
 
     unsafe fn read_acceleration_structure_compact_size(
@@ -1853,6 +1896,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
         acceleration_structure: &super::AccelerationStructure,
         buffer: &super::Buffer,
     ) {
+        // wgpu-core encodes this with no barrier after the build of the
+        // acceleration structure being queried, so if the current encoder
+        // contains builds, split it; otherwise the size could be read from a
+        // still-building acceleration structure.
+        if self.state.acceleration_structure_builder_has_builds {
+            self.split_acceleration_structure_builder();
+        }
         let command_encoder = self.enter_acceleration_structure_builder();
         command_encoder.writeCompactedAccelerationStructureSize_toBuffer_offset(
             &acceleration_structure.raw,

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -7,10 +7,10 @@ use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLBlitCommandEncoder,
     MTLBlitPassDescriptor, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder,
     MTLCommandQueue, MTLComputeCommandEncoder, MTLComputePassDescriptor, MTLCounterDontSample,
-    MTLDevice, MTLLoadAction, MTLPrimitiveType, MTLRenderCommandEncoder, MTLRenderPassDescriptor,
-    MTLResidencySet, MTLResidencySetDescriptor, MTLSamplerState, MTLScissorRect, MTLSize,
-    MTLStoreAction, MTLTexture, MTLVertexAmplificationViewMapping, MTLViewport,
-    MTLVisibilityResultMode,
+    MTLDevice, MTLFence, MTLLoadAction, MTLPrimitiveType, MTLRenderCommandEncoder,
+    MTLRenderPassDescriptor, MTLResidencySet, MTLResidencySetDescriptor, MTLSamplerState,
+    MTLScissorRect, MTLSize, MTLStoreAction, MTLTexture, MTLVertexAmplificationViewMapping,
+    MTLViewport, MTLVisibilityResultMode,
 };
 
 use super::{
@@ -34,9 +34,9 @@ impl Default for super::CommandState {
         Self {
             blit: None,
             acceleration_structure_builder: None,
-            acceleration_structure_fence: None,
-            pending_acceleration_structure_fence_wait: false,
-            acceleration_structure_builder_has_builds: false,
+            contains_acceleration_structure_commands: false,
+            acceleration_structure_builder_has_commands: false,
+            acceleration_structure_fence_updated: false,
             render: None,
             compute: None,
             raw_primitive_type: MTLPrimitiveType::Point,
@@ -162,7 +162,9 @@ impl super::CommandEncoder {
 
     fn enter_blit(&mut self) -> Retained<ProtocolObject<dyn MTLBlitCommandEncoder>> {
         if self.state.blit.is_none() {
-            self.leave_acceleration_structure_builder();
+            // A preceding acceleration structure encoder must publish its
+            // commands before they are followed by anything else.
+            self.end_acceleration_structure_builder(true);
             debug_assert!(self.state.render.is_none() && self.state.compute.is_none());
             let cmd_buf = self.raw_cmd_buf.as_ref().unwrap();
 
@@ -261,6 +263,19 @@ impl super::CommandEncoder {
         }
     }
 
+    /// The fence ordering this command buffer's acceleration structure
+    /// encoders against each other, created on first use.
+    ///
+    /// `newFence` is only reached from acceleration structure command paths,
+    /// which only exist on hardware and OS versions where `MTLFence` is
+    /// available (macOS 10.14 / iOS 12; acceleration structures require
+    /// newer). A nil fence is a device-level allocation failure.
+    fn acceleration_structure_fence(&mut self) -> Retained<ProtocolObject<dyn MTLFence>> {
+        self.acceleration_structure_fence
+            .get_or_insert_with(|| self.shared.device.newFence().unwrap())
+            .clone()
+    }
+
     fn enter_acceleration_structure_builder(
         &mut self,
     ) -> Retained<ProtocolObject<dyn MTLAccelerationStructureCommandEncoder>> {
@@ -276,43 +291,62 @@ impl super::CommandEncoder {
                 self.state.acceleration_structure_builder =
                     cmd_buf.accelerationStructureCommandEncoder().to_owned();
             });
-            if self.state.pending_acceleration_structure_fence_wait {
-                self.state.pending_acceleration_structure_fence_wait = false;
+            self.state.contains_acceleration_structure_commands = true;
+            if self.state.acceleration_structure_fence_updated {
+                self.state.acceleration_structure_fence_updated = false;
+                let fence = self.acceleration_structure_fence();
                 self.state
                     .acceleration_structure_builder
                     .as_ref()
                     .unwrap()
-                    .waitForFence(self.state.acceleration_structure_fence.as_ref().unwrap());
+                    .waitForFence(&fence);
             }
         }
         self.state.acceleration_structure_builder.clone().unwrap()
     }
 
-    pub(super) fn leave_acceleration_structure_builder(&mut self) {
+    /// Ends the current acceleration structure encoder, if any.
+    ///
+    /// With `publish`, the encoder first updates
+    /// [`Self::acceleration_structure_fence`], which the next acceleration
+    /// structure encoder in this command buffer waits on (see
+    /// [`Self::enter_acceleration_structure_builder`]): Metal does not order
+    /// acceleration structure commands against each other, even on the same
+    /// encoder. Ordering against acceleration structure commands in other
+    /// command buffers is not handled here; `Queue::submit` links those with
+    /// a queue-wide event at submit time, in commit order.
+    ///
+    /// `end_encoding` and `discard_encoding` are the callers with
+    /// `publish = false`: `end_encoding` because the command buffer ends
+    /// there, so ordering against later command buffers is `Queue::submit`'s
+    /// job, and `discard_encoding` because the command buffer it belongs to
+    /// is never committed, so its commands never execute and no later
+    /// encoder may wait on them.
+    fn end_acceleration_structure_builder(&mut self, publish: bool) {
         if let Some(encoder) = self.state.acceleration_structure_builder.take() {
+            if publish {
+                let fence = self.acceleration_structure_fence();
+                encoder.updateFence(&fence);
+                self.state.acceleration_structure_fence_updated = true;
+            }
             encoder.endEncoding();
-            self.state.acceleration_structure_builder_has_builds = false;
+            self.state.acceleration_structure_builder_has_commands = false;
         }
     }
 
-    /// Ends the current acceleration structure encoder, if any, after
-    /// updating [`super::CommandState::acceleration_structure_fence`], which
-    /// the next acceleration structure encoder then waits on (see
-    /// [`Self::enter_acceleration_structure_builder`]). Metal does not order
-    /// acceleration structure commands encoded on the same encoder, and
-    /// fences are only defined across encoder boundaries, so this is how
-    /// commands later in the command buffer are ordered after prior builds.
-    fn split_acceleration_structure_builder(&mut self) {
-        if let Some(encoder) = self.state.acceleration_structure_builder.take() {
-            let fence = self
-                .state
-                .acceleration_structure_fence
-                .get_or_insert_with(|| self.shared.device.newFence().unwrap());
-            encoder.updateFence(fence);
-            encoder.endEncoding();
-            self.state.pending_acceleration_structure_fence_wait = true;
-            self.state.acceleration_structure_builder_has_builds = false;
-        }
+    /// Clears the acceleration structure state scoped to the command buffer
+    /// being recorded, and drops its fence.
+    ///
+    /// wgpu-core pools command encoders and hands them to later command
+    /// buffers, so a recording must leave none of it behind: a stale
+    /// `waitForFence` would wait on an update that lives in a command buffer
+    /// that is never committed, and a stale
+    /// `contains_acceleration_structure_commands` would put an unrelated
+    /// command buffer into the acceleration structure event chain
+    /// `Queue::submit` builds.
+    fn reset_acceleration_structure_state(&mut self) {
+        self.state.reset_acceleration_structure_state();
+        self.acceleration_structure_fence = None;
     }
 
     fn active_encoder(&mut self) -> Option<&ProtocolObject<dyn MTLCommandEncoder>> {
@@ -332,7 +366,9 @@ impl super::CommandEncoder {
     fn begin_pass(&mut self) {
         self.state.reset();
         self.leave_blit();
-        self.leave_acceleration_structure_builder();
+        // A preceding acceleration structure encoder must publish its
+        // commands before they are followed by anything else.
+        self.end_acceleration_structure_builder(true);
     }
 
     /// Updates the bindings for a single shader stage, called in `set_bind_group`.
@@ -439,6 +475,16 @@ impl super::CommandEncoder {
 }
 
 impl super::CommandState {
+    /// Clears the acceleration structure state scoped to the command buffer
+    /// being recorded. Called when a recording ends, so that a pooled
+    /// encoder never carries it into the next command buffer. See
+    /// `CommandEncoder::reset_acceleration_structure_state`.
+    fn reset_acceleration_structure_state(&mut self) {
+        self.contains_acceleration_structure_commands = false;
+        self.acceleration_structure_builder_has_commands = false;
+        self.acceleration_structure_fence_updated = false;
+    }
+
     fn reset(&mut self) {
         self.storage_buffer_length_map.clear();
         self.vertex_buffer_size_map.clear();
@@ -529,8 +575,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn discard_encoding(&mut self) {
         self.leave_blit();
-        self.leave_acceleration_structure_builder();
-        self.state.pending_acceleration_structure_fence_wait = false;
+        // The command buffer is never committed, so its acceleration structure
+        // commands never execute; ending the encoder without publishing keeps
+        // any later encoder from waiting on them.
+        self.end_acceleration_structure_builder(false);
+        // The encoder returns to wgpu-core's pool; it must not carry this
+        // command buffer's state into the next recording.
+        self.reset_acceleration_structure_state();
         // when discarding, we don't have a guarantee that
         // everything is in a good state, so check carefully
         if let Some(encoder) = self.state.render.take() {
@@ -558,15 +609,25 @@ impl crate::CommandEncoder for super::CommandEncoder {
         }
 
         self.leave_blit();
-        self.leave_acceleration_structure_builder();
-        self.state.pending_acceleration_structure_fence_wait = false;
+        // The command buffer ends here; there is no later encoder in it that
+        // the open acceleration structure encoder could be ordered against.
+        // Ordering against other command buffers happens in `Queue::submit`,
+        // based on `contains_acceleration_structure_commands`.
+        self.end_acceleration_structure_builder(false);
         debug_assert!(self.state.render.is_none());
         debug_assert!(self.state.compute.is_none());
         debug_assert!(self.state.pending_timer_queries.is_empty());
 
+        let contains_acceleration_structure_commands =
+            self.state.contains_acceleration_structure_commands;
+        // The encoder returns to wgpu-core's pool; it must not carry this
+        // command buffer's state into the next recording.
+        self.reset_acceleration_structure_state();
+
         Ok(super::CommandBuffer {
             raw: self.raw_cmd_buf.take().unwrap(),
             queue_shared: Arc::clone(&self.queue_shared),
+            contains_acceleration_structure_commands,
         })
     }
 
@@ -748,6 +809,9 @@ impl crate::CommandEncoder for super::CommandEncoder {
         copy: wgt::AccelerationStructureCopy,
     ) {
         let command_encoder = self.enter_acceleration_structure_builder();
+        // A copy writes an acceleration structure, so a later compact-size
+        // read must not share the encoder with it.
+        self.state.acceleration_structure_builder_has_commands = true;
         match copy {
             wgt::AccelerationStructureCopy::Clone => unsafe {
                 command_encoder
@@ -1850,7 +1914,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         >,
     {
         let command_encoder = self.enter_acceleration_structure_builder();
-        self.state.acceleration_structure_builder_has_builds = true;
+        self.state.acceleration_structure_builder_has_commands = true;
         for descriptor in descriptors {
             let acceleration_structure_descriptor =
                 conv::map_acceleration_structure_descriptor(descriptor.entries, descriptor.flags);
@@ -1883,12 +1947,16 @@ impl crate::CommandEncoder for super::CommandEncoder {
     ) {
         // wgpu-core emits an acceleration structure barrier at every point
         // where ordering between acceleration structure commands is required,
-        // so rather than interpret the usage flags, split any open encoder
-        // unconditionally. An encoder is only open here if it encoded prior
-        // acceleration structure commands, so this never splits needlessly,
-        // and not relying on the flags keeps this correct if wgpu-core's
-        // barrier emission changes.
-        self.split_acceleration_structure_builder();
+        // so rather than interpret the usage flags, close the open encoder
+        // with a fence update unconditionally; the next acceleration structure
+        // encoder in this command buffer waits on it. Shader passes do not
+        // wait on the fence: a pass that binds an acceleration structure is
+        // ordered by Metal against the acceleration structure commands that
+        // precede it in the command buffer, while a build that reaches other
+        // acceleration structures through descriptor addresses (as a TLAS
+        // build reaches its instances' BLASes) is untracked by Metal either
+        // way. Ordering across command buffers is `Queue::submit`'s job.
+        self.end_acceleration_structure_builder(true);
     }
 
     unsafe fn read_acceleration_structure_compact_size(
@@ -1896,12 +1964,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
         acceleration_structure: &super::AccelerationStructure,
         buffer: &super::Buffer,
     ) {
-        // wgpu-core encodes this with no barrier after the build of the
-        // acceleration structure being queried, so if the current encoder
-        // contains builds, split it; otherwise the size could be read from a
-        // still-building acceleration structure.
-        if self.state.acceleration_structure_builder_has_builds {
-            self.split_acceleration_structure_builder();
+        // wgpu-core encodes this with no barrier after the build or copy of
+        // the acceleration structure being queried, so if the current encoder
+        // holds acceleration structure commands, close it first; otherwise the
+        // size could be read from a structure whose commands have not
+        // completed.
+        if self.state.acceleration_structure_builder_has_commands {
+            self.end_acceleration_structure_builder(true);
         }
         let command_encoder = self.enter_acceleration_structure_builder();
         command_encoder.writeCompactedAccelerationStructureSize_toBuffer_offset(
@@ -1968,5 +2037,30 @@ impl Drop for super::CommandBuffer {
                 .fetch_sub(1, atomic::Ordering::AcqRel);
             debug_assert!(previous > 0);
         }
+        // An unsubmitted command buffer needs no synchronization cleanup: its
+        // fence updates stay unconsumed because waits are only encoded for
+        // command buffers of the same buffer, and `Queue::submit` never
+        // assigned it an event value, so no other command buffer waits on it.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CommandState;
+
+    #[test]
+    fn reset_acceleration_structure_state_clears_per_command_buffer_flags() {
+        let mut state = CommandState {
+            contains_acceleration_structure_commands: true,
+            acceleration_structure_builder_has_commands: true,
+            acceleration_structure_fence_updated: true,
+            ..CommandState::default()
+        };
+
+        state.reset_acceleration_structure_state();
+
+        assert!(!state.contains_acceleration_structure_commands);
+        assert!(!state.acceleration_structure_builder_has_commands);
+        assert!(!state.acceleration_structure_fence_updated);
     }
 }

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -5,16 +5,17 @@ use objc2::{
 use objc2_foundation::{NSRange, NSString, NSUInteger};
 use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLBlitCommandEncoder,
-    MTLBlitPassDescriptor, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder,
-    MTLCommandQueue, MTLComputeCommandEncoder, MTLComputePassDescriptor, MTLCounterDontSample,
-    MTLDevice, MTLFence, MTLLoadAction, MTLPrimitiveType, MTLRenderCommandEncoder,
-    MTLRenderPassDescriptor, MTLResidencySet, MTLResidencySetDescriptor, MTLSamplerState,
+    MTLBlitPassDescriptor, MTLBuffer, MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue,
+    MTLComputeCommandEncoder, MTLComputePassDescriptor, MTLCounterDontSample, MTLDevice, MTLFence,
+    MTLLoadAction, MTLPrimitiveType, MTLRenderCommandEncoder, MTLRenderPassDescriptor,
+    MTLRenderStages, MTLResidencySet, MTLResidencySetDescriptor, MTLResourceUsage, MTLSamplerState,
     MTLScissorRect, MTLSize, MTLStoreAction, MTLTexture, MTLVertexAmplificationViewMapping,
     MTLViewport, MTLVisibilityResultMode,
 };
 
 use super::{
     adapter::{self, VERTEX_BUFFER_SLOT_START},
+    command_buffer_slot::CommandBufferSlot,
     conv, TimestampQuerySupport,
 };
 use crate::CommandEncoder as _;
@@ -23,7 +24,7 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use core::{ops::Range, ptr::NonNull, sync::atomic};
+use core::{ops::Range, ptr::NonNull};
 use smallvec::SmallVec;
 
 // has to match `Temp::binding_sizes`
@@ -36,7 +37,7 @@ impl Default for super::CommandState {
             acceleration_structure_builder: None,
             contains_acceleration_structure_commands: false,
             acceleration_structure_builder_has_commands: false,
-            acceleration_structure_fence_updated: false,
+            acceleration_structure_pass: false,
             render: None,
             compute: None,
             raw_primitive_type: MTLPrimitiveType::Point,
@@ -263,17 +264,35 @@ impl super::CommandEncoder {
         }
     }
 
-    /// The fence ordering this command buffer's acceleration structure
-    /// encoders against each other, created on first use.
-    ///
-    /// `newFence` is only reached from acceleration structure command paths,
-    /// which only exist on hardware and OS versions where `MTLFence` is
-    /// available (macOS 10.14 / iOS 12; acceleration structures require
-    /// newer). A nil fence is a device-level allocation failure.
-    fn acceleration_structure_fence(&mut self) -> Retained<ProtocolObject<dyn MTLFence>> {
-        self.acceleration_structure_fence
-            .get_or_insert_with(|| self.shared.device.newFence().unwrap())
-            .clone()
+    fn acceleration_structure_fence(&self) -> Retained<ProtocolObject<dyn MTLFence>> {
+        self.queue_shared.acceleration_structure_fence()
+    }
+
+    /// Make `encoder` wait on the acceleration structure build fence, once per
+    /// pass, so resources built by earlier command buffers are complete before
+    /// they are consumed.
+    fn wait_for_acceleration_structure_build(&mut self, encoder: &Encoder<'_>) {
+        if !self.state.acceleration_structure_pass {
+            let fence = self.acceleration_structure_fence();
+            match encoder {
+                Encoder::Vertex(enc) | Encoder::Fragment(enc) => {
+                    enc.waitForFence_beforeStages(
+                        &fence,
+                        MTLRenderStages::Vertex | MTLRenderStages::Fragment,
+                    );
+                }
+                Encoder::Compute(enc) => enc.waitForFence(&fence),
+                Encoder::Task(_) | Encoder::Mesh(_) => unreachable!(),
+            }
+            #[cfg(test)]
+            match encoder {
+                Encoder::Vertex(enc) | Encoder::Fragment(enc) => self.trace(*enc, "render-wait"),
+                Encoder::Compute(enc) => self.trace(*enc, "compute-wait"),
+                _ => unreachable!(),
+            }
+            self.state.acceleration_structure_pass = true;
+            self.state.contains_acceleration_structure_commands = true;
+        }
     }
 
     fn enter_acceleration_structure_builder(
@@ -292,61 +311,37 @@ impl super::CommandEncoder {
                     cmd_buf.accelerationStructureCommandEncoder().to_owned();
             });
             self.state.contains_acceleration_structure_commands = true;
-            if self.state.acceleration_structure_fence_updated {
-                self.state.acceleration_structure_fence_updated = false;
-                let fence = self.acceleration_structure_fence();
-                self.state
-                    .acceleration_structure_builder
-                    .as_ref()
-                    .unwrap()
-                    .waitForFence(&fence);
-            }
+            let fence = self.acceleration_structure_fence();
+            self.state
+                .acceleration_structure_builder
+                .as_ref()
+                .unwrap()
+                .waitForFence(&fence);
+            #[cfg(test)]
+            self.trace(
+                self.state.acceleration_structure_builder.as_ref().unwrap(),
+                "as-wait",
+            );
         }
         self.state.acceleration_structure_builder.clone().unwrap()
     }
 
-    /// Ends the current acceleration structure encoder, if any.
-    ///
-    /// With `publish`, the encoder first updates
-    /// [`Self::acceleration_structure_fence`], which the next acceleration
-    /// structure encoder in this command buffer waits on (see
-    /// [`Self::enter_acceleration_structure_builder`]): Metal does not order
-    /// acceleration structure commands against each other, even on the same
-    /// encoder. Ordering against acceleration structure commands in other
-    /// command buffers is not handled here; `Queue::submit` links those with
-    /// a queue-wide event at submit time, in commit order.
-    ///
-    /// `end_encoding` and `discard_encoding` are the callers with
-    /// `publish = false`: `end_encoding` because the command buffer ends
-    /// there, so ordering against later command buffers is `Queue::submit`'s
-    /// job, and `discard_encoding` because the command buffer it belongs to
-    /// is never committed, so its commands never execute and no later
-    /// encoder may wait on them.
     fn end_acceleration_structure_builder(&mut self, publish: bool) {
         if let Some(encoder) = self.state.acceleration_structure_builder.take() {
             if publish {
-                let fence = self.acceleration_structure_fence();
-                encoder.updateFence(&fence);
-                self.state.acceleration_structure_fence_updated = true;
+                encoder.updateFence(&self.acceleration_structure_fence());
+                #[cfg(test)]
+                self.trace(&encoder, "as-update");
             }
             encoder.endEncoding();
+            #[cfg(test)]
+            self.trace(&encoder, "as-end");
             self.state.acceleration_structure_builder_has_commands = false;
         }
     }
 
-    /// Clears the acceleration structure state scoped to the command buffer
-    /// being recorded, and drops its fence.
-    ///
-    /// wgpu-core pools command encoders and hands them to later command
-    /// buffers, so a recording must leave none of it behind: a stale
-    /// `waitForFence` would wait on an update that lives in a command buffer
-    /// that is never committed, and a stale
-    /// `contains_acceleration_structure_commands` would put an unrelated
-    /// command buffer into the acceleration structure event chain
-    /// `Queue::submit` builds.
     fn reset_acceleration_structure_state(&mut self) {
         self.state.reset_acceleration_structure_state();
-        self.acceleration_structure_fence = None;
     }
 
     fn active_encoder(&mut self) -> Option<&ProtocolObject<dyn MTLCommandEncoder>> {
@@ -409,6 +404,9 @@ impl super::CommandEncoder {
                     binding_size,
                     binding_location,
                 } => {
+                    if group.uses_acceleration_structures {
+                        self.wait_for_acceleration_structure_build(&encoder);
+                    }
                     let buffer = Some(unsafe { ptr.as_ref() });
                     if let Some(dyn_index) = dynamic_index {
                         offset += dynamic_offsets[*dyn_index as usize] as wgt::BufferAddress;
@@ -427,6 +425,7 @@ impl super::CommandEncoder {
                 super::BufferLikeResource::AccelerationStructure(ptr) => {
                     let buffer = Some(unsafe { ptr.as_ref() });
                     let index = (resource_indices.buffers + index) as usize;
+                    self.wait_for_acceleration_structure_build(&encoder);
                     encoder.set_acceleration_structure(buffer, index);
                 }
             }
@@ -482,7 +481,7 @@ impl super::CommandState {
     fn reset_acceleration_structure_state(&mut self) {
         self.contains_acceleration_structure_commands = false;
         self.acceleration_structure_builder_has_commands = false;
-        self.acceleration_structure_fence_updated = false;
+        self.acceleration_structure_pass = false;
     }
 
     fn reset(&mut self) {
@@ -536,24 +535,21 @@ impl crate::CommandEncoder for super::CommandEncoder {
         let queue = &self.queue_shared.raw;
         let retain_references = self.shared.settings.retain_command_buffer_references;
 
-        // Guard against exhausting Metal's command buffer budget. Use the hard
-        // limit (`MAX_COMMAND_BUFFERS`) so we fail before Metal can hang inside
-        // `new_command_buffer`.
-        let previous = self
-            .queue_shared
-            .command_buffer_created_not_submitted
-            .fetch_add(1, atomic::Ordering::AcqRel);
-        if previous >= adapter::MAX_COMMAND_BUFFERS {
-            let current = previous + 1;
+        // Leave one native slot for serialized internal allocate-and-commit work.
+        let slot = CommandBufferSlot::reserve(
+            &self.queue_shared.command_buffer_created_not_submitted,
+            adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS,
+        )
+        .map_err(|current| {
             log::warn!(
                 "metal: refusing to create new command buffer; {current} outstanding command \
-                 buffers exceeds the limit of {}. Treating this as device lost. \
+                 buffers reaches the limit of {}. Treating this as device lost. \
                  Ensure command encoders are submitted or dropped rather than kept alive \
                  to avoid exhausting Metal's command buffer budget.",
-                adapter::MAX_COMMAND_BUFFERS
+                adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS
             );
-            return Err(crate::DeviceError::Lost);
-        }
+            crate::DeviceError::Lost
+        })?;
 
         let raw = autoreleasepool(move |_| {
             let cmd_buf_ref = if retain_references {
@@ -569,15 +565,14 @@ impl crate::CommandEncoder for super::CommandEncoder {
         });
 
         self.raw_cmd_buf = Some(raw);
+        self.command_buffer_slot = Some(slot);
 
         Ok(())
     }
 
     unsafe fn discard_encoding(&mut self) {
         self.leave_blit();
-        // The command buffer is never committed, so its acceleration structure
-        // commands never execute; ending the encoder without publishing keeps
-        // any later encoder from waiting on them.
+        // Discarded commands never enter the commit-evaluated fence timeline.
         self.end_acceleration_structure_builder(false);
         // The encoder returns to wgpu-core's pool; it must not carry this
         // command buffer's state into the next recording.
@@ -590,15 +585,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
         if let Some(encoder) = self.state.compute.take() {
             encoder.endEncoding();
         }
-        let had_command_buffer = self.raw_cmd_buf.is_some();
         // Clear the Option first so the underlying `metal::CommandBuffer` is
         // dropped before we update the counter.
         self.raw_cmd_buf = None;
-        if had_command_buffer {
-            self.queue_shared
-                .command_buffer_created_not_submitted
-                .fetch_sub(1, atomic::Ordering::AcqRel);
-        }
+        self.command_buffer_slot = None;
     }
 
     unsafe fn end_encoding(&mut self) -> Result<super::CommandBuffer, crate::DeviceError> {
@@ -609,11 +599,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         }
 
         self.leave_blit();
-        // The command buffer ends here; there is no later encoder in it that
-        // the open acceleration structure encoder could be ordered against.
-        // Ordering against other command buffers happens in `Queue::submit`,
-        // based on `contains_acceleration_structure_commands`.
-        self.end_acceleration_structure_builder(false);
+        self.end_acceleration_structure_builder(true);
         debug_assert!(self.state.render.is_none());
         debug_assert!(self.state.compute.is_none());
         debug_assert!(self.state.pending_timer_queries.is_empty());
@@ -626,7 +612,8 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
         Ok(super::CommandBuffer {
             raw: self.raw_cmd_buf.take().unwrap(),
-            queue_shared: Arc::clone(&self.queue_shared),
+            slot: self.command_buffer_slot.take().unwrap(),
+            _queue_shared: Arc::clone(&self.queue_shared),
             contains_acceleration_structure_commands,
         })
     }
@@ -1148,7 +1135,16 @@ impl crate::CommandEncoder for super::CommandEncoder {
     }
 
     unsafe fn end_render_pass(&mut self) {
-        self.state.render.take().unwrap().endEncoding();
+        let encoder = self.state.render.take().unwrap();
+        if core::mem::take(&mut self.state.acceleration_structure_pass) {
+            encoder.updateFence_afterStages(
+                &self.acceleration_structure_fence(),
+                MTLRenderStages::Vertex | MTLRenderStages::Fragment,
+            );
+            #[cfg(test)]
+            self.trace(&encoder, "render-update");
+        }
+        encoder.endEncoding();
     }
 
     unsafe fn set_bind_group(
@@ -1822,7 +1818,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
         });
     }
     unsafe fn end_compute_pass(&mut self) {
-        self.state.compute.take().unwrap().endEncoding();
+        let encoder = self.state.compute.take().unwrap();
+        if core::mem::take(&mut self.state.acceleration_structure_pass) {
+            encoder.updateFence(&self.acceleration_structure_fence());
+            #[cfg(test)]
+            self.trace(&encoder, "compute-update");
+        }
+        encoder.endEncoding();
     }
 
     unsafe fn set_compute_pipeline(&mut self, pipeline: &super::ComputePipeline) {
@@ -1916,8 +1918,43 @@ impl crate::CommandEncoder for super::CommandEncoder {
         let command_encoder = self.enter_acceleration_structure_builder();
         self.state.acceleration_structure_builder_has_commands = true;
         for descriptor in descriptors {
+            // Descriptor resources need explicit tracked access declarations for
+            // earlier staging/copy/compute writes and subsequent input overwrites.
+            let read = |buffer: &super::Buffer| {
+                command_encoder.useResource_usage(
+                    ProtocolObject::from_ref(&*buffer.raw),
+                    MTLResourceUsage::Read,
+                );
+            };
+            match descriptor.entries {
+                crate::AccelerationStructureEntries::Instances(instances) => {
+                    read(instances.buffer.unwrap())
+                }
+                crate::AccelerationStructureEntries::Triangles(triangles) => {
+                    for triangle in triangles.iter() {
+                        read(triangle.vertex_buffer.unwrap());
+                        if let Some(indices) = &triangle.indices {
+                            read(indices.buffer.unwrap());
+                        }
+                        if let Some(transform) = &triangle.transform {
+                            read(transform.buffer);
+                        }
+                    }
+                }
+                crate::AccelerationStructureEntries::AABBs(aabbs) => {
+                    for aabb in aabbs.iter() {
+                        read(aabb.buffer.unwrap());
+                    }
+                }
+            }
+            command_encoder.useResource_usage(
+                ProtocolObject::from_ref(&*descriptor.scratch_buffer.raw),
+                MTLResourceUsage::Read | MTLResourceUsage::Write,
+            );
             let acceleration_structure_descriptor =
                 conv::map_acceleration_structure_descriptor(descriptor.entries, descriptor.flags);
+            #[cfg(test)]
+            self.trace(&command_encoder, "build");
             match descriptor.mode {
                 crate::AccelerationStructureBuildMode::Build => {
                     command_encoder
@@ -1945,17 +1982,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         &mut self,
         _barrier: crate::AccelerationStructureBarrier,
     ) {
-        // wgpu-core emits an acceleration structure barrier at every point
-        // where ordering between acceleration structure commands is required,
-        // so rather than interpret the usage flags, close the open encoder
-        // with a fence update unconditionally; the next acceleration structure
-        // encoder in this command buffer waits on it. Shader passes do not
-        // wait on the fence: a pass that binds an acceleration structure is
-        // ordered by Metal against the acceleration structure commands that
-        // precede it in the command buffer, while a build that reaches other
-        // acceleration structures through descriptor addresses (as a TLAS
-        // build reaches its instances' BLASes) is untracked by Metal either
-        // way. Ordering across command buffers is `Queue::submit`'s job.
+        // Dependent builds cannot share an AS encoder, even with tracked storage.
         self.end_acceleration_structure_builder(true);
     }
 
@@ -1973,6 +2000,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
             self.end_acceleration_structure_builder(true);
         }
         let command_encoder = self.enter_acceleration_structure_builder();
+        self.state.acceleration_structure_builder_has_commands = true;
+        command_encoder.useResource_usage(
+            ProtocolObject::from_ref(&*buffer.raw),
+            MTLResourceUsage::Write,
+        );
+        #[cfg(test)]
+        self.trace(&command_encoder, "compact-size");
         command_encoder.writeCompactedAccelerationStructureSize_toBuffer_offset(
             &acceleration_structure.raw,
             &buffer.raw,
@@ -2022,45 +2056,5 @@ impl Drop for super::CommandEncoder {
     }
 }
 
-impl Drop for super::CommandBuffer {
-    fn drop(&mut self) {
-        // `command_buffer_created_not_submitted` is usually decremented when the command
-        // buffer is submitted. But if we're dropping a command buffer that was never
-        // submitted, we need to decrement the count here.
-        let status = self.raw.status();
-        if status == MTLCommandBufferStatus::NotEnqueued
-            || status == MTLCommandBufferStatus::Enqueued
-        {
-            let previous = self
-                .queue_shared
-                .command_buffer_created_not_submitted
-                .fetch_sub(1, atomic::Ordering::AcqRel);
-            debug_assert!(previous > 0);
-        }
-        // An unsubmitted command buffer needs no synchronization cleanup: its
-        // fence updates stay unconsumed because waits are only encoded for
-        // command buffers of the same buffer, and `Queue::submit` never
-        // assigned it an event value, so no other command buffer waits on it.
-    }
-}
-
 #[cfg(test)]
-mod tests {
-    use super::super::CommandState;
-
-    #[test]
-    fn reset_acceleration_structure_state_clears_per_command_buffer_flags() {
-        let mut state = CommandState {
-            contains_acceleration_structure_commands: true,
-            acceleration_structure_builder_has_commands: true,
-            acceleration_structure_fence_updated: true,
-            ..CommandState::default()
-        };
-
-        state.reset_acceleration_structure_state();
-
-        assert!(!state.contains_acceleration_structure_commands);
-        assert!(!state.acceleration_structure_builder_has_commands);
-        assert!(!state.acceleration_structure_fence_updated);
-    }
-}
+pub(super) mod tests;

--- a/wgpu-hal/src/metal/command/tests.rs
+++ b/wgpu-hal/src/metal/command/tests.rs
@@ -555,6 +555,76 @@ fn query_only_compute_and_render_passes_join_once() {
 }
 
 #[test]
+fn descriptor_transform_layout_and_duplicate_invocations() {
+    use objc2_metal::{
+        MTLAccelerationStructureTriangleGeometryDescriptor, MTLMatrixLayout,
+        MTLPrimitiveAccelerationStructureDescriptor,
+    };
+    let Some(crate::OpenDevice { device, .. }) = open() else {
+        return;
+    };
+    let data = buffer(&device, 256);
+    for no_duplicate in [false, true] {
+        let mut flags = wgt::AccelerationStructureGeometryFlags::empty();
+        flags.set(
+            wgt::AccelerationStructureGeometryFlags::NO_DUPLICATE_ANY_HIT_INVOCATION,
+            no_duplicate,
+        );
+        let mut entries = triangles(&data);
+        if let crate::AccelerationStructureEntries::Triangles(triangles) = &mut entries {
+            triangles[0].flags = flags;
+            triangles[0].transform = Some(crate::AccelerationStructureTriangleTransform {
+                buffer: &data,
+                offset: 64,
+            });
+        }
+        let descriptor = conv::map_acceleration_structure_descriptor(
+            &entries,
+            wgt::AccelerationStructureFlags::empty(),
+        )
+        .downcast::<MTLPrimitiveAccelerationStructureDescriptor>()
+        .unwrap();
+        let geometry = descriptor
+            .geometryDescriptors()
+            .unwrap()
+            .objectAtIndex(0)
+            .downcast::<MTLAccelerationStructureTriangleGeometryDescriptor>()
+            .unwrap();
+        assert_eq!(
+            geometry.transformationMatrixLayout(),
+            MTLMatrixLayout::RowMajor
+        );
+        assert_eq!(geometry.transformationMatrixBufferOffset(), 64);
+        assert_eq!(
+            geometry.allowDuplicateIntersectionFunctionInvocation(),
+            !no_duplicate
+        );
+        let entries =
+            crate::AccelerationStructureEntries::AABBs(vec![crate::AccelerationStructureAABBs {
+                buffer: Some(&data),
+                offset: 0,
+                count: 1,
+                stride: 24,
+                flags,
+            }]);
+        let descriptor = conv::map_acceleration_structure_descriptor(
+            &entries,
+            wgt::AccelerationStructureFlags::empty(),
+        )
+        .downcast::<MTLPrimitiveAccelerationStructureDescriptor>()
+        .unwrap();
+        assert_eq!(
+            descriptor
+                .geometryDescriptors()
+                .unwrap()
+                .objectAtIndex(0)
+                .allowDuplicateIntersectionFunctionInvocation(),
+            !no_duplicate
+        );
+    }
+}
+
+#[test]
 fn tlas_recorded_before_blas_and_compact_size_retirement() {
     let Some(crate::OpenDevice { mut device, queue }) = open() else {
         return;

--- a/wgpu-hal/src/metal/command/tests.rs
+++ b/wgpu-hal/src/metal/command/tests.rs
@@ -1,0 +1,773 @@
+//! All tests here access a real Metal GPU, including fence setup, non-ray encoder,
+//! and descriptor cases; this is not a CPU-only suite. The ignored capacity test
+//! retains 4095 native command buffers and requires explicit hardware authorization.
+
+use super::*;
+use crate::metal as m;
+use crate::{Adapter as _, Device as _, Queue as _};
+use alloc::vec;
+use core::{cell::RefCell, sync::atomic};
+use objc2_metal::{MTLCommandBufferStatus, MTLCreateSystemDefaultDevice, MTLResourceOptions};
+
+#[derive(Clone, Debug)]
+struct Event {
+    buffer: usize,
+    encoder: Option<usize>,
+    operation: &'static str,
+}
+
+std::thread_local! {
+    static EVENTS: RefCell<Vec<Event>> = const { RefCell::new(Vec::new()) };
+}
+
+pub(in crate::metal) fn identity<T: ?Sized>(object: &T) -> usize {
+    core::ptr::from_ref(object).cast::<()>() as usize
+}
+
+pub(in crate::metal) fn record(
+    buffer: &ProtocolObject<dyn MTLCommandBuffer>,
+    encoder: Option<usize>,
+    operation: &'static str,
+) {
+    std::eprintln!(
+        "Metal emission buffer={:#x} encoder={encoder:?} {operation}",
+        identity(buffer)
+    );
+    EVENTS.with_borrow_mut(|events| {
+        events.push(Event {
+            buffer: identity(buffer),
+            encoder,
+            operation,
+        })
+    });
+}
+
+impl m::CommandEncoder {
+    pub(super) fn trace<T: ?Sized>(&self, encoder: &ProtocolObject<T>, operation: &'static str) {
+        record(
+            self.raw_cmd_buf.as_ref().unwrap(),
+            Some(identity(encoder)),
+            operation,
+        );
+    }
+}
+
+fn events() -> Vec<Event> {
+    EVENTS.with_borrow(|events| events.clone())
+}
+
+fn open() -> Option<crate::OpenDevice<m::Api>> {
+    let raw = MTLCreateSystemDefaultDevice()?;
+    let exposed = m::AdapterShared::expose(raw);
+    if !exposed
+        .features
+        .contains(wgt::Features::EXPERIMENTAL_RAY_QUERY)
+    {
+        std::eprintln!("SKIP: Metal ray queries unavailable");
+        return None;
+    }
+    Some(unsafe {
+        exposed
+            .adapter
+            .open(
+                wgt::Features::EXPERIMENTAL_RAY_QUERY,
+                &exposed.capabilities.limits,
+                &wgt::MemoryHints::default(),
+            )
+            .unwrap()
+    })
+}
+
+fn encoder(device: &m::Device, queue: &m::Queue) -> m::CommandEncoder {
+    unsafe {
+        device
+            .create_command_encoder(&crate::CommandEncoderDescriptor { label: None, queue })
+            .unwrap()
+    }
+}
+
+fn buffer(device: &m::Device, size: usize) -> m::Buffer {
+    m::Buffer {
+        raw: device
+            .shared
+            .device
+            .newBufferWithLength_options(size, MTLResourceOptions::StorageModeShared)
+            .unwrap(),
+        size: size as u64,
+    }
+}
+
+fn triangles(vertex: &m::Buffer) -> crate::AccelerationStructureEntries<'_, m::Buffer> {
+    crate::AccelerationStructureEntries::Triangles(vec![crate::AccelerationStructureTriangles {
+        vertex_buffer: Some(vertex),
+        vertex_format: wgt::VertexFormat::Float32x3,
+        first_vertex: 0,
+        vertex_count: 3,
+        vertex_stride: 12,
+        indices: None,
+        transform: None,
+        flags: wgt::AccelerationStructureGeometryFlags::OPAQUE,
+    }])
+}
+
+fn storage(
+    device: &m::Device,
+    entries: &crate::AccelerationStructureEntries<'_, m::Buffer>,
+) -> (m::AccelerationStructure, m::Buffer) {
+    let sizes = unsafe {
+        device.get_acceleration_structure_build_sizes(
+            &crate::GetAccelerationStructureBuildSizesDescriptor {
+                entries,
+                flags: wgt::AccelerationStructureFlags::empty(),
+            },
+        )
+    };
+    let structure = unsafe {
+        device
+            .create_acceleration_structure(&crate::AccelerationStructureDescriptor {
+                label: None,
+                size: sizes.acceleration_structure_size,
+                format: match entries {
+                    crate::AccelerationStructureEntries::Instances(_) => {
+                        crate::AccelerationStructureFormat::TopLevel
+                    }
+                    _ => crate::AccelerationStructureFormat::BottomLevel,
+                },
+                allow_compaction: true,
+            })
+            .unwrap()
+    };
+    (structure, buffer(device, sizes.build_scratch_size as usize))
+}
+
+unsafe fn build(
+    encoder: &mut m::CommandEncoder,
+    entries: &crate::AccelerationStructureEntries<'_, m::Buffer>,
+    structure: &m::AccelerationStructure,
+    scratch: &m::Buffer,
+) {
+    unsafe {
+        encoder.build_acceleration_structures(
+            1,
+            [crate::BuildAccelerationStructureDescriptor {
+                entries,
+                mode: crate::AccelerationStructureBuildMode::Build,
+                flags: wgt::AccelerationStructureFlags::empty(),
+                source_acceleration_structure: None,
+                destination_acceleration_structure: structure,
+                scratch_buffer: scratch,
+                scratch_buffer_offset: 0,
+            }],
+        );
+    }
+}
+
+fn assert_recording(id: usize, expected: &[&str]) {
+    let recording: Vec<_> = events()
+        .into_iter()
+        .filter(|event| event.buffer == id)
+        .collect();
+    assert_eq!(
+        recording
+            .iter()
+            .map(|event| event.operation)
+            .collect::<Vec<_>>(),
+        expected
+    );
+    for group in recording.chunks(4) {
+        if group.len() == 4 && group[0].operation == "as-wait" {
+            assert!(group.iter().all(|event| event.encoder == group[0].encoder));
+        }
+    }
+}
+
+#[test]
+fn fence_setup_failure_is_fallible() {
+    let mut sync = m::AccelerationStructureSync::default();
+    assert!(matches!(
+        sync.initialize_fence(|| None),
+        Err(crate::DeviceError::OutOfMemory)
+    ));
+    assert!(sync.fence.is_none());
+    assert!(!sync.seeded);
+    let Some(opened) = open() else { return };
+    let fence = opened.device.shared.device.newFence().unwrap();
+    sync.initialize_fence(|| Some(fence.clone())).unwrap();
+    sync.initialize_fence(|| panic!("initialized fence must be reused"))
+        .unwrap();
+    assert_eq!(identity(&**sync.fence.as_ref().unwrap()), identity(&*fence));
+}
+
+#[test]
+fn non_ray_encoder_does_not_allocate_as_fence() {
+    let Some(raw) = MTLCreateSystemDefaultDevice() else {
+        return;
+    };
+    let exposed = m::AdapterShared::expose(raw);
+    let opened = unsafe {
+        exposed
+            .adapter
+            .open(
+                wgt::Features::empty(),
+                &exposed.capabilities.limits,
+                &wgt::MemoryHints::default(),
+            )
+            .unwrap()
+    };
+    let enc = encoder(&opened.device, &opened.queue);
+    assert!(opened
+        .queue
+        .shared
+        .acceleration_structure_sync
+        .lock()
+        .fence
+        .is_none());
+    drop(enc);
+}
+
+#[test]
+#[ignore = "opt-in native queue-capacity stress; may make the machine/display unresponsive"]
+fn first_as_at_native_recording_capacity() {
+    const CHILD: &str = "WGPU_METAL_CAPACITY_TEST_CHILD";
+    const CHILD_COMPLETED: i32 = 42;
+    if std::env::var_os(CHILD).is_none() {
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--ignored",
+                "--exact",
+                "metal::command::tests::first_as_at_native_recording_capacity",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .spawn()
+            .unwrap();
+        // This userspace deadline cannot protect against GPU/driver hangs or display freezes.
+        let deadline = std::time::Instant::now() + core::time::Duration::from_secs(60);
+        loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                // A zero-test libtest invocation exits 0, not CHILD_COMPLETED.
+                assert_eq!(
+                    status.code(),
+                    Some(CHILD_COMPLETED),
+                    "capacity subprocess did not complete the native test: {status}"
+                );
+                return;
+            }
+            if std::time::Instant::now() >= deadline {
+                child.kill().unwrap();
+                child.wait().unwrap();
+                panic!("native capacity subprocess failed to make bounded progress");
+            }
+            std::thread::sleep(core::time::Duration::from_millis(20));
+        }
+    }
+    assert_eq!(std::env::var(CHILD).as_deref(), Ok("1"));
+    run_native_recording_capacity();
+    // Signal completion only after the native checks and resource drops have finished.
+    std::process::exit(CHILD_COMPLETED);
+}
+
+fn run_native_recording_capacity() {
+    let crate::OpenDevice { device, queue } =
+        open().expect("opt-in native capacity test requires a Metal ray-query device");
+    let vertex = buffer(&device, 36);
+    let vertices = [-1.0f32, -1.0, 1.0, 1.0, -1.0, 1.0, 0.0, 1.0, 1.0];
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            vertices.as_ptr().cast::<u8>(),
+            vertex.raw.contents().as_ptr().cast(),
+            36,
+        );
+    }
+    let entries = triangles(&vertex);
+    let (blas, scratch) = storage(&device, &entries);
+    let mut enc = encoder(&device, &queue);
+    unsafe {
+        enc.begin_encoding(None).unwrap();
+        build(&mut enc, &entries, &blas, &scratch);
+        let participant = enc.end_encoding().unwrap();
+        let mut held = Vec::new();
+        for _ in 1..adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS {
+            enc.begin_encoding(None).unwrap();
+            held.push(enc.end_encoding().unwrap());
+        }
+        assert!(matches!(
+            enc.begin_encoding(None),
+            Err(crate::DeviceError::Lost)
+        ));
+        assert_eq!(
+            queue
+                .shared
+                .command_buffer_created_not_submitted
+                .load(atomic::Ordering::Acquire),
+            adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS
+        );
+        let fence = device.create_fence().unwrap();
+        // Internal empty-submit and idle joins must also progress with held recordings.
+        queue.submit(&[], &[], (&fence, 1)).unwrap();
+        queue.wait_for_idle().unwrap();
+        assert!(!queue.shared.acceleration_structure_sync.lock().seeded);
+        queue.submit(&[&participant], &[], (&fence, 2)).unwrap();
+        assert!(device
+            .wait(&fence, 2, Some(core::time::Duration::from_secs(30)))
+            .unwrap());
+        let emitted = events();
+        let seed = emitted
+            .iter()
+            .position(|e| e.operation == "seed-commit")
+            .unwrap();
+        let commit = emitted
+            .iter()
+            .position(|e| e.operation == "commit" && e.buffer == identity(&*participant.raw))
+            .unwrap();
+        assert!(seed < commit);
+        assert!(emitted.iter().any(|e| e.operation == "retire-wait"));
+        enc.reset_all(held.into_iter().chain([participant]));
+        assert_eq!(
+            queue
+                .shared
+                .command_buffer_created_not_submitted
+                .load(atomic::Ordering::Acquire),
+            0
+        );
+        drop(enc);
+        device.destroy_fence(fence);
+        device.destroy_acceleration_structure(blas);
+    }
+}
+
+#[test]
+fn encoder_finish_discard_reuse_and_submit_order() {
+    let Some(crate::OpenDevice { device, queue }) = open() else {
+        return;
+    };
+    let vertex = buffer(&device, 36);
+    let vertices = [-1.0f32, -1.0, 1.0, 1.0, -1.0, 1.0, 0.0, 1.0, 1.0];
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            vertices.as_ptr().cast::<u8>(),
+            vertex.raw.contents().as_ptr().cast(),
+            36,
+        );
+    }
+    let entries = triangles(&vertex);
+    let (blas, scratch) = storage(&device, &entries);
+    let mut enc = encoder(&device, &queue);
+    unsafe {
+        enc.begin_encoding(None).unwrap();
+        build(&mut enc, &entries, &blas, &scratch);
+        enc.enter_blit();
+        let abandoned = enc.end_encoding().unwrap();
+        let abandoned_id = identity(&*abandoned.raw);
+        assert_recording(abandoned_id, &["as-wait", "build", "as-update", "as-end"]);
+        assert!(abandoned.contains_acceleration_structure_commands);
+        assert!(!enc.state.contains_acceleration_structure_commands);
+
+        enc.begin_encoding(None).unwrap();
+        build(&mut enc, &entries, &blas, &scratch);
+        let discarded_raw = enc.raw_cmd_buf.as_ref().unwrap().clone();
+        let discarded_id = identity(&*discarded_raw);
+        enc.discard_encoding();
+        assert_recording(discarded_id, &["as-wait", "build", "as-end"]);
+
+        enc.begin_encoding(None).unwrap();
+        let ordinary = enc.end_encoding().unwrap();
+        assert!(!ordinary.contains_acceleration_structure_commands);
+        assert!(!queue.shared.acceleration_structure_sync.lock().seeded);
+
+        enc.begin_encoding(None).unwrap();
+        build(&mut enc, &entries, &blas, &scratch);
+        let submitted = enc.end_encoding().unwrap();
+        let submitted_id = identity(&*submitted.raw);
+        assert_recording(submitted_id, &["as-wait", "build", "as-update", "as-end"]);
+        let fence = device.create_fence().unwrap();
+        queue
+            .submit(&[&submitted, &ordinary], &[], (&fence, 1))
+            .unwrap();
+        assert!(device
+            .wait(&fence, 1, Some(core::time::Duration::from_secs(30)))
+            .unwrap());
+        assert_eq!(submitted.raw.status(), MTLCommandBufferStatus::Completed);
+        assert!(queue.shared.acceleration_structure_sync.lock().seeded);
+        let commits: Vec<_> = events()
+            .into_iter()
+            .filter(|event| event.operation.ends_with("commit"))
+            .collect();
+        assert_eq!(commits.len(), 3);
+        assert_eq!(commits[0].operation, "seed-commit");
+        assert_eq!(commits[1].buffer, submitted_id);
+        assert_eq!(commits[2].buffer, identity(&*ordinary.raw));
+        assert!(!commits.iter().any(|event| event.buffer == abandoned_id));
+        let retirement: Vec<_> = events()
+            .into_iter()
+            .filter(|event| event.operation == "retire-wait")
+            .collect();
+        assert_eq!(retirement.len(), 1);
+        assert_eq!(retirement[0].buffer, identity(&*ordinary.raw));
+
+        EVENTS.with_borrow_mut(Vec::clear);
+        enc.begin_encoding(None).unwrap();
+        enc.enter_blit();
+        let post = enc.end_encoding().unwrap();
+        queue.submit(&[&post], &[], (&fence, 2)).unwrap();
+        queue.submit(&[], &[], (&fence, 3)).unwrap();
+        assert!(device
+            .wait(&fence, 3, Some(core::time::Duration::from_secs(30)))
+            .unwrap());
+        assert_eq!(
+            events()
+                .iter()
+                .map(|event| event.operation)
+                .collect::<Vec<_>>(),
+            ["commit"]
+        );
+        drop(abandoned);
+        assert_eq!(
+            queue
+                .shared
+                .command_buffer_created_not_submitted
+                .load(atomic::Ordering::Acquire),
+            0
+        );
+        device.destroy_fence(fence);
+    }
+}
+
+#[test]
+fn query_only_compute_and_render_passes_join_once() {
+    let Some(crate::OpenDevice { device, queue }) = open() else {
+        return;
+    };
+    let vertex = buffer(&device, 36);
+    let entries = triangles(&vertex);
+    let (blas, _) = storage(&device, &entries);
+    let mut group = m::BindGroup::default();
+    group
+        .buffers
+        .push(m::BufferLikeResource::AccelerationStructure(NonNull::from(
+            &*blas.raw,
+        )));
+    group.counters.cs.buffers = 1;
+    group.counters.vs.buffers = 1;
+    group.counters.fs.buffers = 1;
+    let info = m::BindGroupLayoutInfo {
+        base_resource_indices: Default::default(),
+    };
+    let mut enc = encoder(&device, &queue);
+    let texture_desc = objc2_metal::MTLTextureDescriptor::new();
+    texture_desc.setPixelFormat(objc2_metal::MTLPixelFormat::RGBA8Unorm);
+    unsafe {
+        texture_desc.setWidth(1);
+        texture_desc.setHeight(1);
+    }
+    texture_desc.setUsage(objc2_metal::MTLTextureUsage::RenderTarget);
+    let target = m::TextureView {
+        raw: device
+            .shared
+            .device
+            .newTextureWithDescriptor(&texture_desc)
+            .unwrap(),
+        aspects: crate::FormatAspects::COLOR,
+    };
+    unsafe {
+        enc.begin_encoding(None).unwrap();
+        enc.begin_compute_pass(&crate::ComputePassDescriptor {
+            label: None,
+            timestamp_writes: None,
+        });
+        let raw = enc.state.compute.as_ref().unwrap().clone();
+        for _ in 0..2 {
+            enc.update_bind_group_state(
+                Encoder::Compute(&raw),
+                Default::default(),
+                &info,
+                &[],
+                0,
+                &group,
+            );
+        }
+        enc.end_compute_pass();
+        let compute = enc.end_encoding().unwrap();
+        assert!(compute.contains_acceleration_structure_commands);
+        assert_recording(identity(&*compute.raw), &["compute-wait", "compute-update"]);
+
+        enc.begin_encoding(None).unwrap();
+        enc.begin_render_pass(&crate::RenderPassDescriptor {
+            label: None,
+            extent: wgt::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            sample_count: 1,
+            color_attachments: &[Some(crate::ColorAttachment {
+                target: crate::Attachment {
+                    view: &target,
+                    usage: wgt::TextureUses::COLOR_TARGET,
+                },
+                depth_slice: None,
+                resolve_target: None,
+                ops: crate::AttachmentOps::STORE | crate::AttachmentOps::LOAD_CLEAR,
+                clear_value: wgt::Color::BLACK,
+            })],
+            depth_stencil_attachment: None,
+            multiview_mask: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        })
+        .unwrap();
+        let raw = enc.state.render.as_ref().unwrap().clone();
+        enc.update_bind_group_state(
+            Encoder::Vertex(&raw),
+            Default::default(),
+            &info,
+            &[],
+            0,
+            &group,
+        );
+        enc.update_bind_group_state(
+            Encoder::Fragment(&raw),
+            Default::default(),
+            &info,
+            &[],
+            0,
+            &group,
+        );
+        enc.end_render_pass();
+        let render = enc.end_encoding().unwrap();
+        assert!(render.contains_acceleration_structure_commands);
+        assert_recording(identity(&*render.raw), &["render-wait", "render-update"]);
+        assert!(!queue.shared.acceleration_structure_sync.lock().seeded);
+        // These bindings deliberately never dispatch or draw against the unbuilt AS.
+        drop((compute, render));
+        enc.begin_encoding(None).unwrap();
+        enc.begin_compute_pass(&crate::ComputePassDescriptor {
+            label: None,
+            timestamp_writes: None,
+        });
+        enc.end_compute_pass();
+        assert!(
+            !enc.end_encoding()
+                .unwrap()
+                .contains_acceleration_structure_commands
+        );
+    }
+}
+
+#[test]
+fn tlas_recorded_before_blas_and_compact_size_retirement() {
+    let Some(crate::OpenDevice { mut device, queue }) = open() else {
+        return;
+    };
+    Arc::get_mut(&mut device.shared)
+        .unwrap()
+        .settings
+        .retain_command_buffer_references = false;
+    let vertex = buffer(&device, 36);
+    let vertices = [-1.0f32, -1.0, 1.0, 1.0, -1.0, 1.0, 0.0, 1.0, 1.0];
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            vertices.as_ptr().cast::<u8>(),
+            vertex.raw.contents().as_ptr().cast(),
+            36,
+        );
+    }
+    let entries = triangles(&vertex);
+    let (blas, scratch) = storage(&device, &entries);
+    let instances = device.tlas_instance_to_bytes(crate::TlasInstance {
+        transform: [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        custom_data: 7,
+        mask: 255,
+        blas_address: unsafe { device.get_acceleration_structure_device_address(&blas) },
+    });
+    let instance_buffer = buffer(&device, instances.len());
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            instances.as_ptr(),
+            instance_buffer.raw.contents().as_ptr().cast(),
+            instances.len(),
+        );
+    }
+    let tlas_entries =
+        crate::AccelerationStructureEntries::Instances(crate::AccelerationStructureInstances {
+            buffer: Some(&instance_buffer),
+            offset: 0,
+            count: 1,
+        });
+    let (tlas, tlas_scratch) = storage(&device, &tlas_entries);
+    let compact_size = buffer(&device, 8);
+    let fence = unsafe { device.create_fence().unwrap() };
+    let mut producer = encoder(&device, &queue);
+    let mut consumer = encoder(&device, &queue);
+    for split in [false, true] {
+        EVENTS.with_borrow_mut(Vec::clear);
+        unsafe {
+            consumer.begin_encoding(None).unwrap();
+            build(&mut consumer, &tlas_entries, &tlas, &tlas_scratch);
+            consumer.read_acceleration_structure_compact_size(&tlas, &compact_size);
+            let consumer_buffer = consumer.end_encoding().unwrap();
+            producer.begin_encoding(None).unwrap();
+            build(&mut producer, &entries, &blas, &scratch);
+            let producer_buffer = producer.end_encoding().unwrap();
+            m::CommandEncoder::set_acceleration_structure_dependencies(
+                &[&consumer_buffer],
+                &[&blas],
+            );
+            let consumer_id = identity(&*consumer_buffer.raw);
+            assert_recording(
+                consumer_id,
+                &[
+                    "as-wait",
+                    "build",
+                    "as-update",
+                    "as-end",
+                    "as-wait",
+                    "compact-size",
+                    "as-update",
+                    "as-end",
+                ],
+            );
+            if split {
+                queue.submit(&[&producer_buffer], &[], (&fence, 2)).unwrap();
+                queue.submit(&[&consumer_buffer], &[], (&fence, 3)).unwrap();
+            } else {
+                queue
+                    .submit(&[&producer_buffer, &consumer_buffer], &[], (&fence, 1))
+                    .unwrap();
+            }
+            assert!(device
+                .wait(
+                    &fence,
+                    if split { 3 } else { 1 },
+                    Some(core::time::Duration::from_secs(30))
+                )
+                .unwrap());
+            assert_eq!(
+                consumer_buffer.raw.status(),
+                MTLCommandBufferStatus::Completed
+            );
+            assert_ne!(compact_size.raw.contents().cast::<u32>().as_ptr().read(), 0);
+            let commits: Vec<_> = events()
+                .into_iter()
+                .filter(|event| event.operation == "commit")
+                .map(|event| event.buffer)
+                .collect();
+            assert_eq!(commits, [identity(&*producer_buffer.raw), consumer_id]);
+            let retirement: Vec<_> = events()
+                .into_iter()
+                .filter(|event| event.operation == "retire-wait")
+                .map(|event| event.buffer)
+                .collect();
+            if split {
+                assert_eq!(retirement, [identity(&*producer_buffer.raw), consumer_id]);
+            } else {
+                assert_eq!(retirement, [consumer_id]);
+            }
+        }
+    }
+    unsafe {
+        device.destroy_fence(fence);
+    }
+}
+
+#[test]
+fn independent_build_batch_shares_encoder_and_queue_fence() {
+    let Some(crate::OpenDevice { device, queue }) = open() else {
+        return;
+    };
+    let vertex = buffer(&device, 36);
+    let entries = triangles(&vertex);
+    let (first, first_scratch) = storage(&device, &entries);
+    let (second, second_scratch) = storage(&device, &entries);
+    let mut first_encoder = encoder(&device, &queue);
+    let mut second_encoder = encoder(&device, &queue);
+    let fence = first_encoder.acceleration_structure_fence();
+    assert_eq!(
+        identity(&*fence),
+        identity(&*second_encoder.acceleration_structure_fence())
+    );
+    unsafe {
+        first_encoder.begin_encoding(None).unwrap();
+        second_encoder.begin_encoding(None).unwrap();
+        first_encoder.build_acceleration_structures(
+            2,
+            [(&first, &first_scratch), (&second, &second_scratch)].map(|(destination, scratch)| {
+                crate::BuildAccelerationStructureDescriptor {
+                    entries: &entries,
+                    mode: crate::AccelerationStructureBuildMode::Build,
+                    flags: wgt::AccelerationStructureFlags::empty(),
+                    source_acceleration_structure: None,
+                    destination_acceleration_structure: destination,
+                    scratch_buffer: scratch,
+                    scratch_buffer_offset: 0,
+                }
+            }),
+        );
+        let batch = first_encoder.end_encoding().unwrap();
+        assert_recording(
+            identity(&*batch.raw),
+            &["as-wait", "build", "build", "as-update", "as-end"],
+        );
+        let ids: Vec<_> = events()
+            .into_iter()
+            .filter(|event| event.buffer == identity(&*batch.raw))
+            .map(|event| event.encoder)
+            .collect();
+        assert!(ids.iter().all(|id| *id == ids[0]));
+        second_encoder.discard_encoding();
+        assert!(!queue.shared.acceleration_structure_sync.lock().seeded);
+    }
+}
+
+#[test]
+fn concurrent_recordings_use_commit_order() {
+    let Some(crate::OpenDevice { device, queue }) = open() else {
+        return;
+    };
+    let vertex = buffer(&device, 36);
+    let vertices = [-1.0f32, -1.0, 1.0, 1.0, -1.0, 1.0, 0.0, 1.0, 1.0];
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            vertices.as_ptr().cast::<u8>(),
+            vertex.raw.contents().as_ptr().cast(),
+            36,
+        );
+    }
+    let entries = triangles(&vertex);
+    let (first, first_scratch) = storage(&device, &entries);
+    let (second, second_scratch) = storage(&device, &entries);
+    let rendezvous = std::sync::Barrier::new(2);
+    let record_build = |structure: &m::AccelerationStructure, scratch: &m::Buffer| {
+        let mut enc = encoder(&device, &queue);
+        unsafe {
+            enc.begin_encoding(None).unwrap();
+            build(&mut enc, &entries, structure, scratch);
+            rendezvous.wait();
+            let buffer = enc.end_encoding().unwrap();
+            assert_recording(
+                identity(&*buffer.raw),
+                &["as-wait", "build", "as-update", "as-end"],
+            );
+            buffer
+        }
+    };
+    let (first, second) = std::thread::scope(|scope| {
+        let first = scope.spawn(|| record_build(&first, &first_scratch));
+        let second = scope.spawn(|| record_build(&second, &second_scratch));
+        (first.join().unwrap(), second.join().unwrap())
+    });
+    unsafe {
+        let fence = device.create_fence().unwrap();
+        queue.submit(&[&second, &first], &[], (&fence, 1)).unwrap();
+        assert!(device
+            .wait(&fence, 1, Some(core::time::Duration::from_secs(30)))
+            .unwrap());
+        let commits: Vec<_> = events()
+            .into_iter()
+            .filter(|event| event.operation == "commit")
+            .map(|event| event.buffer)
+            .collect();
+        assert_eq!(commits, [identity(&*second.raw), identity(&*first.raw)]);
+        device.destroy_fence(fence);
+    }
+}

--- a/wgpu-hal/src/metal/command_buffer_slot.rs
+++ b/wgpu-hal/src/metal/command_buffer_slot.rs
@@ -1,0 +1,205 @@
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+/// Admission held from before native allocation until commit or native buffer drop.
+#[derive(Debug)]
+pub(super) struct CommandBufferSlot {
+    count: Arc<AtomicUsize>,
+    submitted: AtomicBool,
+}
+
+impl CommandBufferSlot {
+    pub(super) fn reserve(count: &Arc<AtomicUsize>, limit: usize) -> Result<Self, usize> {
+        count.fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+            (count < limit).then_some(count + 1)
+        })?;
+        Ok(Self {
+            count: Arc::clone(count),
+            submitted: AtomicBool::new(false),
+        })
+    }
+
+    pub(super) fn mark_submitted(&self) {
+        assert!(!self.submitted.swap(true, Ordering::AcqRel));
+        self.release();
+    }
+
+    fn release(&self) {
+        let previous = self.count.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0);
+    }
+}
+
+impl Drop for CommandBufferSlot {
+    fn drop(&mut self) {
+        if !*self.submitted.get_mut() {
+            self.release();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Barrier;
+
+    #[test]
+    fn cpu_admission_refusal_and_reuse() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let first = CommandBufferSlot::reserve(&count, 3).unwrap();
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        let second = CommandBufferSlot::reserve(&count, 3).unwrap();
+        assert_eq!(count.load(Ordering::Acquire), 2);
+        let third = CommandBufferSlot::reserve(&count, 3).unwrap();
+        assert_eq!(count.load(Ordering::Acquire), 3);
+        for _ in 0..2 {
+            assert_eq!(CommandBufferSlot::reserve(&count, 3).unwrap_err(), 3);
+            assert_eq!(count.load(Ordering::Acquire), 3);
+        }
+        drop(second);
+        assert_eq!(count.load(Ordering::Acquire), 2);
+        let replacement = CommandBufferSlot::reserve(&count, 3).unwrap();
+        assert_eq!(count.load(Ordering::Acquire), 3);
+        drop((first, third, replacement));
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        assert_eq!(Arc::strong_count(&count), 1);
+    }
+
+    #[test]
+    fn cpu_discard_clears_encoder_reservation() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let mut encoder_slot = Some(CommandBufferSlot::reserve(&count, 1).unwrap());
+        assert!(encoder_slot.is_some());
+        // discard_encoding clears the raw buffer before clearing this Option.
+        encoder_slot = None;
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        drop(encoder_slot.take());
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        encoder_slot = Some(CommandBufferSlot::reserve(&count, 1).unwrap());
+        drop(encoder_slot);
+        assert_eq!(count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn cpu_finish_transfers_reservation_until_buffer_drop() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let mut encoder_slot = Some(CommandBufferSlot::reserve(&count, 2).unwrap());
+        // end_encoding moves the slot without releasing it; reset_all drops buffers.
+        let finished_slot = encoder_slot.take().unwrap();
+        drop(encoder_slot);
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        let next_recording = CommandBufferSlot::reserve(&count, 2).unwrap();
+        drop(finished_slot);
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        drop(next_recording);
+        assert_eq!(count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn cpu_submit_releases_before_buffer_drop_once() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let submitted = CommandBufferSlot::reserve(&count, 1).unwrap();
+        // Queue::submit calls this after raw.commit(), not at finish or completion.
+        submitted.mark_submitted();
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        let next_recording = CommandBufferSlot::reserve(&count, 1).unwrap();
+        drop(submitted);
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        drop(next_recording);
+        assert_eq!(count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn cpu_duplicate_submission_does_not_double_release() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let submitted = CommandBufferSlot::reserve(&count, 1).unwrap();
+        submitted.mark_submitted();
+        let next_recording = CommandBufferSlot::reserve(&count, 1).unwrap();
+        assert!(std::panic::catch_unwind(|| submitted.mark_submitted()).is_err());
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        drop(submitted);
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        drop(next_recording);
+        assert_eq!(count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn cpu_allocation_unwind_releases_reservation() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let result = std::panic::catch_unwind(|| {
+            let _slot = CommandBufferSlot::reserve(&count, 1).unwrap();
+            // begin_encoding keeps the reservation local while native allocation runs.
+            panic!("simulate allocation failure before storing the raw buffer");
+        });
+        assert!(result.is_err());
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        let slot = CommandBufferSlot::reserve(&count, 1).unwrap();
+        drop(slot);
+        assert_eq!(Arc::strong_count(&count), 1);
+    }
+
+    #[test]
+    fn cpu_concurrent_admissions_respect_limit() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let start = Barrier::new(9);
+        let admitted = Barrier::new(9);
+        let release = Barrier::new(9);
+        std::thread::scope(|scope| {
+            let mut threads = alloc::vec::Vec::new();
+            for _ in 0..8 {
+                threads.push(scope.spawn(|| {
+                    start.wait();
+                    let slot = CommandBufferSlot::reserve(&count, 3);
+                    admitted.wait();
+                    release.wait();
+                    match slot {
+                        Ok(slot) => {
+                            drop(slot);
+                            true
+                        }
+                        Err(current) => {
+                            assert_eq!(current, 3);
+                            false
+                        }
+                    }
+                }));
+            }
+            start.wait();
+            admitted.wait();
+            let held = count.load(Ordering::Acquire);
+            release.wait();
+            assert_eq!(held, 3);
+            let successes = threads
+                .into_iter()
+                .map(|thread| usize::from(thread.join().unwrap()))
+                .sum::<usize>();
+            assert_eq!(successes, 3);
+        });
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        assert_eq!(Arc::strong_count(&count), 1);
+    }
+
+    #[test]
+    fn cpu_reservation_keeps_counter_alive() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let weak = Arc::downgrade(&count);
+        let slot = CommandBufferSlot::reserve(&count, 1).unwrap();
+        drop(count);
+        assert_eq!(weak.upgrade().unwrap().load(Ordering::Acquire), 1);
+        slot.mark_submitted();
+        assert_eq!(weak.upgrade().unwrap().load(Ordering::Acquire), 0);
+        drop(slot);
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn cpu_production_capacity_reserves_one_internal_slot() {
+        assert_eq!(super::super::adapter::MAX_COMMAND_BUFFERS, 4096);
+        assert_eq!(super::super::adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS, 4095);
+        assert_eq!(
+            super::super::adapter::MAX_COMMAND_BUFFERS
+                - super::super::adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS,
+            1
+        );
+    }
+}

--- a/wgpu-hal/src/metal/completion.rs
+++ b/wgpu-hal/src/metal/completion.rs
@@ -1,0 +1,305 @@
+use core::time::Duration;
+use std::time::Instant;
+
+use parking_lot::{Condvar, Mutex};
+
+#[derive(Debug, Default)]
+pub(super) struct Completion {
+    value: Mutex<crate::FenceValue>,
+    changed: Condvar,
+}
+
+impl Completion {
+    pub(super) fn value(&self) -> crate::FenceValue {
+        *self.value.lock()
+    }
+
+    pub(super) fn publish(&self, value: crate::FenceValue, succeeded: bool) -> crate::FenceValue {
+        let mut completed = self.value.lock();
+        // Native callbacks may arrive out of order. Failed buffers only wake
+        // waiters so they can report the native error, not successful completion.
+        if succeeded && value > *completed {
+            *completed = value;
+            self.changed.notify_all();
+        } else if !succeeded {
+            self.changed.notify_all();
+        }
+        *completed
+    }
+
+    pub(super) fn wait(
+        &self,
+        value: crate::FenceValue,
+        timeout: Option<Duration>,
+        mut native_status: impl FnMut() -> Result<bool, crate::DeviceError>,
+    ) -> Result<bool, crate::DeviceError> {
+        // Represent the fixed deadline as origin + duration to avoid overflowing
+        // Instant for large timeouts. Wakeups never reset this origin.
+        let start = Instant::now();
+        let mut completed = self.value.lock();
+        loop {
+            if native_status()? || *completed >= value {
+                return Ok(true);
+            }
+            match timeout {
+                Some(timeout) => {
+                    let remaining = timeout.saturating_sub(start.elapsed());
+                    if remaining.is_zero() {
+                        return Ok(false);
+                    }
+                    self.changed.wait_for(&mut completed, remaining);
+                }
+                None => self.changed.wait(&mut completed),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::sync::Arc;
+    use std::{
+        sync::{mpsc, Barrier},
+        thread,
+    };
+
+    const BOUND: Duration = Duration::from_secs(5);
+
+    #[test]
+    fn cpu_early_completion_and_zero_timeout() {
+        let completion = Completion::default();
+        assert!(!completion
+            .wait(1, Some(Duration::ZERO), || Ok(false))
+            .unwrap());
+        completion.publish(1, true);
+        assert!(completion
+            .wait(1, Some(Duration::ZERO), || Ok(false))
+            .unwrap());
+        assert!(completion.wait(1, None, || Ok(false)).unwrap());
+    }
+
+    #[test]
+    fn cpu_native_status_shortcuts() {
+        let completion = Completion::default();
+        assert!(completion
+            .wait(1, Some(Duration::ZERO), || Ok(true))
+            .unwrap());
+        assert!(matches!(
+            completion.wait(1, None, || Err(crate::DeviceError::Lost)),
+            Err(crate::DeviceError::Lost)
+        ));
+    }
+
+    #[test]
+    fn cpu_check_to_wait_handoff() {
+        let completion = Completion::default();
+        let handoff = Barrier::new(2);
+        thread::scope(|scope| {
+            let publisher = scope.spawn(|| {
+                handoff.wait();
+                // The waiter still owns the predicate lock at the barrier.
+                completion.publish(1, true);
+            });
+            let mut first = true;
+            assert!(completion
+                .wait(1, Some(BOUND), || {
+                    if first {
+                        first = false;
+                        handoff.wait();
+                    }
+                    Ok(false)
+                })
+                .unwrap());
+            publisher.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn cpu_completion_during_lock_acquisition() {
+        let completion = Completion::default();
+        let mut guard = completion.value.lock();
+        let (started, ready) = mpsc::channel();
+        thread::scope(|scope| {
+            let waiter = scope.spawn(|| {
+                started.send(()).unwrap();
+                completion.wait(1, Some(BOUND), || Ok(false)).unwrap()
+            });
+            ready.recv_timeout(BOUND).unwrap();
+            *guard = 1;
+            completion.changed.notify_all();
+            drop(guard);
+            assert!(waiter.join().unwrap());
+        });
+    }
+
+    #[test]
+    fn cpu_indefinite_wait_and_multiple_targets() {
+        let completion = Completion::default();
+        let (checked, checks) = mpsc::channel();
+        let (finished, finishes) = mpsc::channel();
+        thread::scope(|scope| {
+            for target in [1, 2, 2] {
+                let checked = checked.clone();
+                let finished = finished.clone();
+                let completion = &completion;
+                scope.spawn(move || {
+                    let result = completion.wait(target, None, || {
+                        checked.send(target).unwrap();
+                        Ok(false)
+                    });
+                    finished.send((target, result.unwrap())).unwrap();
+                });
+            }
+            for _ in 0..3 {
+                checks.recv_timeout(BOUND).unwrap();
+            }
+            completion.publish(1, true);
+            let first = finishes.recv_timeout(BOUND);
+            assert!(finishes.try_recv().is_err());
+            // Release all waiters even if the first assertion below fails.
+            completion.publish(2, true);
+            assert_eq!(first.unwrap(), (1, true));
+            for _ in 0..2 {
+                assert_eq!(finishes.recv_timeout(BOUND).unwrap(), (2, true));
+            }
+        });
+    }
+
+    #[test]
+    fn cpu_irrelevant_and_spurious_wakeups_keep_deadline() {
+        let completion = Completion::default();
+        let (checked, checks) = mpsc::channel();
+        let (finished, finishes) = mpsc::channel();
+        let (stop, stopped) = mpsc::channel();
+        thread::scope(|scope| {
+            scope.spawn(|| {
+                let start = Instant::now();
+                let result = completion.wait(100, Some(Duration::from_millis(200)), || {
+                    checked.send(()).unwrap();
+                    Ok(false)
+                });
+                finished.send((result.unwrap(), start.elapsed())).unwrap();
+            });
+            checks.recv_timeout(BOUND).unwrap();
+            let completion = &completion;
+            scope.spawn(move || {
+                while matches!(
+                    stopped.recv_timeout(Duration::from_millis(10)),
+                    Err(mpsc::RecvTimeoutError::Timeout)
+                ) {
+                    completion.publish(1, true);
+                    completion.changed.notify_all();
+                }
+            });
+            let result = finishes.recv_timeout(BOUND);
+            stop.send(()).unwrap();
+            let (ready, elapsed) = result.unwrap();
+            assert!(!ready);
+            assert!(elapsed >= Duration::from_millis(200));
+            assert!(elapsed < BOUND);
+            assert!(checks.try_iter().count() > 1);
+        });
+    }
+
+    #[test]
+    fn cpu_ready_status_wins_at_timeout_boundary() {
+        let completion = Completion::default();
+        let (_send, receive) = mpsc::channel::<()>();
+        assert!(completion
+            .wait(1, Some(Duration::from_millis(10)), || {
+                assert_eq!(
+                    receive.recv_timeout(Duration::from_millis(20)),
+                    Err(mpsc::RecvTimeoutError::Timeout)
+                );
+                Ok(true)
+            })
+            .unwrap());
+    }
+
+    #[test]
+    fn cpu_submillisecond_timeout() {
+        let completion = Completion::default();
+        let timeout = Duration::from_micros(100);
+        let start = Instant::now();
+        assert!(!completion.wait(1, Some(timeout), || Ok(false)).unwrap());
+        assert!(start.elapsed() >= timeout);
+        assert!(start.elapsed() < BOUND);
+    }
+
+    #[test]
+    fn cpu_large_timeout_wakes_without_overflow() {
+        let completion = Completion::default();
+        let handoff = Barrier::new(2);
+        thread::scope(|scope| {
+            scope.spawn(|| {
+                handoff.wait();
+                completion.publish(1, true);
+            });
+            let mut first = true;
+            assert!(completion
+                .wait(1, Some(Duration::MAX), || {
+                    if first {
+                        first = false;
+                        handoff.wait();
+                    }
+                    Ok(false)
+                })
+                .unwrap());
+        });
+    }
+
+    #[test]
+    fn cpu_publication_is_monotonic() {
+        let completion = Completion::default();
+        for value in [3, 1, 2, 3, 0] {
+            completion.publish(value, true);
+            assert_eq!(completion.value(), 3);
+        }
+        completion.publish(4, false);
+        assert_eq!(completion.value(), 3);
+        assert!(completion
+            .wait(3, Some(Duration::ZERO), || Ok(false))
+            .unwrap());
+    }
+
+    #[test]
+    fn cpu_failed_completion_wakes_native_error() {
+        let completion = Completion::default();
+        let (checked, checks) = mpsc::channel();
+        thread::scope(|scope| {
+            let completion = &completion;
+            scope.spawn(move || {
+                checks.recv_timeout(BOUND).unwrap();
+                completion.publish(1, false);
+            });
+            let mut first = true;
+            assert!(matches!(
+                completion.wait(1, Some(BOUND), || {
+                    if first {
+                        first = false;
+                        checked.send(()).unwrap();
+                        Ok(false)
+                    } else {
+                        Err(crate::DeviceError::Lost)
+                    }
+                }),
+                Err(crate::DeviceError::Lost)
+            ));
+        });
+        assert_eq!(completion.value(), 0);
+    }
+
+    #[test]
+    fn cpu_completed_block_keeps_state_alive() {
+        let completion = Arc::new(Completion::default());
+        let weak = Arc::downgrade(&completion);
+        let captured = Arc::clone(&completion);
+        let block = block2::RcBlock::new(move || captured.publish(1, true));
+        drop(completion);
+        block.call(());
+        assert_eq!(weak.upgrade().unwrap().value(), 1);
+        drop(block);
+        assert!(weak.upgrade().is_none());
+    }
+}

--- a/wgpu-hal/src/metal/conv.rs
+++ b/wgpu-hal/src/metal/conv.rs
@@ -6,7 +6,7 @@ use objc2_metal::{
     MTLAccelerationStructureTriangleGeometryDescriptor, MTLAccelerationStructureUsage,
     MTLAttributeFormat, MTLBlendFactor, MTLBlendOperation, MTLBlitOption, MTLClearColor,
     MTLColorWriteMask, MTLCompareFunction, MTLCullMode, MTLIndexType,
-    MTLInstanceAccelerationStructureDescriptor, MTLOrigin,
+    MTLInstanceAccelerationStructureDescriptor, MTLMatrixLayout, MTLOrigin,
     MTLPrimitiveAccelerationStructureDescriptor, MTLPrimitiveTopologyClass, MTLPrimitiveType,
     MTLRenderStages, MTLResourceUsage, MTLSamplerAddressMode, MTLSamplerBorderColor,
     MTLSamplerMinMagFilter, MTLSize, MTLStencilOperation, MTLStoreAction, MTLTextureType,
@@ -417,6 +417,7 @@ pub fn map_acceleration_structure_descriptor<'a>(
                         )
                     });
                     if let Some(transform) = triangles.transform.as_ref() {
+                        descriptor.setTransformationMatrixLayout(MTLMatrixLayout::RowMajor);
                         unsafe {
                             descriptor.setTransformationMatrixBuffer(Some(&transform.buffer.raw));
                             descriptor
@@ -428,11 +429,10 @@ pub fn map_acceleration_structure_descriptor<'a>(
                             .flags
                             .contains(wgt::AccelerationStructureGeometryFlags::OPAQUE),
                     );
-                    if !triangles.flags.contains(
+                    let allow_duplicates = !triangles.flags.contains(
                         wgt::AccelerationStructureGeometryFlags::NO_DUPLICATE_ANY_HIT_INVOCATION,
-                    ) {
-                        descriptor.allowDuplicateIntersectionFunctionInvocation();
-                    }
+                    );
+                    descriptor.setAllowDuplicateIntersectionFunctionInvocation(allow_duplicates);
                     // descriptor.setIntersectionFunctionTableOffset(offset);
                     descriptor.into_super()
                 })
@@ -459,11 +459,10 @@ pub fn map_acceleration_structure_descriptor<'a>(
                             .flags
                             .contains(wgt::AccelerationStructureGeometryFlags::OPAQUE),
                     );
-                    if !aabbs.flags.contains(
+                    let allow_duplicates = !aabbs.flags.contains(
                         wgt::AccelerationStructureGeometryFlags::NO_DUPLICATE_ANY_HIT_INVOCATION,
-                    ) {
-                        descriptor.allowDuplicateIntersectionFunctionInvocation();
-                    }
+                    );
+                    descriptor.setAllowDuplicateIntersectionFunctionInvocation(allow_duplicates);
                     // descriptor.setIntersectionFunctionTableOffset(offset);
                     descriptor.into_super()
                 })

--- a/wgpu-hal/src/metal/conv.rs
+++ b/wgpu-hal/src/metal/conv.rs
@@ -365,6 +365,7 @@ pub fn map_resource_usage(ty: &wgt::BindingType) -> MTLResourceUsage {
             }
         },
         wgt::BindingType::Sampler(..) => MTLResourceUsage::empty(),
+        wgt::BindingType::AccelerationStructure { .. } => MTLResourceUsage::Read,
         _ => unreachable!(),
     }
 }

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -8,14 +8,15 @@ use objc2::{
     rc::{autoreleasepool, Retained},
     runtime::ProtocolObject,
 };
-use objc2_foundation::{ns_string, NSError, NSRange, NSString, NSUInteger};
+use objc2_foundation::{ns_string, NSArray, NSError, NSRange, NSString, NSUInteger};
 use objc2_metal::{
-    MTLAccelerationStructure, MTLAccelerationStructureInstanceOptions, MTLBuffer,
-    MTLCaptureManager, MTLCaptureScope, MTLCommandBuffer, MTLCommandBufferStatus,
-    MTLCompileOptions, MTLComputePipelineDescriptor, MTLComputePipelineState,
-    MTLCounterSampleBufferDescriptor, MTLCounterSet, MTLDepthClipMode, MTLDepthStencilDescriptor,
-    MTLDevice, MTLFunction, MTLIndirectAccelerationStructureInstanceDescriptor, MTLLanguageVersion,
-    MTLLibrary, MTLMeshRenderPipelineDescriptor, MTLMutability, MTLPackedFloat3, MTLPackedFloat4x3,
+    MTLAccelerationStructure, MTLAccelerationStructureInstanceOptions, MTLArgumentAccess,
+    MTLArgumentDescriptor, MTLArgumentEncoder, MTLBuffer, MTLCaptureManager, MTLCaptureScope,
+    MTLCommandBuffer, MTLCommandBufferStatus, MTLCompileOptions, MTLComputePipelineDescriptor,
+    MTLComputePipelineState, MTLCounterSampleBufferDescriptor, MTLCounterSet, MTLDataType,
+    MTLDepthClipMode, MTLDepthStencilDescriptor, MTLDevice, MTLFunction,
+    MTLIndirectAccelerationStructureInstanceDescriptor, MTLLanguageVersion, MTLLibrary,
+    MTLMeshRenderPipelineDescriptor, MTLMutability, MTLPackedFloat3, MTLPackedFloat4x3,
     MTLPipelineBufferDescriptorArray, MTLPipelineOption, MTLPixelFormat, MTLPrimitiveTopologyClass,
     MTLRenderPipelineColorAttachmentDescriptorArray, MTLRenderPipelineDescriptor, MTLResource,
     MTLResourceID, MTLResourceOptions, MTLSamplerAddressMode, MTLSamplerDescriptor,
@@ -1043,11 +1044,38 @@ impl crate::Device for super::Device {
                                 let acceleration_structures =
                                     &desc.acceleration_structures[start..end];
 
-                                for (idx, &acceleration_structure) in
-                                    acceleration_structures.iter().enumerate()
-                                {
-                                    contents[idx] = acceleration_structure.raw.gpuResourceID();
+                                // Encode through a real argument encoder rather
+                                // than writing gpuResourceIDs directly, so the
+                                // handles the `constant
+                                // NagaArgumentBufferWrapper<AS>*` dereference
+                                // follow the argument-buffer ABI.
+                                let argument_descriptor = MTLArgumentDescriptor::new();
+                                argument_descriptor
+                                    .setDataType(MTLDataType::InstanceAccelerationStructure);
+                                argument_descriptor.setIndex(0);
+                                argument_descriptor.setArrayLength(count as usize);
+                                argument_descriptor.setAccess(MTLArgumentAccess::ReadOnly);
 
+                                let argument_encoder = self
+                                    .shared
+                                    .device
+                                    .newArgumentEncoderWithArguments(&NSArray::from_slice(&[
+                                        &*argument_descriptor,
+                                    ]))
+                                    .unwrap();
+                                unsafe {
+                                    argument_encoder.setArgumentBuffer_offset(Some(&buffer), 0);
+                                    for (idx, &acceleration_structure) in
+                                        acceleration_structures.iter().enumerate()
+                                    {
+                                        argument_encoder.setAccelerationStructure_atIndex(
+                                            Some(acceleration_structure.raw.as_ref()),
+                                            idx,
+                                        );
+                                    }
+                                }
+
+                                for &acceleration_structure in acceleration_structures.iter() {
                                     let use_info = bg
                                         .resources_to_use
                                         .entry(acceleration_structure.as_raw().cast())
@@ -1057,6 +1085,8 @@ impl crate::Device for super::Device {
                                     use_info.visible_in_compute |=
                                         layout.visibility.contains(wgt::ShaderStages::COMPUTE);
                                 }
+
+                                bg.uses_acceleration_structures = true;
                             }
                             _ => {
                                 unimplemented!();

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -740,6 +740,7 @@ impl crate::Device for super::Device {
             shared: Arc::clone(&self.shared),
             queue_shared: Arc::clone(&desc.queue.shared),
             raw_cmd_buf: None,
+            acceleration_structure_fence: None,
             state: super::CommandState::default(),
             temp: super::Temp::default(),
             counters: Arc::clone(&self.counters),

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1,7 +1,6 @@
 use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
-use core::{ptr::NonNull, sync::atomic};
+use core::ptr::NonNull;
 use parking_lot::RwLock;
-use std::{thread, time};
 
 use bytemuck::TransparentWrapper;
 use objc2::{
@@ -415,6 +414,14 @@ impl super::Device {
         }
     }
 
+    /// # Safety
+    ///
+    /// `raw` must belong to the device using this buffer, and `size` must not
+    /// exceed its allocation. Its resolved hazard tracking mode must be tracked,
+    /// or the caller must independently synchronize all conflicting accesses,
+    /// including compute/blit writes before acceleration-structure input reads.
+    /// Resource-use declarations provide residency but do not synchronize an
+    /// untracked import; the AS fence does not cover preceding non-AS producers.
     pub unsafe fn buffer_from_raw(
         raw: Retained<ProtocolObject<dyn MTLBuffer>>,
         size: wgt::BufferAddress,
@@ -735,12 +742,22 @@ impl crate::Device for super::Device {
         &self,
         desc: &crate::CommandEncoderDescriptor<super::Queue>,
     ) -> Result<super::CommandEncoder, crate::DeviceError> {
+        if self
+            .features
+            .contains(wgt::Features::EXPERIMENTAL_RAY_QUERY)
+        {
+            desc.queue
+                .shared
+                .acceleration_structure_sync
+                .lock()
+                .initialize_fence(|| self.shared.device.newFence())?;
+        }
         self.counters.command_encoders.add(1);
         Ok(super::CommandEncoder {
             shared: Arc::clone(&self.shared),
             queue_shared: Arc::clone(&desc.queue.shared),
             raw_cmd_buf: None,
-            acceleration_structure_fence: None,
+            command_buffer_slot: None,
             state: super::CommandState::default(),
             temp: super::Temp::default(),
             counters: Arc::clone(&self.counters),
@@ -1887,7 +1904,7 @@ impl crate::Device for super::Device {
             None
         };
         Ok(super::Fence {
-            completed_value: Arc::new(atomic::AtomicU64::new(0)),
+            completed_value: Arc::new(super::completion::Completion::default()),
             pending_command_buffers: RwLock::new(Vec::new()),
             shared_event,
         })
@@ -1898,14 +1915,7 @@ impl crate::Device for super::Device {
     }
 
     unsafe fn get_fence_value(&self, fence: &super::Fence) -> DeviceResult<crate::FenceValue> {
-        let mut max_value = fence.completed_value.load(atomic::Ordering::Acquire);
-        let pending_command_buffers = fence.pending_command_buffers.read();
-        for &(value, ref cmd_buf) in pending_command_buffers.iter() {
-            if cmd_buf.status() == MTLCommandBufferStatus::Completed {
-                max_value = value;
-            }
-        }
-        Ok(max_value)
+        Ok(fence.get_latest())
     }
     unsafe fn wait(
         &self,
@@ -1913,7 +1923,7 @@ impl crate::Device for super::Device {
         wait_value: crate::FenceValue,
         timeout: Option<core::time::Duration>,
     ) -> DeviceResult<bool> {
-        if wait_value <= fence.completed_value.load(atomic::Ordering::Acquire) {
+        if wait_value <= fence.completed_value.value() {
             return Ok(true);
         }
 
@@ -1925,6 +1935,11 @@ impl crate::Device for super::Device {
         {
             Some((_, cmd_buf)) => cmd_buf.clone(),
             None => {
+                drop(pending_command_buffers);
+                // Maintenance may have retired the buffer since the fast check.
+                if wait_value <= fence.completed_value.value() {
+                    return Ok(true);
+                }
                 log::error!("No active command buffers for fence value {wait_value}");
                 return Err(crate::DeviceError::Lost);
             }
@@ -1933,18 +1948,13 @@ impl crate::Device for super::Device {
         // Make sure that nothing is blocked during the actual wait.
         drop(pending_command_buffers);
 
-        let start = time::Instant::now();
-        loop {
-            if let MTLCommandBufferStatus::Completed = cmd_buf.status() {
-                return Ok(true);
-            }
-            if let Some(timeout) = timeout {
-                if start.elapsed() >= timeout {
-                    return Ok(false);
-                }
-            }
-            thread::sleep(core::time::Duration::from_millis(1));
-        }
+        fence
+            .completed_value
+            .wait(wait_value, timeout, || match cmd_buf.status() {
+                MTLCommandBufferStatus::Completed => Ok(true),
+                MTLCommandBufferStatus::Error => Err(crate::DeviceError::Lost),
+                _ => Ok(false),
+            })
     }
 
     unsafe fn start_graphics_debugger_capture(&self) -> bool {

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -48,7 +48,7 @@ use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLArgumentBuffersTier,
     MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue,
     MTLComputeCommandEncoder, MTLComputePipelineState, MTLCounterSampleBuffer, MTLCullMode,
-    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLIndexType,
+    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLFence, MTLIndexType,
     MTLLanguageVersion, MTLLibrary, MTLPrimitiveType, MTLReadWriteTextureTier,
     MTLRenderCommandEncoder, MTLRenderPipelineState, MTLRenderStages, MTLResource,
     MTLResourceUsage, MTLSamplerState, MTLSharedEvent, MTLSize, MTLTexture, MTLTextureType,
@@ -1084,6 +1084,20 @@ struct CommandState {
     blit: Option<Retained<ProtocolObject<dyn MTLBlitCommandEncoder>>>,
     acceleration_structure_builder:
         Option<Retained<ProtocolObject<dyn MTLAccelerationStructureCommandEncoder>>>,
+    /// Fence used to order acceleration structure encoders split by
+    /// `CommandEncoder::split_acceleration_structure_builder`. Created lazily
+    /// and kept alive for the lifetime of the encoder. Command buffers
+    /// created with unretained references do not retain this fence, so the
+    /// encoder (which owns it) must be kept alive until its submitted
+    /// command buffers have finished executing.
+    acceleration_structure_fence: Option<Retained<ProtocolObject<dyn MTLFence>>>,
+    /// Whether the next acceleration structure encoder must wait on
+    /// [`Self::acceleration_structure_fence`] before encoding any commands.
+    pending_acceleration_structure_fence_wait: bool,
+    /// Whether the current acceleration structure encoder has encoded any
+    /// builds, i.e. whether commands consuming their results must split the
+    /// encoder first.
+    acceleration_structure_builder_has_builds: bool,
     render: Option<Retained<ProtocolObject<dyn MTLRenderCommandEncoder>>>,
     compute: Option<Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>>,
     raw_primitive_type: MTLPrimitiveType,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -22,6 +22,8 @@ end of the VS buffer table.
 )]
 mod adapter;
 mod command;
+mod command_buffer_slot;
+mod completion;
 mod conv;
 mod device;
 mod library_from_metallib;
@@ -46,9 +48,9 @@ use objc2::{
 use objc2_foundation::ns_string;
 use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLArgumentBuffersTier,
-    MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue,
-    MTLComputeCommandEncoder, MTLComputePipelineState, MTLCounterSampleBuffer, MTLCullMode,
-    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLEvent, MTLFence,
+    MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder,
+    MTLCommandQueue, MTLComputeCommandEncoder, MTLComputePipelineState, MTLCounterSampleBuffer,
+    MTLCullMode, MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLFence,
     MTLIndexType, MTLLanguageVersion, MTLLibrary, MTLPrimitiveType, MTLReadWriteTextureTier,
     MTLRenderCommandEncoder, MTLRenderPipelineState, MTLRenderStages, MTLResource,
     MTLResourceUsage, MTLSamplerState, MTLSharedEvent, MTLSize, MTLTexture, MTLTextureType,
@@ -458,6 +460,10 @@ pub struct Queue {
 static_assertions::assert_impl_all!(Queue: Send, Sync);
 
 impl Queue {
+    /// # Safety
+    ///
+    /// The queue must support at least `MAX_COMMAND_BUFFERS` (4096) live command
+    /// buffers. External users must not consume that budget while wgpu uses it.
     pub unsafe fn queue_from_raw(
         raw: Retained<ProtocolObject<dyn MTLCommandQueue>>,
         timestamp_period: f32,
@@ -465,7 +471,7 @@ impl Queue {
         Self {
             shared: Arc::new(QueueShared {
                 raw,
-                command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
+                command_buffer_created_not_submitted: Arc::new(atomic::AtomicUsize::new(0)),
                 acceleration_structure_sync: Mutex::default(),
             }),
             timestamp_period,
@@ -487,48 +493,42 @@ pub struct QueueShared {
     // (In a few places we call `.commandBuffer{,WithUnretainedReferences}` directly
     // to create command buffers for internal purposes. In those cases we always
     // commit the buffer immediately, so we don't adjust the counter for them.)
-    command_buffer_created_not_submitted: atomic::AtomicUsize,
-    // Synchronization for acceleration structure command encoders. Metal does
-    // not order acceleration structure commands against each other, whether
-    // they share an encoder or not. Within one command buffer,
-    // `CommandEncoder` orders the encoders with an `MTLFence`. Across command
-    // buffers, `Queue::submit` links whole command buffers with the event in
-    // here, in commit order. See `AccelerationStructureSync`.
+    command_buffer_created_not_submitted: Arc<atomic::AtomicUsize>,
+    // Serializes commits and internal allocations through commit, not recording.
+    // The single reserved native slot cannot be held by another uncommitted
+    // internal buffer. Fence dependencies are evaluated at commit.
     acceleration_structure_sync: Mutex<AccelerationStructureSync>,
 }
 
-/// Cross-command-buffer ordering of acceleration structure commands.
-///
-/// Metal orders a command buffer against the command buffers committed before
-/// it, but acceleration structure commands are exempt: a build in one command
-/// buffer can observe an acceleration structure mid-build of an earlier
-/// command buffer, even though the two are committed back to back. The
-/// exemption is not limited to acceleration structure work on either side: a
-/// build races *any* earlier command buffer, including one that encodes data
-/// the build consumes.
-///
-/// The pairing is decided at submit time, not encode time, because Metal
-/// defines it in terms of commits: once a submission contains acceleration
-/// structure commands, every command buffer of that submission, and of every
-/// later submission on the queue, waits, before it starts executing, on the
-/// value the previous chained command buffer signals when its commands
-/// complete, and signals a fresh value after its own commands. Chaining whole
-/// submissions closes the exemption against all earlier work; values are
-/// assigned and encoded under the enclosing mutex, which `submit` holds until
-/// the command buffers are committed, so every wait references a value whose
-/// command buffer has been or is being committed and therefore will signal. A
-/// command buffer dropped without submission never takes part, so no wait can
-/// outlive the command buffer that satisfies it.
 #[derive(Debug, Default)]
 struct AccelerationStructureSync {
-    /// The queue-wide event, created on first use. Acceleration structure
-    /// commands only exist on hardware and OS versions where `MTLEvent` is
-    /// available.
-    event: Option<Retained<ProtocolObject<dyn MTLEvent>>>,
-    /// The value the next chained command buffer must wait on; 0 means there
-    /// is no acceleration structure work on the queue yet, so no submission
-    /// is chained.
-    last_signaled_value: u64,
+    // Apple evaluates wait-before-update reuse when buffers are committed,
+    // so recording order and abandoned buffers do not reserve dependencies.
+    fence: Option<Retained<ProtocolObject<dyn MTLFence>>>,
+    seeded: bool,
+}
+
+impl AccelerationStructureSync {
+    fn initialize_fence(
+        &mut self,
+        allocate: impl FnOnce() -> Option<Retained<ProtocolObject<dyn MTLFence>>>,
+    ) -> Result<(), crate::DeviceError> {
+        if self.fence.is_none() {
+            self.fence = Some(allocate().ok_or(crate::DeviceError::OutOfMemory)?);
+        }
+        Ok(())
+    }
+}
+
+impl QueueShared {
+    fn acceleration_structure_fence(&self) -> Retained<ProtocolObject<dyn MTLFence>> {
+        self.acceleration_structure_sync
+            .lock()
+            .fence
+            .as_ref()
+            .expect("ray-query encoder setup must initialize the queue fence")
+            .clone()
+    }
 }
 
 pub struct Device {
@@ -583,66 +583,35 @@ impl crate::Queue for Queue {
         (signal_fence, signal_value): (&Fence, crate::FenceValue),
     ) -> Result<(), crate::DeviceError> {
         autoreleasepool(|_| -> Result<(), crate::DeviceError> {
-            // Link command buffers into the commit-order chain (see
-            // `AccelerationStructureSync`). The mutex is held until the
-            // command buffers are committed so that a concurrent submission
-            // cannot commit between this submission's value assignments and
-            // its commits.
-            let mut acceleration_structure_sync = self.shared.acceleration_structure_sync.lock();
-            // Metal exempts acceleration structure commands from the
-            // back-to-back execution of command buffers committed in order,
-            // so an acceleration structure build is not ordered against any
-            // earlier command buffer: not even against a copy in the same
-            // submission of data the build consumes (for example the
-            // instance buffer of a top level acceleration structure, which
-            // wgpu-core encodes onto an internal command buffer of the same
-            // submission). The event chain therefore serializes whole
-            // command buffers from the first submission that contains
-            // acceleration structure commands onward: every command buffer
-            // of such a submission waits on the value the previous chained
-            // command buffer signals at completion, which orders the
-            // acceleration structure commands against all earlier work on
-            // the queue, and signals a fresh value that later submissions
-            // wait on in turn.
-            let chain_entire_submission = acceleration_structure_sync.last_signaled_value > 0
-                || command_buffers
-                    .iter()
-                    .any(|cmd_buffer| cmd_buffer.contains_acceleration_structure_commands);
-            for cmd_buffer in command_buffers {
-                if !chain_entire_submission {
-                    continue;
-                }
-                let event = match acceleration_structure_sync.event.clone() {
-                    Some(event) => event,
-                    None => {
-                        let event = self
-                            .shared
-                            .raw
-                            .device()
-                            .newEvent()
-                            .ok_or(crate::DeviceError::OutOfMemory)?;
-                        acceleration_structure_sync.event = Some(event.clone());
-                        event
-                    }
-                };
-                if acceleration_structure_sync.last_signaled_value > 0 {
-                    cmd_buffer.raw.encodeWaitForEvent_value(
-                        event.as_ref(),
-                        acceleration_structure_sync.last_signaled_value,
-                    );
-                }
-                acceleration_structure_sync.last_signaled_value += 1;
-                cmd_buffer.raw.encodeSignalEvent_value(
-                    event.as_ref(),
-                    acceleration_structure_sync.last_signaled_value,
-                );
+            let mut sync = self.shared.acceleration_structure_sync.lock();
+            let participates = command_buffers
+                .iter()
+                .any(|buffer| buffer.contains_acceleration_structure_commands);
+            if participates && !sync.seeded {
+                // Every participant waits before updating. Seed the fence with a
+                // committed producer, independently of recording or discard order.
+                let raw = self.shared.raw.commandBuffer().unwrap();
+                let encoder = raw.blitCommandEncoder().unwrap();
+                encoder.updateFence(sync.fence.as_ref().unwrap());
+                encoder.endEncoding();
+                #[cfg(test)]
+                command::tests::record(&raw, None, "seed-commit");
+                raw.commit();
+                sync.seeded = true;
             }
 
             let extra_command_buffer = {
                 let completed_value = Arc::clone(&signal_fence.completed_value);
-                let block = block2::RcBlock::new(move |_cmd_buf| {
-                    completed_value.store(signal_value, atomic::Ordering::Release);
-                });
+                // Keep the domain fence alive even for unretained command buffers.
+                let queue_shared = Arc::clone(&self.shared);
+                let block = block2::RcBlock::new(
+                    move |cmd_buf: NonNull<ProtocolObject<dyn MTLCommandBuffer>>| {
+                        let _keep_alive = &queue_shared;
+                        let succeeded = unsafe { cmd_buf.as_ref() }.status()
+                            == MTLCommandBufferStatus::Completed;
+                        completed_value.publish(signal_value, succeeded);
+                    },
+                );
 
                 let raw = match command_buffers.last() {
                     Some(&cmd_buf) => cmd_buf.raw.clone(),
@@ -655,6 +624,19 @@ impl crate::Queue for Queue {
                             .unwrap()
                     }
                 };
+                if participates {
+                    // This tail wait joins AS work for submission retirement;
+                    // producer/consumer waits are already in the relevant passes.
+                    let encoder = raw.blitCommandEncoder().unwrap();
+                    encoder.waitForFence(sync.fence.as_ref().unwrap());
+                    #[cfg(test)]
+                    command::tests::record(
+                        &raw,
+                        Some(command::tests::identity(&*encoder)),
+                        "retire-wait",
+                    );
+                    encoder.endEncoding();
+                }
                 raw.setLabel(Some(ns_string!("(wgpu internal) Signal")));
                 unsafe { raw.addCompletedHandler(block2::RcBlock::as_ptr(&block)) };
 
@@ -675,15 +657,10 @@ impl crate::Queue for Queue {
             };
 
             for cmd_buffer in command_buffers {
+                #[cfg(test)]
+                command::tests::record(&cmd_buffer.raw, None, "commit");
                 cmd_buffer.raw.commit();
-                // One command buffer per `end_encoding` call moves from the
-                // "created but not yet submitted" bucket into the submitted
-                // set, so update the counter.
-                let previous = self
-                    .shared
-                    .command_buffer_created_not_submitted
-                    .fetch_sub(1, atomic::Ordering::AcqRel);
-                debug_assert!(previous > 0);
+                cmd_buffer.slot.mark_submitted();
             }
 
             if let Some(raw) = extra_command_buffer {
@@ -699,6 +676,7 @@ impl crate::Queue for Queue {
         texture: SurfaceTexture,
     ) -> Result<(), crate::SurfaceError> {
         autoreleasepool(|_| {
+            let _sync = self.shared.acceleration_structure_sync.lock();
             // We do not bother adjusting `command_buffer_created_not_submitted`
             // because we immediately commit this buffer.
             let command_buffer = self.shared.raw.commandBuffer().unwrap();
@@ -725,6 +703,7 @@ impl crate::Queue for Queue {
 
     unsafe fn wait_for_idle(&self) -> Result<(), crate::DeviceError> {
         autoreleasepool(|_| {
+            let _sync = self.shared.acceleration_structure_sync.lock();
             let command_buffer = self.shared.raw.commandBuffer().unwrap();
             command_buffer.setLabel(Some(ns_string!("(wgpu internal) wait_for_idle")));
             command_buffer.commit();
@@ -970,6 +949,10 @@ pub struct BindGroup {
 
     argument_buffers: Vec<Retained<ProtocolObject<dyn MTLBuffer>>>,
     resources_to_use: HashMap<NonNull<ProtocolObject<dyn MTLResource>>, UseResourceInfo>,
+    /// True when the group contains acceleration structures encoded into an
+    /// argument buffer. Those ride on the argument-buffer bind path, which
+    /// would otherwise skip the acceleration structure build fence wait.
+    uses_acceleration_structures: bool,
 }
 
 impl crate::DynBindGroup for BindGroup {}
@@ -1126,7 +1109,7 @@ unsafe impl Sync for QuerySet {}
 
 #[derive(Debug)]
 pub struct Fence {
-    completed_value: Arc<atomic::AtomicU64>,
+    completed_value: Arc<completion::Completion>,
     /// The pending fence values have to be ascending.
     pending_command_buffers: RwLock<Vec<PendingCommandBuffer>>,
     shared_event: Option<Retained<ProtocolObject<dyn MTLSharedEvent>>>,
@@ -1144,14 +1127,16 @@ unsafe impl Sync for Fence {}
 
 impl Fence {
     fn get_latest(&self) -> crate::FenceValue {
-        let mut max_value = self.completed_value.load(atomic::Ordering::Acquire);
+        let mut max_value = self.completed_value.value();
         let pending_command_buffers = self.pending_command_buffers.read();
         for &(value, ref cmd_buf) in pending_command_buffers.iter() {
             if cmd_buf.status() == MTLCommandBufferStatus::Completed {
-                max_value = value;
+                max_value = max_value.max(value);
             }
         }
-        max_value
+        drop(pending_command_buffers);
+        // Cache native status observations before maintain can discard them.
+        self.completed_value.publish(max_value, true)
     }
 
     fn maintain(&self) {
@@ -1182,9 +1167,7 @@ struct CommandState {
     blit: Option<Retained<ProtocolObject<dyn MTLBlitCommandEncoder>>>,
     acceleration_structure_builder:
         Option<Retained<ProtocolObject<dyn MTLAccelerationStructureCommandEncoder>>>,
-    /// Whether this command buffer has encoded any acceleration structure
-    /// commands. `Queue::submit` orders command buffers with acceleration
-    /// structure commands against each other based on this.
+    /// Whether this recording builds, copies, or queries an acceleration structure.
     contains_acceleration_structure_commands: bool,
     /// Whether the current acceleration structure encoder has encoded any
     /// acceleration structure commands, i.e. whether a later
@@ -1192,11 +1175,8 @@ struct CommandState {
     /// first. wgpu-core emits a barrier between all other pairs of
     /// acceleration structure commands, which closes the encoder anyway.
     acceleration_structure_builder_has_commands: bool,
-    /// Whether an earlier acceleration structure encoder in this command
-    /// buffer updated `CommandEncoder::acceleration_structure_fence` and no
-    /// encoder has waited on it yet. The next acceleration structure encoder
-    /// in this command buffer must wait before encoding commands.
-    acceleration_structure_fence_updated: bool,
+    /// Whether the current compute/render pass has joined the AS domain.
+    acceleration_structure_pass: bool,
     render: Option<Retained<ProtocolObject<dyn MTLRenderCommandEncoder>>>,
     compute: Option<Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>>,
     raw_primitive_type: MTLPrimitiveType,
@@ -1236,13 +1216,7 @@ pub struct CommandEncoder {
     shared: Arc<AdapterShared>,
     queue_shared: Arc<QueueShared>,
     raw_cmd_buf: Option<Retained<ProtocolObject<dyn MTLCommandBuffer>>>,
-    /// Fence ordering the acceleration structure encoders of this command
-    /// buffer against each other. It is created on first use and belongs to
-    /// this command buffer alone: Metal requires the command buffer whose
-    /// pass updates a fence to be committed before the command buffer whose
-    /// pass waits on it, so a fence shared with other command buffers would
-    /// reintroduce an encode-order requirement that wgpu does not guarantee.
-    acceleration_structure_fence: Option<Retained<ProtocolObject<dyn MTLFence>>>,
+    command_buffer_slot: Option<command_buffer_slot::CommandBufferSlot>,
     state: CommandState,
     temp: Temp,
     counters: Arc<wgt::HalCounters>,
@@ -1262,11 +1236,11 @@ unsafe impl Sync for CommandEncoder {}
 #[derive(Debug)]
 pub struct CommandBuffer {
     raw: Retained<ProtocolObject<dyn MTLCommandBuffer>>,
-    queue_shared: Arc<QueueShared>,
-    /// Whether this command buffer encoded any acceleration structure
-    /// commands. A submission containing such a command buffer is chained
-    /// whole by `Queue::submit` based on this. See
-    /// `AccelerationStructureSync`.
+    // Field order drops the native buffer before releasing unsubmitted admission.
+    slot: command_buffer_slot::CommandBufferSlot,
+    // Keep the queue's AS fence alive for unretained command buffers.
+    _queue_shared: Arc<QueueShared>,
+    /// Includes query-only compute and render passes.
     contains_acceleration_structure_commands: bool,
 }
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -48,8 +48,8 @@ use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLArgumentBuffersTier,
     MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue,
     MTLComputeCommandEncoder, MTLComputePipelineState, MTLCounterSampleBuffer, MTLCullMode,
-    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLFence, MTLIndexType,
-    MTLLanguageVersion, MTLLibrary, MTLPrimitiveType, MTLReadWriteTextureTier,
+    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLEvent, MTLFence,
+    MTLIndexType, MTLLanguageVersion, MTLLibrary, MTLPrimitiveType, MTLReadWriteTextureTier,
     MTLRenderCommandEncoder, MTLRenderPipelineState, MTLRenderStages, MTLResource,
     MTLResourceUsage, MTLSamplerState, MTLSharedEvent, MTLSize, MTLTexture, MTLTextureType,
     MTLTriangleFillMode, MTLWinding,
@@ -466,6 +466,7 @@ impl Queue {
             shared: Arc::new(QueueShared {
                 raw,
                 command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
+                acceleration_structure_sync: Mutex::default(),
             }),
             timestamp_period,
         }
@@ -487,6 +488,47 @@ pub struct QueueShared {
     // to create command buffers for internal purposes. In those cases we always
     // commit the buffer immediately, so we don't adjust the counter for them.)
     command_buffer_created_not_submitted: atomic::AtomicUsize,
+    // Synchronization for acceleration structure command encoders. Metal does
+    // not order acceleration structure commands against each other, whether
+    // they share an encoder or not. Within one command buffer,
+    // `CommandEncoder` orders the encoders with an `MTLFence`. Across command
+    // buffers, `Queue::submit` links whole command buffers with the event in
+    // here, in commit order. See `AccelerationStructureSync`.
+    acceleration_structure_sync: Mutex<AccelerationStructureSync>,
+}
+
+/// Cross-command-buffer ordering of acceleration structure commands.
+///
+/// Metal orders a command buffer against the command buffers committed before
+/// it, but acceleration structure commands are exempt: a build in one command
+/// buffer can observe an acceleration structure mid-build of an earlier
+/// command buffer, even though the two are committed back to back. The
+/// exemption is not limited to acceleration structure work on either side: a
+/// build races *any* earlier command buffer, including one that encodes data
+/// the build consumes.
+///
+/// The pairing is decided at submit time, not encode time, because Metal
+/// defines it in terms of commits: once a submission contains acceleration
+/// structure commands, every command buffer of that submission, and of every
+/// later submission on the queue, waits, before it starts executing, on the
+/// value the previous chained command buffer signals when its commands
+/// complete, and signals a fresh value after its own commands. Chaining whole
+/// submissions closes the exemption against all earlier work; values are
+/// assigned and encoded under the enclosing mutex, which `submit` holds until
+/// the command buffers are committed, so every wait references a value whose
+/// command buffer has been or is being committed and therefore will signal. A
+/// command buffer dropped without submission never takes part, so no wait can
+/// outlive the command buffer that satisfies it.
+#[derive(Debug, Default)]
+struct AccelerationStructureSync {
+    /// The queue-wide event, created on first use. Acceleration structure
+    /// commands only exist on hardware and OS versions where `MTLEvent` is
+    /// available.
+    event: Option<Retained<ProtocolObject<dyn MTLEvent>>>,
+    /// The value the next chained command buffer must wait on; 0 means there
+    /// is no acceleration structure work on the queue yet, so no submission
+    /// is chained.
+    last_signaled_value: u64,
 }
 
 pub struct Device {
@@ -540,7 +582,62 @@ impl crate::Queue for Queue {
         _surface_textures: &[&SurfaceTexture],
         (signal_fence, signal_value): (&Fence, crate::FenceValue),
     ) -> Result<(), crate::DeviceError> {
-        autoreleasepool(|_| {
+        autoreleasepool(|_| -> Result<(), crate::DeviceError> {
+            // Link command buffers into the commit-order chain (see
+            // `AccelerationStructureSync`). The mutex is held until the
+            // command buffers are committed so that a concurrent submission
+            // cannot commit between this submission's value assignments and
+            // its commits.
+            let mut acceleration_structure_sync = self.shared.acceleration_structure_sync.lock();
+            // Metal exempts acceleration structure commands from the
+            // back-to-back execution of command buffers committed in order,
+            // so an acceleration structure build is not ordered against any
+            // earlier command buffer: not even against a copy in the same
+            // submission of data the build consumes (for example the
+            // instance buffer of a top level acceleration structure, which
+            // wgpu-core encodes onto an internal command buffer of the same
+            // submission). The event chain therefore serializes whole
+            // command buffers from the first submission that contains
+            // acceleration structure commands onward: every command buffer
+            // of such a submission waits on the value the previous chained
+            // command buffer signals at completion, which orders the
+            // acceleration structure commands against all earlier work on
+            // the queue, and signals a fresh value that later submissions
+            // wait on in turn.
+            let chain_entire_submission = acceleration_structure_sync.last_signaled_value > 0
+                || command_buffers
+                    .iter()
+                    .any(|cmd_buffer| cmd_buffer.contains_acceleration_structure_commands);
+            for cmd_buffer in command_buffers {
+                if !chain_entire_submission {
+                    continue;
+                }
+                let event = match acceleration_structure_sync.event.clone() {
+                    Some(event) => event,
+                    None => {
+                        let event = self
+                            .shared
+                            .raw
+                            .device()
+                            .newEvent()
+                            .ok_or(crate::DeviceError::OutOfMemory)?;
+                        acceleration_structure_sync.event = Some(event.clone());
+                        event
+                    }
+                };
+                if acceleration_structure_sync.last_signaled_value > 0 {
+                    cmd_buffer.raw.encodeWaitForEvent_value(
+                        event.as_ref(),
+                        acceleration_structure_sync.last_signaled_value,
+                    );
+                }
+                acceleration_structure_sync.last_signaled_value += 1;
+                cmd_buffer.raw.encodeSignalEvent_value(
+                    event.as_ref(),
+                    acceleration_structure_sync.last_signaled_value,
+                );
+            }
+
             let extra_command_buffer = {
                 let completed_value = Arc::clone(&signal_fence.completed_value);
                 let block = block2::RcBlock::new(move |_cmd_buf| {
@@ -592,8 +689,9 @@ impl crate::Queue for Queue {
             if let Some(raw) = extra_command_buffer {
                 raw.commit();
             }
-        });
-        Ok(())
+
+            Ok(())
+        })
     }
     unsafe fn present(
         &self,
@@ -1084,20 +1182,21 @@ struct CommandState {
     blit: Option<Retained<ProtocolObject<dyn MTLBlitCommandEncoder>>>,
     acceleration_structure_builder:
         Option<Retained<ProtocolObject<dyn MTLAccelerationStructureCommandEncoder>>>,
-    /// Fence used to order acceleration structure encoders split by
-    /// `CommandEncoder::split_acceleration_structure_builder`. Created lazily
-    /// and kept alive for the lifetime of the encoder. Command buffers
-    /// created with unretained references do not retain this fence, so the
-    /// encoder (which owns it) must be kept alive until its submitted
-    /// command buffers have finished executing.
-    acceleration_structure_fence: Option<Retained<ProtocolObject<dyn MTLFence>>>,
-    /// Whether the next acceleration structure encoder must wait on
-    /// [`Self::acceleration_structure_fence`] before encoding any commands.
-    pending_acceleration_structure_fence_wait: bool,
+    /// Whether this command buffer has encoded any acceleration structure
+    /// commands. `Queue::submit` orders command buffers with acceleration
+    /// structure commands against each other based on this.
+    contains_acceleration_structure_commands: bool,
     /// Whether the current acceleration structure encoder has encoded any
-    /// builds, i.e. whether commands consuming their results must split the
-    /// encoder first.
-    acceleration_structure_builder_has_builds: bool,
+    /// acceleration structure commands, i.e. whether a later
+    /// `read_acceleration_structure_compact_size` must close the encoder
+    /// first. wgpu-core emits a barrier between all other pairs of
+    /// acceleration structure commands, which closes the encoder anyway.
+    acceleration_structure_builder_has_commands: bool,
+    /// Whether an earlier acceleration structure encoder in this command
+    /// buffer updated `CommandEncoder::acceleration_structure_fence` and no
+    /// encoder has waited on it yet. The next acceleration structure encoder
+    /// in this command buffer must wait before encoding commands.
+    acceleration_structure_fence_updated: bool,
     render: Option<Retained<ProtocolObject<dyn MTLRenderCommandEncoder>>>,
     compute: Option<Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>>,
     raw_primitive_type: MTLPrimitiveType,
@@ -1137,6 +1236,13 @@ pub struct CommandEncoder {
     shared: Arc<AdapterShared>,
     queue_shared: Arc<QueueShared>,
     raw_cmd_buf: Option<Retained<ProtocolObject<dyn MTLCommandBuffer>>>,
+    /// Fence ordering the acceleration structure encoders of this command
+    /// buffer against each other. It is created on first use and belongs to
+    /// this command buffer alone: Metal requires the command buffer whose
+    /// pass updates a fence to be committed before the command buffer whose
+    /// pass waits on it, so a fence shared with other command buffers would
+    /// reintroduce an encode-order requirement that wgpu does not guarantee.
+    acceleration_structure_fence: Option<Retained<ProtocolObject<dyn MTLFence>>>,
     state: CommandState,
     temp: Temp,
     counters: Arc<wgt::HalCounters>,
@@ -1157,6 +1263,11 @@ unsafe impl Sync for CommandEncoder {}
 pub struct CommandBuffer {
     raw: Retained<ProtocolObject<dyn MTLCommandBuffer>>,
     queue_shared: Arc<QueueShared>,
+    /// Whether this command buffer encoded any acceleration structure
+    /// commands. A submission containing such a command buffer is chained
+    /// whole by `Queue::submit` based on this. See
+    /// `AccelerationStructureSync`.
+    contains_acceleration_structure_commands: bool,
 }
 
 impl crate::DynCommandBuffer for CommandBuffer {}

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -1459,6 +1459,7 @@ bitflags_array! {
         ///
         /// Supported platforms:
         /// - DX12
+        /// - Metal
         /// - Vulkan
         ///
         /// This is a native only feature.

--- a/wgpu-types/src/features.rs
+++ b/wgpu-types/src/features.rs
@@ -1308,6 +1308,12 @@ bitflags_array! {
         /// Supported platforms:
         /// - Vulkan
         ///
+        /// Unsupported platforms:
+        /// - Metal (blocked upstream: MSL ray queries expose no intersection vertex
+        ///   position; the `metal::raytracing` API has no equivalent of
+        ///   `rayQueryGetIntersectionVertexPosition`)
+        /// - DX12
+        ///
         /// This is a native only feature
         ///
         /// [`AccelerationStructureFlags::ALLOW_RAY_HIT_VERTEX_RETURN`]: super::AccelerationStructureFlags::ALLOW_RAY_HIT_VERTEX_RETURN
@@ -1332,6 +1338,7 @@ bitflags_array! {
         /// Supported platforms
         /// - Vulkan
         /// - DX12
+        /// - Metal
         ///
         /// [BlasTriangleGeometrySizeDescriptor::vertex_format]: super::BlasTriangleGeometrySizeDescriptor
         #[name("wgpu-extended-acceleration-structure-vertex-formats")]

--- a/wgpu-types/src/vertex.rs
+++ b/wgpu-types/src/vertex.rs
@@ -265,6 +265,9 @@ impl VertexFormat {
             // https://microsoft.github.io/DirectX-Specs/d3d/Raytracing.html#d3d12_raytracing_geometry_triangles_desc
             //
             // Vulkan does not express a minimum stride.
+            //
+            // Metal instead requires the stride to cover the full format size
+            // (8 bytes), and builds with smaller strides are rejected there.
             Self::Float16x4 | Self::Snorm16x4 => 6,
             _ => unreachable!(),
         }

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -392,6 +392,11 @@ impl Device {
     /// - `hal_buffer` must be created respecting `desc`
     /// - `hal_buffer` must be initialized
     /// - `hal_buffer` must not have zero size
+    /// - On Metal, the buffer's resolved hazard tracking mode must be tracked,
+    ///   or the caller must independently synchronize all conflicting accesses,
+    ///   including compute/blit writes before acceleration-structure input reads.
+    ///   wgpu's resource-use declarations do not synchronize untracked imports,
+    ///   and its AS fence does not cover preceding non-AS producers.
     #[cfg(wgpu_core)]
     #[must_use]
     pub unsafe fn create_buffer_from_hal<A: hal::Api>(


### PR DESCRIPTION
**Connections**

Depends on #10288 (stacked).

**Description**

Two Metal feature completions, one commit each:

**1. `EXTENDED_ACCELERATION_STRUCTURE_VERTEX_FORMATS`** — Metal's geometry descriptors accept any `MTLAttributeFormat`, so `Float16x4`, `Snorm16x4`, `Float16x2`, `Snorm16x2`, and `Float32x2` BLAS vertex formats work wherever ray tracing is supported. One divergence: Metal requires the vertex stride to cover the full attribute size, stricter than wgpu's cross-API minimum (DirectX allows packed 6-byte strides for 16-bit 4-component formats), so the core build path validates the stride against the format size on Metal and documents why (`wgpu-types/src/vertex.rs`, `wgpu-core` build validation).

**2. `ACCELERATION_STRUCTURE_BINDING_ARRAY`** — Metal has no native array-of-acceleration-structure binding, so naga emits `binding_array<acceleration_structure>` as an argument-buffer-wrapped `instance_acceleration_structure*` buffer binding (MSL 2.4), and the backend encodes the array with an `MTLArgumentEncoder` at bind group creation. Bind groups carrying acceleration structure arrays are marked so render/compute passes declare their resource usage; `map_resource_usage` maps AS usage to `MTLResourceUsageRead`. `max_acceleration_structures_per_shader_stage` rises from 1 to 8 — one buffer binding point each, conservatively derived from Metal's 31-slot buffer table minus the existing storage (8) and uniform (12) reservations; it is a derived budget, not a published Apple limit. Binding array limits are reported when ray tracing is supported.

`EXPERIMENTAL_RAY_HIT_VERTEX_RETURN` remains Unsupported on Metal (and DX12): MSL ray queries expose no intersection vertex position — the `metal::raytracing` API has no equivalent of `rayQueryGetIntersectionVertexPosition` (documented in `features.rs`).

**Testing**

All on Apple M4 Max (macOS, Metal), `cargo nextest`:

- `ray_tracing::extra_formats::extra_formats_query`: builds and traces BLASes in all five extended formats, verifying intersection distances match `Float32x3` baselines.
- `ray_tracing::as_build`: packed 6-byte stride for `Snorm16x4` rejected on Metal with `VertexStrideTooSmall`, 8-byte stride accepted; existing misalignment/too-small checks intact.
- `binding_array::tlas::binding_array_tlas`: constant index `tlas_array[1]`.
- `binding_array::tlas::binding_array_tlas_dynamic_index` (new): two TLAS over the same BLAS with different instance transforms (hit at t=4 vs t=6), indexed by a storage-buffer-loaded (non-uniform) index; asserts the committed hit lands at the transform of the selected element — end-to-end coverage of naga's `ACCELERATION_STRUCTURE_BINDING_ARRAY` capability gate on hardware.
- Full `wgpu-gpu` nextest suite: 328 passed / 2 failed / 6 skipped; the two failures are `passthrough::{binary,source}`, which require DirectX `dxc` on PATH and fail identically on trunk in this macOS environment (environmental, not regressions).
- `ray_traced_triangle`, `ray_scene` examples run clean.
- `cargo clippy -p wgpu-hal -p wgpu-types` clean; `cargo fmt` clean (workspace + tests crate).

**Squash or Rebase?**

Rebase — two commits, each independently bisectable (features advertise/formats; binding arrays).

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
