### PR TITLE
[metal] synchronize acceleration structure builds with a seeded fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 - Fix crash on fence creation when running in a MacOS Seatbelt sandbox. By @wumpf in [#9415](https://github.com/gfx-rs/wgpu/pull/9415)
 - Fixed structure field names incorrectly ignoring reserved keywords in the Metal (MSL) backend. By @39ali [#9379](https://github.com/gfx-rs/wgpu/pull/9379).
 - Restore the `Queue::as_raw` method, which was removed without good reason in v29. It now returns `&ProtocolObject<dyn MTLCommandQueue>`. By @andyleiserson in [#9560](https://github.com/gfx-rs/wgpu/pull/9560).
+- Fixed missing synchronization between acceleration structure builds, which could cause TLAS builds to consume BLASes that were still building, producing incorrect intersection results or GPU hangs. By @jtbirdsell in [#9645](https://github.com/gfx-rs/wgpu/pull/9645).
 
 ### Dependency Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,8 +241,8 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 #### Metal
 
-- Wake Metal completion waits from native completed handlers instead of polling at one-millisecond intervals.
-- Order Metal acceleration-structure builds and ray-query passes with encoder fences, without serializing unrelated later submissions. Reserve native command-buffer capacity for internal submissions and report ray-query fence allocation failure during fallible encoder setup.
+- Wake Metal completion waits from native completed handlers instead of polling at one-millisecond intervals. By @acoliver in [#10292](https://github.com/gfx-rs/wgpu/pull/10292).
+- Order Metal acceleration-structure builds and ray-query passes with encoder fences, without serializing unrelated later submissions. Reserve native command-buffer capacity for internal submissions and report ray-query fence allocation failure during fallible encoder setup. By @acoliver in [#10292](https://github.com/gfx-rs/wgpu/pull/10292).
 - Fix crash on fence creation when running in a MacOS Seatbelt sandbox. By @wumpf in [#9415](https://github.com/gfx-rs/wgpu/pull/9415)
 - Fixed structure field names incorrectly ignoring reserved keywords in the Metal (MSL) backend. By @39ali [#9379](https://github.com/gfx-rs/wgpu/pull/9379).
 - Restore the `Queue::as_raw` method, which was removed without good reason in v29. It now returns `&ProtocolObject<dyn MTLCommandQueue>`. By @andyleiserson in [#9560](https://github.com/gfx-rs/wgpu/pull/9560).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,8 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 #### Metal
 
+- Wake Metal completion waits from native completed handlers instead of polling at one-millisecond intervals.
+- Order Metal acceleration-structure builds and ray-query passes with encoder fences, without serializing unrelated later submissions. Reserve native command-buffer capacity for internal submissions and report ray-query fence allocation failure during fallible encoder setup.
 - Fix crash on fence creation when running in a MacOS Seatbelt sandbox. By @wumpf in [#9415](https://github.com/gfx-rs/wgpu/pull/9415)
 - Fixed structure field names incorrectly ignoring reserved keywords in the Metal (MSL) backend. By @39ali [#9379](https://github.com/gfx-rs/wgpu/pull/9379).
 - Restore the `Queue::as_raw` method, which was removed without good reason in v29. It now returns `&ProtocolObject<dyn MTLCommandQueue>`. By @andyleiserson in [#9560](https://github.com/gfx-rs/wgpu/pull/9560).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,6 +238,7 @@ objc2-metal = { version = "0.3.2", default-features = false, features = [
     "MTLDevice",
     "MTLDrawable",
     "MTLEvent",
+    "MTLFence",
     "MTLLibrary",
     "MTLPipeline",
     "MTLPixelFormat",

--- a/tests/tests/wgpu-gpu/main.rs
+++ b/tests/tests/wgpu-gpu/main.rs
@@ -11,6 +11,7 @@ mod regression {
     pub mod issue_6467;
     pub mod issue_6827;
     pub mod issue_9115;
+    pub mod issue_9215;
 }
 
 mod adapter;
@@ -140,6 +141,7 @@ fn all_tests() -> Vec<wgpu_test::GpuTestInitializer> {
     regression::issue_6467::all_tests(&mut tests);
     regression::issue_6827::all_tests(&mut tests);
     regression::issue_9115::all_tests(&mut tests);
+    regression::issue_9215::all_tests(&mut tests);
     render_pass_ownership::all_tests(&mut tests);
     render_target::all_tests(&mut tests);
     resource_descriptor_accessor::all_tests(&mut tests);

--- a/tests/tests/wgpu-gpu/regression/issue_9215.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_9215.rs
@@ -1,0 +1,709 @@
+use std::mem::size_of;
+
+use wgpu::util::{BufferInitDescriptor, DeviceExt};
+use wgpu_macros::gpu_test;
+use wgpu_test::{GpuTestConfiguration, GpuTestInitializer, TestParameters, TestingContext};
+
+fn acceleration_structure_limits() -> wgpu::Limits {
+    wgpu::Limits::default().using_minimum_supported_acceleration_structure_values()
+}
+
+pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
+    vec.push(BLAS_AND_TLAS_IN_SAME_COMMAND_BUFFER);
+    vec.push(BLAS_AND_TLAS_IN_SEPARATE_COMMAND_BUFFERS);
+    vec.push(ENCODER_DISCARDED_AFTER_BLAS_BUILD);
+    vec.push(COMMAND_BUFFER_DROPPED_WITHOUT_SUBMIT);
+    vec.push(BLIT_BETWEEN_BUILDS_IN_SAME_COMMAND_BUFFER);
+    vec.push(COMPUTE_PASS_BETWEEN_BUILDS_IN_SAME_COMMAND_BUFFER);
+    vec.push(COMPACTED_BLAS_IN_PENDING_WRITES);
+    vec.push(ENCODER_DISCARDED_AFTER_PUBLISHED_CLOSE);
+    vec.push(COMMAND_BUFFER_DROPPED_AFTER_PUBLISHED_CLOSE);
+}
+
+// The failures are races, so a pass is evidence rather than proof. On the
+// hardware this bug reproduces on (Apple M4 Max), the unfixed failure rate of
+// the affected configurations is tens of percent per iteration, which 40
+// repetitions turn into a strong signal while keeping the test fast.
+const ITERATIONS: u32 = 40;
+
+// `rayQueryGetCommittedIntersection().kind` for a committed triangle hit.
+const TRIANGLE_HIT_KIND: u32 = 1;
+
+// On Metal, acceleration structure builds are not ordered against each other
+// within an encoder, nor across command buffers committed back to back, so a
+// TLAS build could consume a BLAS that is still building. The ray query below
+// then commits no intersection (kind 0) instead of the triangle (kind 1).
+//
+// Each iteration builds a fresh BLAS and a TLAS referencing it, traces a ray
+// straight up through the triangle, and reads back the committed intersection
+// kind.
+//
+// See <https://github.com/gfx-rs/wgpu/issues/9215>.
+
+struct TraceSetup {
+    vertex_buffer: wgpu::Buffer,
+    blas_size: wgpu::BlasTriangleGeometrySizeDescriptor,
+    blas: wgpu::Blas,
+    tlas: wgpu::Tlas,
+    hit_buffer: wgpu::Buffer,
+    read_back: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+}
+
+fn create_trace_setup(ctx: &TestingContext, pipeline: &wgpu::ComputePipeline) -> TraceSetup {
+    let vertex_buffer = ctx.device.create_buffer_init(&BufferInitDescriptor {
+        label: Some("BLAS vertices"),
+        contents: bytemuck::cast_slice(&[[1.0_f32, 1.0, 0.0], [-1.0, 1.0, -1.0], [-1.0, 1.0, 1.0]]),
+        usage: wgpu::BufferUsages::BLAS_INPUT,
+    });
+
+    let blas_size = wgpu::BlasTriangleGeometrySizeDescriptor {
+        vertex_format: wgpu::VertexFormat::Float32x3,
+        vertex_count: 3,
+        index_format: None,
+        index_count: None,
+        flags: wgpu::AccelerationStructureGeometryFlags::OPAQUE,
+    };
+
+    let blas_flags = wgpu::AccelerationStructureFlags::PREFER_FAST_BUILD;
+    let blas = ctx.device.create_blas(
+        &wgpu::CreateBlasDescriptor {
+            label: None,
+            flags: blas_flags,
+            update_mode: wgpu::AccelerationStructureUpdateMode::Build,
+        },
+        wgpu::BlasGeometrySizeDescriptors::Triangles {
+            descriptors: vec![blas_size.clone()],
+        },
+    );
+    let mut tlas = ctx.device.create_tlas(&wgpu::CreateTlasDescriptor {
+        label: None,
+        max_instances: 1,
+        flags: wgpu::AccelerationStructureFlags::PREFER_FAST_BUILD,
+        update_mode: wgpu::AccelerationStructureUpdateMode::Build,
+    });
+
+    tlas[0] = Some(wgpu::TlasInstance::new(
+        &blas,
+        [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0,
+        ],
+        0,
+        0xff,
+    ));
+
+    let hit_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("hit kind"),
+        size: size_of::<u32>() as wgpu::BufferAddress,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+
+    let read_back = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("hit kind readback"),
+        size: hit_buffer.size(),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: None,
+        layout: &pipeline.get_bind_group_layout(0),
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: tlas.as_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: hit_buffer.as_entire_binding(),
+            },
+        ],
+    });
+
+    TraceSetup {
+        vertex_buffer,
+        blas_size,
+        blas,
+        tlas,
+        hit_buffer,
+        read_back,
+        bind_group,
+    }
+}
+
+fn blas_build_entry(setup: &TraceSetup) -> wgpu::BlasBuildEntry<'_> {
+    wgpu::BlasBuildEntry {
+        blas: &setup.blas,
+        geometry: wgpu::BlasGeometries::TriangleGeometries(vec![wgpu::BlasTriangleGeometry {
+            size: &setup.blas_size,
+            vertex_buffer: &setup.vertex_buffer,
+            first_vertex: 0,
+            vertex_stride: 12,
+            index_buffer: None,
+            first_index: None,
+            transform_buffer: None,
+            transform_buffer_offset: None,
+        }]),
+    }
+}
+
+// Records the TLAS build, the ray query, and the readback copy onto `encoder`.
+fn record_tlas_trace_and_copy(
+    setup: &TraceSetup,
+    pipeline: &wgpu::ComputePipeline,
+    encoder: &mut wgpu::CommandEncoder,
+) {
+    encoder.build_acceleration_structures([], [&setup.tlas]);
+
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, &setup.bind_group, &[]);
+        pass.dispatch_workgroups(1, 1, 1);
+    }
+
+    encoder.copy_buffer_to_buffer(
+        &setup.hit_buffer,
+        0,
+        &setup.read_back,
+        0,
+        setup.hit_buffer.size(),
+    );
+}
+
+async fn read_hit_kind(ctx: &TestingContext, setup: &TraceSetup) -> u32 {
+    let slice = setup.read_back.slice(..);
+    slice.map_async(wgpu::MapMode::Read, Result::unwrap);
+    ctx.async_poll(wgpu::PollType::wait_indefinitely())
+        .await
+        .unwrap();
+
+    let hit_kind = {
+        let view = slice.get_mapped_range().unwrap();
+        u32::from_ne_bytes(view[..size_of::<u32>()].try_into().unwrap())
+    };
+    setup.read_back.unmap();
+    hit_kind
+}
+
+fn create_ray_query_pipeline(ctx: &TestingContext) -> wgpu::ComputePipeline {
+    let shader = ctx
+        .device
+        .create_shader_module(wgpu::include_wgsl!("issue_9215.wgsl"));
+    ctx.device
+        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: None,
+            layout: None,
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        })
+}
+
+async fn run_iterations(ctx: TestingContext, separate_command_buffers: bool) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    for i in 0..ITERATIONS {
+        let setup = create_trace_setup(&ctx, &pipeline);
+
+        if separate_command_buffers {
+            let mut blas_encoder = ctx
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            let blas_entry = blas_build_entry(&setup);
+            blas_encoder.build_acceleration_structures([&blas_entry], []);
+
+            let mut tlas_encoder = ctx
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            record_tlas_trace_and_copy(&setup, &pipeline, &mut tlas_encoder);
+
+            ctx.queue
+                .submit([blas_encoder.finish(), tlas_encoder.finish()]);
+        } else {
+            let mut encoder = ctx
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            let blas_entry = blas_build_entry(&setup);
+            encoder.build_acceleration_structures([&blas_entry], []);
+            record_tlas_trace_and_copy(&setup, &pipeline, &mut encoder);
+
+            ctx.queue.submit([encoder.finish()]);
+        }
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+// A BLAS build is recorded and then thrown away: either by discarding the
+// encoder, or by finishing and dropping the command buffer without submitting
+// it. The consumer below is fully encoded before the producer goes away, but
+// the producer's encoder is not: wgpu-core recycles hal command encoders, so
+// any per-command-buffer state the producer leaves behind is handed to a
+// later recording. The submission here must run its own acceleration
+// structure work correctly regardless of what the abandoned recording did.
+async fn run_iterations_with_abandoned_producer(ctx: TestingContext, discard_encoder: bool) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    for i in 0..ITERATIONS {
+        let setup = create_trace_setup(&ctx, &pipeline);
+
+        let mut producer = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        producer.build_acceleration_structures([&blas_entry], []);
+
+        let mut consumer = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        consumer.build_acceleration_structures([&blas_entry], []);
+        record_tlas_trace_and_copy(&setup, &pipeline, &mut consumer);
+
+        if discard_encoder {
+            drop(producer);
+        } else {
+            drop(producer.finish());
+        }
+
+        ctx.queue.submit([consumer.finish()]);
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+// A BLAS build followed by a blit is recorded and then thrown away: either by
+// discarding the encoder, or by finishing and dropping the command buffer
+// without submitting it. The blit forces the published close of the build's
+// acceleration structure encoder, so the abandoned recording leaves behind
+// encoder state saying a fence was updated and acceleration structure
+// commands are present, with no consumer left in the recording. The consumer
+// is only recorded after the producer is gone, so it records on the
+// producer's recycled encoder: leftover state would make its first
+// acceleration structure encoder wait on a fence whose update was never
+// committed. The submission must still produce a triangle hit.
+async fn run_iterations_with_published_then_abandoned_producer(
+    ctx: TestingContext,
+    discard_encoder: bool,
+) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    let blit_src = ctx.device.create_buffer_init(&BufferInitDescriptor {
+        label: Some("producer blit source"),
+        contents: &[0; 16],
+        usage: wgpu::BufferUsages::COPY_SRC,
+    });
+    let blit_dst = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("producer blit destination"),
+        size: blit_src.size(),
+        usage: wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    for i in 0..ITERATIONS {
+        let setup = create_trace_setup(&ctx, &pipeline);
+
+        let mut producer = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        producer.build_acceleration_structures([&blas_entry], []);
+        producer.copy_buffer_to_buffer(&blit_src, 0, &blit_dst, 0, blit_src.size());
+
+        if discard_encoder {
+            drop(producer);
+        } else {
+            drop(producer.finish());
+        }
+
+        // Recorded only after the producer is gone, on the producer's
+        // recycled encoder.
+        let mut consumer = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        consumer.build_acceleration_structures([&blas_entry], []);
+        record_tlas_trace_and_copy(&setup, &pipeline, &mut consumer);
+
+        ctx.queue.submit([consumer.finish()]);
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+// A blit encoded between two builds closes the acceleration structure encoder
+// they would otherwise share; the builds must still be ordered.
+async fn run_iterations_with_blit_between_builds(ctx: TestingContext) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    let blit_src = ctx.device.create_buffer_init(&BufferInitDescriptor {
+        label: Some("blit source"),
+        contents: &[0; 16],
+        usage: wgpu::BufferUsages::COPY_SRC,
+    });
+    let blit_dst = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("blit destination"),
+        size: blit_src.size(),
+        usage: wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    for i in 0..ITERATIONS {
+        let setup = create_trace_setup(&ctx, &pipeline);
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        encoder.build_acceleration_structures([&blas_entry], []);
+
+        encoder.copy_buffer_to_buffer(&blit_src, 0, &blit_dst, 0, blit_src.size());
+
+        encoder.build_acceleration_structures([], [&setup.tlas]);
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &setup.bind_group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+        encoder.copy_buffer_to_buffer(
+            &setup.hit_buffer,
+            0,
+            &setup.read_back,
+            0,
+            setup.hit_buffer.size(),
+        );
+
+        ctx.queue.submit([encoder.finish()]);
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+// A compute pass encoded between two builds closes the acceleration structure
+// encoder they would otherwise share; the builds must still be ordered.
+async fn run_iterations_with_compute_pass_between_builds(ctx: TestingContext) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    let filler_pipeline = {
+        let shader = ctx
+            .device
+            .create_shader_module(wgpu::include_wgsl!("issue_9215_fill.wgsl"));
+        ctx.device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: None,
+                layout: None,
+                module: &shader,
+                entry_point: Some("main"),
+                compilation_options: Default::default(),
+                cache: None,
+            })
+    };
+    let scratch = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("filler scratch"),
+        size: size_of::<u32>() as wgpu::BufferAddress,
+        usage: wgpu::BufferUsages::STORAGE,
+        mapped_at_creation: false,
+    });
+    let filler_bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: None,
+        layout: &filler_pipeline.get_bind_group_layout(0),
+        entries: &[wgpu::BindGroupEntry {
+            binding: 0,
+            resource: scratch.as_entire_binding(),
+        }],
+    });
+
+    for i in 0..ITERATIONS {
+        let setup = create_trace_setup(&ctx, &pipeline);
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        encoder.build_acceleration_structures([&blas_entry], []);
+
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&filler_pipeline);
+            pass.set_bind_group(0, &filler_bind_group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+
+        encoder.build_acceleration_structures([], [&setup.tlas]);
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &setup.bind_group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+        encoder.copy_buffer_to_buffer(
+            &setup.hit_buffer,
+            0,
+            &setup.read_back,
+            0,
+            setup.hit_buffer.size(),
+        );
+
+        ctx.queue.submit([encoder.finish()]);
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+// A compacted BLAS is produced through the queue's pending writes: the
+// compaction copy is encoded onto the internal pending-writes encoder, which
+// is committed ahead of the command buffers of the next submission. A queue
+// write encoded onto the same encoder closes the acceleration structure
+// encoder the compaction copy leaves open, and the consuming TLAS build in
+// the next submission must be ordered after the copy.
+async fn run_iterations_with_compacted_blas_in_pending_writes(ctx: TestingContext) {
+    let pipeline = create_ray_query_pipeline(&ctx);
+
+    let scratch = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("queue write scratch"),
+        size: 16,
+        usage: wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    for i in 0..ITERATIONS {
+        let mut setup = create_trace_setup(&ctx, &pipeline);
+
+        // The BLAS must allow compaction for `compact_blas` to accept it.
+        let blas = ctx.device.create_blas(
+            &wgpu::CreateBlasDescriptor {
+                label: None,
+                flags: wgpu::AccelerationStructureFlags::PREFER_FAST_BUILD
+                    | wgpu::AccelerationStructureFlags::ALLOW_COMPACTION,
+                update_mode: wgpu::AccelerationStructureUpdateMode::Build,
+            },
+            wgpu::BlasGeometrySizeDescriptors::Triangles {
+                descriptors: vec![setup.blas_size.clone()],
+            },
+        );
+        setup.blas = blas;
+        setup.tlas[0] = Some(wgpu::TlasInstance::new(
+            &setup.blas,
+            [
+                1.0, 0.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, 0.0, //
+                0.0, 0.0, 1.0, 0.0,
+            ],
+            0,
+            0xff,
+        ));
+
+        // Build the BLAS and wait for it so it can be prepared for compaction.
+        let mut blas_encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        let blas_entry = blas_build_entry(&setup);
+        blas_encoder.build_acceleration_structures([&blas_entry], []);
+        ctx.queue.submit([blas_encoder.finish()]);
+
+        let (send, recv) = std::sync::mpsc::channel();
+        setup.blas.prepare_compaction_async(move |res| {
+            res.unwrap();
+            send.send(()).unwrap();
+        });
+        ctx.async_poll(wgpu::PollType::wait_indefinitely())
+            .await
+            .unwrap();
+        recv.recv().unwrap();
+        assert!(setup.blas.ready_for_compaction());
+
+        // Encodes the compaction copy onto the pending-writes encoder.
+        let compacted = ctx.queue.compact_blas(&setup.blas);
+
+        // Encodes a blit onto the same pending-writes encoder, closing the
+        // acceleration structure encoder the compaction copy left open.
+        ctx.queue
+            .write_buffer(&scratch, 0, bytemuck::cast_slice(&[0_u32; 4]));
+
+        let mut tlas = ctx.device.create_tlas(&wgpu::CreateTlasDescriptor {
+            label: None,
+            max_instances: 1,
+            flags: wgpu::AccelerationStructureFlags::PREFER_FAST_BUILD,
+            update_mode: wgpu::AccelerationStructureUpdateMode::Build,
+        });
+        tlas[0] = Some(wgpu::TlasInstance::new(
+            &compacted,
+            [
+                1.0, 0.0, 0.0, 0.0, //
+                0.0, 1.0, 0.0, 0.0, //
+                0.0, 0.0, 1.0, 0.0,
+            ],
+            0,
+            0xff,
+        ));
+
+        let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &pipeline.get_bind_group_layout(0),
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: tlas.as_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: setup.hit_buffer.as_entire_binding(),
+                },
+            ],
+        });
+
+        let mut consumer = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+        consumer.build_acceleration_structures([], [&tlas]);
+        {
+            let mut pass = consumer.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+        consumer.copy_buffer_to_buffer(
+            &setup.hit_buffer,
+            0,
+            &setup.read_back,
+            0,
+            setup.hit_buffer.size(),
+        );
+
+        // Commits the pending writes (compaction copy and queue write) ahead
+        // of the consumer command buffer.
+        ctx.queue.submit([consumer.finish()]);
+
+        let hit_kind = read_hit_kind(&ctx, &setup).await;
+        assert_eq!(
+            hit_kind, TRIANGLE_HIT_KIND,
+            "iteration {i}: ray query did not commit a triangle hit"
+        );
+    }
+}
+
+#[gpu_test]
+static BLAS_AND_TLAS_IN_SAME_COMMAND_BUFFER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move { run_iterations(ctx, false).await });
+
+#[gpu_test]
+static BLAS_AND_TLAS_IN_SEPARATE_COMMAND_BUFFERS: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .limits(acceleration_structure_limits())
+                .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+        )
+        .run_async(|ctx| async move { run_iterations(ctx, true).await });
+
+#[gpu_test]
+static ENCODER_DISCARDED_AFTER_BLAS_BUILD: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move { run_iterations_with_abandoned_producer(ctx, true).await });
+
+#[gpu_test]
+static COMMAND_BUFFER_DROPPED_WITHOUT_SUBMIT: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move { run_iterations_with_abandoned_producer(ctx, false).await });
+
+#[gpu_test]
+static ENCODER_DISCARDED_AFTER_PUBLISHED_CLOSE: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move {
+        run_iterations_with_published_then_abandoned_producer(ctx, true).await
+    });
+
+#[gpu_test]
+static COMMAND_BUFFER_DROPPED_AFTER_PUBLISHED_CLOSE: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .limits(acceleration_structure_limits())
+                .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+        )
+        .run_async(|ctx| async move {
+            run_iterations_with_published_then_abandoned_producer(ctx, false).await
+        });
+
+#[gpu_test]
+static BLIT_BETWEEN_BUILDS_IN_SAME_COMMAND_BUFFER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .limits(acceleration_structure_limits())
+                .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+        )
+        .run_async(|ctx| async move { run_iterations_with_blit_between_builds(ctx).await });
+
+#[gpu_test]
+static COMPUTE_PASS_BETWEEN_BUILDS_IN_SAME_COMMAND_BUFFER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .limits(acceleration_structure_limits())
+                .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+        )
+        .run_async(|ctx| async move { run_iterations_with_compute_pass_between_builds(ctx).await });
+
+#[gpu_test]
+static COMPACTED_BLAS_IN_PENDING_WRITES: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(
+        |ctx| async move { run_iterations_with_compacted_blas_in_pending_writes(ctx).await },
+    );

--- a/tests/tests/wgpu-gpu/regression/issue_9215.rs
+++ b/tests/tests/wgpu-gpu/regression/issue_9215.rs
@@ -1,4 +1,4 @@
-use std::mem::size_of;
+use std::{mem::size_of, time::Duration};
 
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu_macros::gpu_test;
@@ -18,6 +18,9 @@ pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.push(COMPACTED_BLAS_IN_PENDING_WRITES);
     vec.push(ENCODER_DISCARDED_AFTER_PUBLISHED_CLOSE);
     vec.push(COMMAND_BUFFER_DROPPED_AFTER_PUBLISHED_CLOSE);
+    vec.push(RECORD_CONSUMER_BEFORE_PRODUCER);
+    vec.push(REJECT_CONSUMER_SUBMITTED_BEFORE_PRODUCER);
+    vec.push(FIRST_BUILD_AFTER_COMPUTE_UPLOAD);
 }
 
 // The failures are races, so a pass is evidence rather than proof. On the
@@ -96,7 +99,7 @@ fn create_trace_setup(ctx: &TestingContext, pipeline: &wgpu::ComputePipeline) ->
 
     let hit_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("hit kind"),
-        size: size_of::<u32>() as wgpu::BufferAddress,
+        size: 64,
         usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
         mapped_at_creation: false,
     });
@@ -177,13 +180,25 @@ fn record_tlas_trace_and_copy(
 async fn read_hit_kind(ctx: &TestingContext, setup: &TraceSetup) -> u32 {
     let slice = setup.read_back.slice(..);
     slice.map_async(wgpu::MapMode::Read, Result::unwrap);
-    ctx.async_poll(wgpu::PollType::wait_indefinitely())
-        .await
-        .unwrap();
+    ctx.async_poll(wgpu::PollType::Wait {
+        submission_index: None,
+        timeout: Some(Duration::from_secs(30)),
+    })
+    .await
+    .unwrap();
 
     let hit_kind = {
         let view = slice.get_mapped_range().unwrap();
-        u32::from_ne_bytes(view[..size_of::<u32>()].try_into().unwrap())
+        let words: &[u32] = bytemuck::cast_slice(&view);
+        assert_eq!(words[8], 0, "known-miss control");
+        if words[0] == TRIANGLE_HIT_KIND {
+            assert!((f32::from_bits(words[1]) - 1.0).abs() < 1e-5);
+            assert_eq!(&words[2..6], &[0, 0, 0, 0], "hit identifiers");
+            for &barycentric in &words[6..8] {
+                assert!((f32::from_bits(barycentric) - 0.25).abs() < 1e-5);
+            }
+        }
+        words[0]
     };
     setup.read_back.unmap();
     hit_kind
@@ -532,10 +547,13 @@ async fn run_iterations_with_compacted_blas_in_pending_writes(ctx: TestingContex
             res.unwrap();
             send.send(()).unwrap();
         });
-        ctx.async_poll(wgpu::PollType::wait_indefinitely())
-            .await
-            .unwrap();
-        recv.recv().unwrap();
+        ctx.async_poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: Some(Duration::from_secs(30)),
+        })
+        .await
+        .unwrap();
+        recv.recv_timeout(Duration::from_secs(30)).unwrap();
         assert!(setup.blas.ready_for_compaction());
 
         // Encodes the compaction copy onto the pending-writes encoder.
@@ -545,6 +563,25 @@ async fn run_iterations_with_compacted_blas_in_pending_writes(ctx: TestingContex
         // acceleration structure encoder the compaction copy left open.
         ctx.queue
             .write_buffer(&scratch, 0, bytemuck::cast_slice(&[0_u32; 4]));
+
+        // Exercise pending-writes-only retirement as well as same-submit consumption.
+        if i % 2 == 0 {
+            let submission = ctx.queue.submit([]);
+            if i % 4 == 2 {
+                let (send, recv) = std::sync::mpsc::channel();
+                ctx.queue
+                    .on_submitted_work_done(move || send.send(()).unwrap());
+                ctx.async_poll(wgpu::PollType::Wait {
+                    submission_index: Some(submission),
+                    timeout: Some(Duration::from_secs(30)),
+                })
+                .await
+                .unwrap();
+                recv.recv_timeout(Duration::from_secs(30)).unwrap();
+                setup.tlas[0] = None;
+                drop(std::mem::replace(&mut setup.blas, compacted.clone()));
+            }
+        }
 
         let mut tlas = ctx.device.create_tlas(&wgpu::CreateTlasDescriptor {
             label: None,
@@ -707,3 +744,140 @@ static COMPACTED_BLAS_IN_PENDING_WRITES: GpuTestConfiguration = GpuTestConfigura
     .run_async(
         |ctx| async move { run_iterations_with_compacted_blas_in_pending_writes(ctx).await },
     );
+
+#[gpu_test]
+static RECORD_CONSUMER_BEFORE_PRODUCER: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move {
+        let pipeline = create_ray_query_pipeline(&ctx);
+        for separate_submits in [false, true] {
+            for abandon_finished in [false, true] {
+                let setup = create_trace_setup(&ctx, &pipeline);
+                let mut abandoned = ctx.device.create_command_encoder(&Default::default());
+                abandoned.build_acceleration_structures([&blas_build_entry(&setup)], []);
+                let mut consumer = ctx.device.create_command_encoder(&Default::default());
+                record_tlas_trace_and_copy(&setup, &pipeline, &mut consumer);
+                let consumer = consumer.finish();
+                if abandon_finished {
+                    drop(abandoned.finish());
+                } else {
+                    drop(abandoned);
+                }
+                let mut producer = ctx.device.create_command_encoder(&Default::default());
+                producer.build_acceleration_structures([&blas_build_entry(&setup)], []);
+                let producer = producer.finish();
+                if separate_submits {
+                    ctx.queue.submit([producer]);
+                    ctx.queue.submit([consumer]);
+                } else {
+                    ctx.queue.submit([producer, consumer]);
+                }
+                assert_eq!(read_hit_kind(&ctx, &setup).await, TRIANGLE_HIT_KIND);
+
+                // This submission consumes the AS but contains no build commands.
+                let mut query = ctx.device.create_command_encoder(&Default::default());
+                {
+                    let mut pass = query.begin_compute_pass(&Default::default());
+                    pass.set_pipeline(&pipeline);
+                    pass.set_bind_group(0, &setup.bind_group, &[]);
+                    pass.dispatch_workgroups(1, 1, 1);
+                }
+                query.copy_buffer_to_buffer(&setup.hit_buffer, 0, &setup.read_back, 0, 64);
+                ctx.queue.submit([query.finish()]);
+                assert_eq!(read_hit_kind(&ctx, &setup).await, TRIANGLE_HIT_KIND);
+            }
+        }
+    });
+
+#[gpu_test]
+static REJECT_CONSUMER_SUBMITTED_BEFORE_PRODUCER: GpuTestConfiguration =
+    GpuTestConfiguration::new()
+        .parameters(
+            TestParameters::default()
+                .test_features_limits()
+                .limits(acceleration_structure_limits())
+                .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+        )
+        .run_sync(|ctx| {
+            let pipeline = create_ray_query_pipeline(&ctx);
+            for separate_submits in [false, true] {
+                let setup = create_trace_setup(&ctx, &pipeline);
+                let mut consumer = ctx.device.create_command_encoder(&Default::default());
+                consumer.build_acceleration_structures([], [&setup.tlas]);
+                let consumer = consumer.finish();
+                let mut producer = ctx.device.create_command_encoder(&Default::default());
+                producer.build_acceleration_structures([&blas_build_entry(&setup)], []);
+                let producer = producer.finish();
+                // Noop's zero scratch sizes omit build actions, so this needs a native backend.
+                wgpu_test::fail(
+                    &ctx.device,
+                    || {
+                        if separate_submits {
+                            ctx.queue.submit([consumer]);
+                            drop(producer);
+                        } else {
+                            ctx.queue.submit([consumer, producer]);
+                        }
+                    },
+                    Some("is used before it is built"),
+                );
+            }
+        });
+
+#[gpu_test]
+static FIRST_BUILD_AFTER_COMPUTE_UPLOAD: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .test_features_limits()
+            .limits(acceleration_structure_limits())
+            .features(wgpu::Features::EXPERIMENTAL_RAY_QUERY),
+    )
+    .run_async(|ctx| async move {
+        let pipeline = create_ray_query_pipeline(&ctx);
+        let mut setup = create_trace_setup(&ctx, &pipeline);
+        setup.vertex_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("compute generated AS vertices"),
+            size: 36,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::BLAS_INPUT,
+            mapped_at_creation: false,
+        });
+        let shader = ctx
+            .device
+            .create_shader_module(wgpu::include_wgsl!("issue_9215_fill.wgsl"));
+        let generate = ctx
+            .device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: None,
+                layout: None,
+                module: &shader,
+                entry_point: Some("generate_vertices"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+        let group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &generate.get_bind_group_layout(0),
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: setup.vertex_buffer.as_entire_binding(),
+            }],
+        });
+        let mut upload = ctx.device.create_command_encoder(&Default::default());
+        {
+            let mut pass = upload.begin_compute_pass(&Default::default());
+            pass.set_pipeline(&generate);
+            pass.set_bind_group(0, &group, &[]);
+            pass.dispatch_workgroups(1, 1, 1);
+        }
+        ctx.queue.submit([upload.finish()]);
+        let mut build = ctx.device.create_command_encoder(&Default::default());
+        build.build_acceleration_structures([&blas_build_entry(&setup)], []);
+        record_tlas_trace_and_copy(&setup, &pipeline, &mut build);
+        ctx.queue.submit([build.finish()]);
+        assert_eq!(read_hit_kind(&ctx, &setup).await, TRIANGLE_HIT_KIND);
+    });

--- a/tests/tests/wgpu-gpu/regression/issue_9215.wgsl
+++ b/tests/tests/wgpu-gpu/regression/issue_9215.wgsl
@@ -3,18 +3,35 @@ enable wgpu_ray_query;
 @group(0) @binding(0)
 var acc: acceleration_structure;
 
+struct Hit {
+    kind: u32,
+    t: f32,
+    custom: u32,
+    instance: u32,
+    geometry: u32,
+    primitive: u32,
+    barycentrics: vec2f,
+}
+
 @group(0) @binding(1)
-var<storage, read_write> hit_kind: u32;
+var<storage, read_write> hits: array<Hit, 2>;
 
 @compute
 @workgroup_size(1)
 fn main() {
-    var query: ray_query;
-    rayQueryInitialize(
-        &query,
-        acc,
-        RayDesc(0u, 0xffu, 0.0, 10.0, vec3(0.0), vec3(0.0, 1.0, 0.0))
-    );
-    while (rayQueryProceed(&query)) {}
-    hit_kind = rayQueryGetCommittedIntersection(&query).kind;
+    for (var i = 0u; i < 2u; i++) {
+        var query: ray_query;
+        rayQueryInitialize(
+            &query,
+            acc,
+            RayDesc(0u, 0xffu, 0.0, 10.0, vec3f(f32(i) * 4.0, 0.0, 0.0), vec3f(0.0, 1.0, 0.0))
+        );
+        while (rayQueryProceed(&query)) {}
+        let hit = rayQueryGetCommittedIntersection(&query);
+        hits[i].kind = hit.kind;
+        if (hit.kind != 0u) {
+            hits[i] = Hit(hit.kind, hit.t, hit.instance_custom_data, hit.instance_index,
+                hit.geometry_index, hit.primitive_index, hit.barycentrics);
+        }
+    }
 }

--- a/tests/tests/wgpu-gpu/regression/issue_9215.wgsl
+++ b/tests/tests/wgpu-gpu/regression/issue_9215.wgsl
@@ -1,0 +1,20 @@
+enable wgpu_ray_query;
+
+@group(0) @binding(0)
+var acc: acceleration_structure;
+
+@group(0) @binding(1)
+var<storage, read_write> hit_kind: u32;
+
+@compute
+@workgroup_size(1)
+fn main() {
+    var query: ray_query;
+    rayQueryInitialize(
+        &query,
+        acc,
+        RayDesc(0u, 0xffu, 0.0, 10.0, vec3(0.0), vec3(0.0, 1.0, 0.0))
+    );
+    while (rayQueryProceed(&query)) {}
+    hit_kind = rayQueryGetCommittedIntersection(&query).kind;
+}

--- a/tests/tests/wgpu-gpu/regression/issue_9215_fill.wgsl
+++ b/tests/tests/wgpu-gpu/regression/issue_9215_fill.wgsl
@@ -1,0 +1,8 @@
+@group(0) @binding(0)
+var<storage, read_write> scratch: u32;
+
+@compute
+@workgroup_size(1)
+fn main() {
+    scratch = 1u;
+}

--- a/tests/tests/wgpu-gpu/regression/issue_9215_fill.wgsl
+++ b/tests/tests/wgpu-gpu/regression/issue_9215_fill.wgsl
@@ -6,3 +6,14 @@ var<storage, read_write> scratch: u32;
 fn main() {
     scratch = 1u;
 }
+
+@group(0) @binding(0)
+var<storage, read_write> vertices: array<f32>;
+
+@compute @workgroup_size(1)
+fn generate_vertices() {
+    let triangle = array<f32, 9>(1.0, 1.0, 0.0, -1.0, 1.0, -1.0, -1.0, 1.0, 1.0);
+    for (var i = 0u; i < 9u; i++) {
+        vertices[i] = triangle[i];
+    }
+}

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -45,6 +45,9 @@ fn device_class_responds_to(device: &ProtocolObject<dyn MTLDevice>, sel: Sel) ->
 ///
 /// [new command buffer]: https://developer.apple.com/documentation/metal/mtlcommandqueue/makecommandbuffer()?language=objc
 pub(super) const MAX_COMMAND_BUFFERS: usize = 4096;
+// Internal allocations are serialized through commit and need one native slot
+// even when all admitted user recordings remain unsubmitted.
+pub(super) const MAX_UNSUBMITTED_COMMAND_BUFFERS: usize = MAX_COMMAND_BUFFERS - 1;
 
 // Metal has a single buffer limit that we must split across 3 WebGPU limits:
 // The Metal limit is: 31 "Maximum number of entries in the buffer argument table, per graphics or kernel function".
@@ -124,7 +127,7 @@ impl crate::Adapter for super::Adapter {
                 queue: super::Queue {
                     shared: Arc::new(QueueShared {
                         raw: queue,
-                        command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
+                        command_buffer_created_not_submitted: Arc::new(atomic::AtomicUsize::new(0)),
                         acceleration_structure_sync: Mutex::default(),
                     }),
                     timestamp_period,

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -11,6 +11,7 @@ use wgt::{AstcBlock, AstcChannel};
 
 use alloc::{string::ToString as _, sync::Arc, vec::Vec};
 use core::sync::atomic;
+use parking_lot::Mutex;
 
 use crate::metal::QueueShared;
 
@@ -124,6 +125,7 @@ impl crate::Adapter for super::Adapter {
                     shared: Arc::new(QueueShared {
                         raw: queue,
                         command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
+                        acceleration_structure_sync: Mutex::default(),
                     }),
                     timestamp_period,
                 },

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -34,6 +34,9 @@ impl Default for super::CommandState {
         Self {
             blit: None,
             acceleration_structure_builder: None,
+            acceleration_structure_fence: None,
+            pending_acceleration_structure_fence_wait: false,
+            acceleration_structure_builder_has_builds: false,
             render: None,
             compute: None,
             raw_primitive_type: MTLPrimitiveType::Point,
@@ -273,6 +276,14 @@ impl super::CommandEncoder {
                 self.state.acceleration_structure_builder =
                     cmd_buf.accelerationStructureCommandEncoder().to_owned();
             });
+            if self.state.pending_acceleration_structure_fence_wait {
+                self.state.pending_acceleration_structure_fence_wait = false;
+                self.state
+                    .acceleration_structure_builder
+                    .as_ref()
+                    .unwrap()
+                    .waitForFence(self.state.acceleration_structure_fence.as_ref().unwrap());
+            }
         }
         self.state.acceleration_structure_builder.clone().unwrap()
     }
@@ -280,6 +291,27 @@ impl super::CommandEncoder {
     pub(super) fn leave_acceleration_structure_builder(&mut self) {
         if let Some(encoder) = self.state.acceleration_structure_builder.take() {
             encoder.endEncoding();
+            self.state.acceleration_structure_builder_has_builds = false;
+        }
+    }
+
+    /// Ends the current acceleration structure encoder, if any, after
+    /// updating [`super::CommandState::acceleration_structure_fence`], which
+    /// the next acceleration structure encoder then waits on (see
+    /// [`Self::enter_acceleration_structure_builder`]). Metal does not order
+    /// acceleration structure commands encoded on the same encoder, and
+    /// fences are only defined across encoder boundaries, so this is how
+    /// commands later in the command buffer are ordered after prior builds.
+    fn split_acceleration_structure_builder(&mut self) {
+        if let Some(encoder) = self.state.acceleration_structure_builder.take() {
+            let fence = self
+                .state
+                .acceleration_structure_fence
+                .get_or_insert_with(|| self.shared.device.newFence().unwrap());
+            encoder.updateFence(fence);
+            encoder.endEncoding();
+            self.state.pending_acceleration_structure_fence_wait = true;
+            self.state.acceleration_structure_builder_has_builds = false;
         }
     }
 
@@ -498,6 +530,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
     unsafe fn discard_encoding(&mut self) {
         self.leave_blit();
         self.leave_acceleration_structure_builder();
+        self.state.pending_acceleration_structure_fence_wait = false;
         // when discarding, we don't have a guarantee that
         // everything is in a good state, so check carefully
         if let Some(encoder) = self.state.render.take() {
@@ -526,6 +559,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
         self.leave_blit();
         self.leave_acceleration_structure_builder();
+        self.state.pending_acceleration_structure_fence_wait = false;
         debug_assert!(self.state.render.is_none());
         debug_assert!(self.state.compute.is_none());
         debug_assert!(self.state.pending_timer_queries.is_empty());
@@ -1816,6 +1850,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         >,
     {
         let command_encoder = self.enter_acceleration_structure_builder();
+        self.state.acceleration_structure_builder_has_builds = true;
         for descriptor in descriptors {
             let acceleration_structure_descriptor =
                 conv::map_acceleration_structure_descriptor(descriptor.entries, descriptor.flags);
@@ -1844,8 +1879,16 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn place_acceleration_structure_barrier(
         &mut self,
-        _barriers: crate::AccelerationStructureBarrier,
+        _barrier: crate::AccelerationStructureBarrier,
     ) {
+        // wgpu-core emits an acceleration structure barrier at every point
+        // where ordering between acceleration structure commands is required,
+        // so rather than interpret the usage flags, split any open encoder
+        // unconditionally. An encoder is only open here if it encoded prior
+        // acceleration structure commands, so this never splits needlessly,
+        // and not relying on the flags keeps this correct if wgpu-core's
+        // barrier emission changes.
+        self.split_acceleration_structure_builder();
     }
 
     unsafe fn read_acceleration_structure_compact_size(
@@ -1853,6 +1896,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
         acceleration_structure: &super::AccelerationStructure,
         buffer: &super::Buffer,
     ) {
+        // wgpu-core encodes this with no barrier after the build of the
+        // acceleration structure being queried, so if the current encoder
+        // contains builds, split it; otherwise the size could be read from a
+        // still-building acceleration structure.
+        if self.state.acceleration_structure_builder_has_builds {
+            self.split_acceleration_structure_builder();
+        }
         let command_encoder = self.enter_acceleration_structure_builder();
         command_encoder.writeCompactedAccelerationStructureSize_toBuffer_offset(
             &acceleration_structure.raw,

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -7,10 +7,10 @@ use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLBlitCommandEncoder,
     MTLBlitPassDescriptor, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder,
     MTLCommandQueue, MTLComputeCommandEncoder, MTLComputePassDescriptor, MTLCounterDontSample,
-    MTLDevice, MTLLoadAction, MTLPrimitiveType, MTLRenderCommandEncoder, MTLRenderPassDescriptor,
-    MTLResidencySet, MTLResidencySetDescriptor, MTLSamplerState, MTLScissorRect, MTLSize,
-    MTLStoreAction, MTLTexture, MTLVertexAmplificationViewMapping, MTLViewport,
-    MTLVisibilityResultMode,
+    MTLDevice, MTLFence, MTLLoadAction, MTLPrimitiveType, MTLRenderCommandEncoder,
+    MTLRenderPassDescriptor, MTLResidencySet, MTLResidencySetDescriptor, MTLSamplerState,
+    MTLScissorRect, MTLSize, MTLStoreAction, MTLTexture, MTLVertexAmplificationViewMapping,
+    MTLViewport, MTLVisibilityResultMode,
 };
 
 use super::{
@@ -34,9 +34,9 @@ impl Default for super::CommandState {
         Self {
             blit: None,
             acceleration_structure_builder: None,
-            acceleration_structure_fence: None,
-            pending_acceleration_structure_fence_wait: false,
-            acceleration_structure_builder_has_builds: false,
+            contains_acceleration_structure_commands: false,
+            acceleration_structure_builder_has_commands: false,
+            acceleration_structure_fence_updated: false,
             render: None,
             compute: None,
             raw_primitive_type: MTLPrimitiveType::Point,
@@ -162,7 +162,9 @@ impl super::CommandEncoder {
 
     fn enter_blit(&mut self) -> Retained<ProtocolObject<dyn MTLBlitCommandEncoder>> {
         if self.state.blit.is_none() {
-            self.leave_acceleration_structure_builder();
+            // A preceding acceleration structure encoder must publish its
+            // commands before they are followed by anything else.
+            self.end_acceleration_structure_builder(true);
             debug_assert!(self.state.render.is_none() && self.state.compute.is_none());
             let cmd_buf = self.raw_cmd_buf.as_ref().unwrap();
 
@@ -261,6 +263,19 @@ impl super::CommandEncoder {
         }
     }
 
+    /// The fence ordering this command buffer's acceleration structure
+    /// encoders against each other, created on first use.
+    ///
+    /// `newFence` is only reached from acceleration structure command paths,
+    /// which only exist on hardware and OS versions where `MTLFence` is
+    /// available (macOS 10.14 / iOS 12; acceleration structures require
+    /// newer). A nil fence is a device-level allocation failure.
+    fn acceleration_structure_fence(&mut self) -> Retained<ProtocolObject<dyn MTLFence>> {
+        self.acceleration_structure_fence
+            .get_or_insert_with(|| self.shared.device.newFence().unwrap())
+            .clone()
+    }
+
     fn enter_acceleration_structure_builder(
         &mut self,
     ) -> Retained<ProtocolObject<dyn MTLAccelerationStructureCommandEncoder>> {
@@ -276,43 +291,62 @@ impl super::CommandEncoder {
                 self.state.acceleration_structure_builder =
                     cmd_buf.accelerationStructureCommandEncoder().to_owned();
             });
-            if self.state.pending_acceleration_structure_fence_wait {
-                self.state.pending_acceleration_structure_fence_wait = false;
+            self.state.contains_acceleration_structure_commands = true;
+            if self.state.acceleration_structure_fence_updated {
+                self.state.acceleration_structure_fence_updated = false;
+                let fence = self.acceleration_structure_fence();
                 self.state
                     .acceleration_structure_builder
                     .as_ref()
                     .unwrap()
-                    .waitForFence(self.state.acceleration_structure_fence.as_ref().unwrap());
+                    .waitForFence(&fence);
             }
         }
         self.state.acceleration_structure_builder.clone().unwrap()
     }
 
-    pub(super) fn leave_acceleration_structure_builder(&mut self) {
+    /// Ends the current acceleration structure encoder, if any.
+    ///
+    /// With `publish`, the encoder first updates
+    /// [`Self::acceleration_structure_fence`], which the next acceleration
+    /// structure encoder in this command buffer waits on (see
+    /// [`Self::enter_acceleration_structure_builder`]): Metal does not order
+    /// acceleration structure commands against each other, even on the same
+    /// encoder. Ordering against acceleration structure commands in other
+    /// command buffers is not handled here; `Queue::submit` links those with
+    /// a queue-wide event at submit time, in commit order.
+    ///
+    /// `end_encoding` and `discard_encoding` are the callers with
+    /// `publish = false`: `end_encoding` because the command buffer ends
+    /// there, so ordering against later command buffers is `Queue::submit`'s
+    /// job, and `discard_encoding` because the command buffer it belongs to
+    /// is never committed, so its commands never execute and no later
+    /// encoder may wait on them.
+    fn end_acceleration_structure_builder(&mut self, publish: bool) {
         if let Some(encoder) = self.state.acceleration_structure_builder.take() {
+            if publish {
+                let fence = self.acceleration_structure_fence();
+                encoder.updateFence(&fence);
+                self.state.acceleration_structure_fence_updated = true;
+            }
             encoder.endEncoding();
-            self.state.acceleration_structure_builder_has_builds = false;
+            self.state.acceleration_structure_builder_has_commands = false;
         }
     }
 
-    /// Ends the current acceleration structure encoder, if any, after
-    /// updating [`super::CommandState::acceleration_structure_fence`], which
-    /// the next acceleration structure encoder then waits on (see
-    /// [`Self::enter_acceleration_structure_builder`]). Metal does not order
-    /// acceleration structure commands encoded on the same encoder, and
-    /// fences are only defined across encoder boundaries, so this is how
-    /// commands later in the command buffer are ordered after prior builds.
-    fn split_acceleration_structure_builder(&mut self) {
-        if let Some(encoder) = self.state.acceleration_structure_builder.take() {
-            let fence = self
-                .state
-                .acceleration_structure_fence
-                .get_or_insert_with(|| self.shared.device.newFence().unwrap());
-            encoder.updateFence(fence);
-            encoder.endEncoding();
-            self.state.pending_acceleration_structure_fence_wait = true;
-            self.state.acceleration_structure_builder_has_builds = false;
-        }
+    /// Clears the acceleration structure state scoped to the command buffer
+    /// being recorded, and drops its fence.
+    ///
+    /// wgpu-core pools command encoders and hands them to later command
+    /// buffers, so a recording must leave none of it behind: a stale
+    /// `waitForFence` would wait on an update that lives in a command buffer
+    /// that is never committed, and a stale
+    /// `contains_acceleration_structure_commands` would put an unrelated
+    /// command buffer into the acceleration structure event chain
+    /// `Queue::submit` builds.
+    fn reset_acceleration_structure_state(&mut self) {
+        self.state.reset_acceleration_structure_state();
+        self.acceleration_structure_fence = None;
     }
 
     fn active_encoder(&mut self) -> Option<&ProtocolObject<dyn MTLCommandEncoder>> {
@@ -332,7 +366,9 @@ impl super::CommandEncoder {
     fn begin_pass(&mut self) {
         self.state.reset();
         self.leave_blit();
-        self.leave_acceleration_structure_builder();
+        // A preceding acceleration structure encoder must publish its
+        // commands before they are followed by anything else.
+        self.end_acceleration_structure_builder(true);
     }
 
     /// Updates the bindings for a single shader stage, called in `set_bind_group`.
@@ -439,6 +475,16 @@ impl super::CommandEncoder {
 }
 
 impl super::CommandState {
+    /// Clears the acceleration structure state scoped to the command buffer
+    /// being recorded. Called when a recording ends, so that a pooled
+    /// encoder never carries it into the next command buffer. See
+    /// `CommandEncoder::reset_acceleration_structure_state`.
+    fn reset_acceleration_structure_state(&mut self) {
+        self.contains_acceleration_structure_commands = false;
+        self.acceleration_structure_builder_has_commands = false;
+        self.acceleration_structure_fence_updated = false;
+    }
+
     fn reset(&mut self) {
         self.storage_buffer_length_map.clear();
         self.vertex_buffer_size_map.clear();
@@ -529,8 +575,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
     unsafe fn discard_encoding(&mut self) {
         self.leave_blit();
-        self.leave_acceleration_structure_builder();
-        self.state.pending_acceleration_structure_fence_wait = false;
+        // The command buffer is never committed, so its acceleration structure
+        // commands never execute; ending the encoder without publishing keeps
+        // any later encoder from waiting on them.
+        self.end_acceleration_structure_builder(false);
+        // The encoder returns to wgpu-core's pool; it must not carry this
+        // command buffer's state into the next recording.
+        self.reset_acceleration_structure_state();
         // when discarding, we don't have a guarantee that
         // everything is in a good state, so check carefully
         if let Some(encoder) = self.state.render.take() {
@@ -558,15 +609,25 @@ impl crate::CommandEncoder for super::CommandEncoder {
         }
 
         self.leave_blit();
-        self.leave_acceleration_structure_builder();
-        self.state.pending_acceleration_structure_fence_wait = false;
+        // The command buffer ends here; there is no later encoder in it that
+        // the open acceleration structure encoder could be ordered against.
+        // Ordering against other command buffers happens in `Queue::submit`,
+        // based on `contains_acceleration_structure_commands`.
+        self.end_acceleration_structure_builder(false);
         debug_assert!(self.state.render.is_none());
         debug_assert!(self.state.compute.is_none());
         debug_assert!(self.state.pending_timer_queries.is_empty());
 
+        let contains_acceleration_structure_commands =
+            self.state.contains_acceleration_structure_commands;
+        // The encoder returns to wgpu-core's pool; it must not carry this
+        // command buffer's state into the next recording.
+        self.reset_acceleration_structure_state();
+
         Ok(super::CommandBuffer {
             raw: self.raw_cmd_buf.take().unwrap(),
             queue_shared: Arc::clone(&self.queue_shared),
+            contains_acceleration_structure_commands,
         })
     }
 
@@ -748,6 +809,9 @@ impl crate::CommandEncoder for super::CommandEncoder {
         copy: wgt::AccelerationStructureCopy,
     ) {
         let command_encoder = self.enter_acceleration_structure_builder();
+        // A copy writes an acceleration structure, so a later compact-size
+        // read must not share the encoder with it.
+        self.state.acceleration_structure_builder_has_commands = true;
         match copy {
             wgt::AccelerationStructureCopy::Clone => unsafe {
                 command_encoder
@@ -1850,7 +1914,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         >,
     {
         let command_encoder = self.enter_acceleration_structure_builder();
-        self.state.acceleration_structure_builder_has_builds = true;
+        self.state.acceleration_structure_builder_has_commands = true;
         for descriptor in descriptors {
             let acceleration_structure_descriptor =
                 conv::map_acceleration_structure_descriptor(descriptor.entries, descriptor.flags);
@@ -1883,12 +1947,16 @@ impl crate::CommandEncoder for super::CommandEncoder {
     ) {
         // wgpu-core emits an acceleration structure barrier at every point
         // where ordering between acceleration structure commands is required,
-        // so rather than interpret the usage flags, split any open encoder
-        // unconditionally. An encoder is only open here if it encoded prior
-        // acceleration structure commands, so this never splits needlessly,
-        // and not relying on the flags keeps this correct if wgpu-core's
-        // barrier emission changes.
-        self.split_acceleration_structure_builder();
+        // so rather than interpret the usage flags, close the open encoder
+        // with a fence update unconditionally; the next acceleration structure
+        // encoder in this command buffer waits on it. Shader passes do not
+        // wait on the fence: a pass that binds an acceleration structure is
+        // ordered by Metal against the acceleration structure commands that
+        // precede it in the command buffer, while a build that reaches other
+        // acceleration structures through descriptor addresses (as a TLAS
+        // build reaches its instances' BLASes) is untracked by Metal either
+        // way. Ordering across command buffers is `Queue::submit`'s job.
+        self.end_acceleration_structure_builder(true);
     }
 
     unsafe fn read_acceleration_structure_compact_size(
@@ -1896,12 +1964,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
         acceleration_structure: &super::AccelerationStructure,
         buffer: &super::Buffer,
     ) {
-        // wgpu-core encodes this with no barrier after the build of the
-        // acceleration structure being queried, so if the current encoder
-        // contains builds, split it; otherwise the size could be read from a
-        // still-building acceleration structure.
-        if self.state.acceleration_structure_builder_has_builds {
-            self.split_acceleration_structure_builder();
+        // wgpu-core encodes this with no barrier after the build or copy of
+        // the acceleration structure being queried, so if the current encoder
+        // holds acceleration structure commands, close it first; otherwise the
+        // size could be read from a structure whose commands have not
+        // completed.
+        if self.state.acceleration_structure_builder_has_commands {
+            self.end_acceleration_structure_builder(true);
         }
         let command_encoder = self.enter_acceleration_structure_builder();
         command_encoder.writeCompactedAccelerationStructureSize_toBuffer_offset(
@@ -1968,5 +2037,30 @@ impl Drop for super::CommandBuffer {
                 .fetch_sub(1, atomic::Ordering::AcqRel);
             debug_assert!(previous > 0);
         }
+        // An unsubmitted command buffer needs no synchronization cleanup: its
+        // fence updates stay unconsumed because waits are only encoded for
+        // command buffers of the same buffer, and `Queue::submit` never
+        // assigned it an event value, so no other command buffer waits on it.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CommandState;
+
+    #[test]
+    fn reset_acceleration_structure_state_clears_per_command_buffer_flags() {
+        let mut state = CommandState {
+            contains_acceleration_structure_commands: true,
+            acceleration_structure_builder_has_commands: true,
+            acceleration_structure_fence_updated: true,
+            ..CommandState::default()
+        };
+
+        state.reset_acceleration_structure_state();
+
+        assert!(!state.contains_acceleration_structure_commands);
+        assert!(!state.acceleration_structure_builder_has_commands);
+        assert!(!state.acceleration_structure_fence_updated);
     }
 }

--- a/wgpu-hal/src/metal/command.rs
+++ b/wgpu-hal/src/metal/command.rs
@@ -5,16 +5,17 @@ use objc2::{
 use objc2_foundation::{NSRange, NSString, NSUInteger};
 use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLBlitCommandEncoder,
-    MTLBlitPassDescriptor, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder,
-    MTLCommandQueue, MTLComputeCommandEncoder, MTLComputePassDescriptor, MTLCounterDontSample,
-    MTLDevice, MTLFence, MTLLoadAction, MTLPrimitiveType, MTLRenderCommandEncoder,
-    MTLRenderPassDescriptor, MTLResidencySet, MTLResidencySetDescriptor, MTLSamplerState,
+    MTLBlitPassDescriptor, MTLBuffer, MTLCommandBuffer, MTLCommandEncoder, MTLCommandQueue,
+    MTLComputeCommandEncoder, MTLComputePassDescriptor, MTLCounterDontSample, MTLDevice, MTLFence,
+    MTLLoadAction, MTLPrimitiveType, MTLRenderCommandEncoder, MTLRenderPassDescriptor,
+    MTLRenderStages, MTLResidencySet, MTLResidencySetDescriptor, MTLResourceUsage, MTLSamplerState,
     MTLScissorRect, MTLSize, MTLStoreAction, MTLTexture, MTLVertexAmplificationViewMapping,
     MTLViewport, MTLVisibilityResultMode,
 };
 
 use super::{
     adapter::{self, VERTEX_BUFFER_SLOT_START},
+    command_buffer_slot::CommandBufferSlot,
     conv, TimestampQuerySupport,
 };
 use crate::CommandEncoder as _;
@@ -23,7 +24,7 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use core::{ops::Range, ptr::NonNull, sync::atomic};
+use core::{ops::Range, ptr::NonNull};
 use smallvec::SmallVec;
 
 // has to match `Temp::binding_sizes`
@@ -36,7 +37,7 @@ impl Default for super::CommandState {
             acceleration_structure_builder: None,
             contains_acceleration_structure_commands: false,
             acceleration_structure_builder_has_commands: false,
-            acceleration_structure_fence_updated: false,
+            acceleration_structure_pass: false,
             render: None,
             compute: None,
             raw_primitive_type: MTLPrimitiveType::Point,
@@ -263,17 +264,35 @@ impl super::CommandEncoder {
         }
     }
 
-    /// The fence ordering this command buffer's acceleration structure
-    /// encoders against each other, created on first use.
-    ///
-    /// `newFence` is only reached from acceleration structure command paths,
-    /// which only exist on hardware and OS versions where `MTLFence` is
-    /// available (macOS 10.14 / iOS 12; acceleration structures require
-    /// newer). A nil fence is a device-level allocation failure.
-    fn acceleration_structure_fence(&mut self) -> Retained<ProtocolObject<dyn MTLFence>> {
-        self.acceleration_structure_fence
-            .get_or_insert_with(|| self.shared.device.newFence().unwrap())
-            .clone()
+    fn acceleration_structure_fence(&self) -> Retained<ProtocolObject<dyn MTLFence>> {
+        self.queue_shared.acceleration_structure_fence()
+    }
+
+    /// Make `encoder` wait on the acceleration structure build fence, once per
+    /// pass, so resources built by earlier command buffers are complete before
+    /// they are consumed.
+    fn wait_for_acceleration_structure_build(&mut self, encoder: &Encoder<'_>) {
+        if !self.state.acceleration_structure_pass {
+            let fence = self.acceleration_structure_fence();
+            match encoder {
+                Encoder::Vertex(enc) | Encoder::Fragment(enc) => {
+                    enc.waitForFence_beforeStages(
+                        &fence,
+                        MTLRenderStages::Vertex | MTLRenderStages::Fragment,
+                    );
+                }
+                Encoder::Compute(enc) => enc.waitForFence(&fence),
+                Encoder::Task(_) | Encoder::Mesh(_) => unreachable!(),
+            }
+            #[cfg(test)]
+            match encoder {
+                Encoder::Vertex(enc) | Encoder::Fragment(enc) => self.trace(*enc, "render-wait"),
+                Encoder::Compute(enc) => self.trace(*enc, "compute-wait"),
+                _ => unreachable!(),
+            }
+            self.state.acceleration_structure_pass = true;
+            self.state.contains_acceleration_structure_commands = true;
+        }
     }
 
     fn enter_acceleration_structure_builder(
@@ -292,61 +311,37 @@ impl super::CommandEncoder {
                     cmd_buf.accelerationStructureCommandEncoder().to_owned();
             });
             self.state.contains_acceleration_structure_commands = true;
-            if self.state.acceleration_structure_fence_updated {
-                self.state.acceleration_structure_fence_updated = false;
-                let fence = self.acceleration_structure_fence();
-                self.state
-                    .acceleration_structure_builder
-                    .as_ref()
-                    .unwrap()
-                    .waitForFence(&fence);
-            }
+            let fence = self.acceleration_structure_fence();
+            self.state
+                .acceleration_structure_builder
+                .as_ref()
+                .unwrap()
+                .waitForFence(&fence);
+            #[cfg(test)]
+            self.trace(
+                self.state.acceleration_structure_builder.as_ref().unwrap(),
+                "as-wait",
+            );
         }
         self.state.acceleration_structure_builder.clone().unwrap()
     }
 
-    /// Ends the current acceleration structure encoder, if any.
-    ///
-    /// With `publish`, the encoder first updates
-    /// [`Self::acceleration_structure_fence`], which the next acceleration
-    /// structure encoder in this command buffer waits on (see
-    /// [`Self::enter_acceleration_structure_builder`]): Metal does not order
-    /// acceleration structure commands against each other, even on the same
-    /// encoder. Ordering against acceleration structure commands in other
-    /// command buffers is not handled here; `Queue::submit` links those with
-    /// a queue-wide event at submit time, in commit order.
-    ///
-    /// `end_encoding` and `discard_encoding` are the callers with
-    /// `publish = false`: `end_encoding` because the command buffer ends
-    /// there, so ordering against later command buffers is `Queue::submit`'s
-    /// job, and `discard_encoding` because the command buffer it belongs to
-    /// is never committed, so its commands never execute and no later
-    /// encoder may wait on them.
     fn end_acceleration_structure_builder(&mut self, publish: bool) {
         if let Some(encoder) = self.state.acceleration_structure_builder.take() {
             if publish {
-                let fence = self.acceleration_structure_fence();
-                encoder.updateFence(&fence);
-                self.state.acceleration_structure_fence_updated = true;
+                encoder.updateFence(&self.acceleration_structure_fence());
+                #[cfg(test)]
+                self.trace(&encoder, "as-update");
             }
             encoder.endEncoding();
+            #[cfg(test)]
+            self.trace(&encoder, "as-end");
             self.state.acceleration_structure_builder_has_commands = false;
         }
     }
 
-    /// Clears the acceleration structure state scoped to the command buffer
-    /// being recorded, and drops its fence.
-    ///
-    /// wgpu-core pools command encoders and hands them to later command
-    /// buffers, so a recording must leave none of it behind: a stale
-    /// `waitForFence` would wait on an update that lives in a command buffer
-    /// that is never committed, and a stale
-    /// `contains_acceleration_structure_commands` would put an unrelated
-    /// command buffer into the acceleration structure event chain
-    /// `Queue::submit` builds.
     fn reset_acceleration_structure_state(&mut self) {
         self.state.reset_acceleration_structure_state();
-        self.acceleration_structure_fence = None;
     }
 
     fn active_encoder(&mut self) -> Option<&ProtocolObject<dyn MTLCommandEncoder>> {
@@ -409,6 +404,9 @@ impl super::CommandEncoder {
                     binding_size,
                     binding_location,
                 } => {
+                    if group.uses_acceleration_structures {
+                        self.wait_for_acceleration_structure_build(&encoder);
+                    }
                     let buffer = Some(unsafe { ptr.as_ref() });
                     if let Some(dyn_index) = dynamic_index {
                         offset += dynamic_offsets[*dyn_index as usize] as wgt::BufferAddress;
@@ -427,6 +425,7 @@ impl super::CommandEncoder {
                 super::BufferLikeResource::AccelerationStructure(ptr) => {
                     let buffer = Some(unsafe { ptr.as_ref() });
                     let index = (resource_indices.buffers + index) as usize;
+                    self.wait_for_acceleration_structure_build(&encoder);
                     encoder.set_acceleration_structure(buffer, index);
                 }
             }
@@ -482,7 +481,7 @@ impl super::CommandState {
     fn reset_acceleration_structure_state(&mut self) {
         self.contains_acceleration_structure_commands = false;
         self.acceleration_structure_builder_has_commands = false;
-        self.acceleration_structure_fence_updated = false;
+        self.acceleration_structure_pass = false;
     }
 
     fn reset(&mut self) {
@@ -536,24 +535,21 @@ impl crate::CommandEncoder for super::CommandEncoder {
         let queue = &self.queue_shared.raw;
         let retain_references = self.shared.settings.retain_command_buffer_references;
 
-        // Guard against exhausting Metal's command buffer budget. Use the hard
-        // limit (`MAX_COMMAND_BUFFERS`) so we fail before Metal can hang inside
-        // `new_command_buffer`.
-        let previous = self
-            .queue_shared
-            .command_buffer_created_not_submitted
-            .fetch_add(1, atomic::Ordering::AcqRel);
-        if previous >= adapter::MAX_COMMAND_BUFFERS {
-            let current = previous + 1;
+        // Leave one native slot for serialized internal allocate-and-commit work.
+        let slot = CommandBufferSlot::reserve(
+            &self.queue_shared.command_buffer_created_not_submitted,
+            adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS,
+        )
+        .map_err(|current| {
             log::warn!(
                 "metal: refusing to create new command buffer; {current} outstanding command \
-                 buffers exceeds the limit of {}. Treating this as device lost. \
+                 buffers reaches the limit of {}. Treating this as device lost. \
                  Ensure command encoders are submitted or dropped rather than kept alive \
                  to avoid exhausting Metal's command buffer budget.",
-                adapter::MAX_COMMAND_BUFFERS
+                adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS
             );
-            return Err(crate::DeviceError::Lost);
-        }
+            crate::DeviceError::Lost
+        })?;
 
         let raw = autoreleasepool(move |_| {
             let cmd_buf_ref = if retain_references {
@@ -569,15 +565,14 @@ impl crate::CommandEncoder for super::CommandEncoder {
         });
 
         self.raw_cmd_buf = Some(raw);
+        self.command_buffer_slot = Some(slot);
 
         Ok(())
     }
 
     unsafe fn discard_encoding(&mut self) {
         self.leave_blit();
-        // The command buffer is never committed, so its acceleration structure
-        // commands never execute; ending the encoder without publishing keeps
-        // any later encoder from waiting on them.
+        // Discarded commands never enter the commit-evaluated fence timeline.
         self.end_acceleration_structure_builder(false);
         // The encoder returns to wgpu-core's pool; it must not carry this
         // command buffer's state into the next recording.
@@ -590,15 +585,10 @@ impl crate::CommandEncoder for super::CommandEncoder {
         if let Some(encoder) = self.state.compute.take() {
             encoder.endEncoding();
         }
-        let had_command_buffer = self.raw_cmd_buf.is_some();
         // Clear the Option first so the underlying `metal::CommandBuffer` is
         // dropped before we update the counter.
         self.raw_cmd_buf = None;
-        if had_command_buffer {
-            self.queue_shared
-                .command_buffer_created_not_submitted
-                .fetch_sub(1, atomic::Ordering::AcqRel);
-        }
+        self.command_buffer_slot = None;
     }
 
     unsafe fn end_encoding(&mut self) -> Result<super::CommandBuffer, crate::DeviceError> {
@@ -609,11 +599,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         }
 
         self.leave_blit();
-        // The command buffer ends here; there is no later encoder in it that
-        // the open acceleration structure encoder could be ordered against.
-        // Ordering against other command buffers happens in `Queue::submit`,
-        // based on `contains_acceleration_structure_commands`.
-        self.end_acceleration_structure_builder(false);
+        self.end_acceleration_structure_builder(true);
         debug_assert!(self.state.render.is_none());
         debug_assert!(self.state.compute.is_none());
         debug_assert!(self.state.pending_timer_queries.is_empty());
@@ -626,7 +612,8 @@ impl crate::CommandEncoder for super::CommandEncoder {
 
         Ok(super::CommandBuffer {
             raw: self.raw_cmd_buf.take().unwrap(),
-            queue_shared: Arc::clone(&self.queue_shared),
+            slot: self.command_buffer_slot.take().unwrap(),
+            _queue_shared: Arc::clone(&self.queue_shared),
             contains_acceleration_structure_commands,
         })
     }
@@ -1148,7 +1135,16 @@ impl crate::CommandEncoder for super::CommandEncoder {
     }
 
     unsafe fn end_render_pass(&mut self) {
-        self.state.render.take().unwrap().endEncoding();
+        let encoder = self.state.render.take().unwrap();
+        if core::mem::take(&mut self.state.acceleration_structure_pass) {
+            encoder.updateFence_afterStages(
+                &self.acceleration_structure_fence(),
+                MTLRenderStages::Vertex | MTLRenderStages::Fragment,
+            );
+            #[cfg(test)]
+            self.trace(&encoder, "render-update");
+        }
+        encoder.endEncoding();
     }
 
     unsafe fn set_bind_group(
@@ -1822,7 +1818,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
         });
     }
     unsafe fn end_compute_pass(&mut self) {
-        self.state.compute.take().unwrap().endEncoding();
+        let encoder = self.state.compute.take().unwrap();
+        if core::mem::take(&mut self.state.acceleration_structure_pass) {
+            encoder.updateFence(&self.acceleration_structure_fence());
+            #[cfg(test)]
+            self.trace(&encoder, "compute-update");
+        }
+        encoder.endEncoding();
     }
 
     unsafe fn set_compute_pipeline(&mut self, pipeline: &super::ComputePipeline) {
@@ -1916,8 +1918,43 @@ impl crate::CommandEncoder for super::CommandEncoder {
         let command_encoder = self.enter_acceleration_structure_builder();
         self.state.acceleration_structure_builder_has_commands = true;
         for descriptor in descriptors {
+            // Descriptor resources need explicit tracked access declarations for
+            // earlier staging/copy/compute writes and subsequent input overwrites.
+            let read = |buffer: &super::Buffer| {
+                command_encoder.useResource_usage(
+                    ProtocolObject::from_ref(&*buffer.raw),
+                    MTLResourceUsage::Read,
+                );
+            };
+            match descriptor.entries {
+                crate::AccelerationStructureEntries::Instances(instances) => {
+                    read(instances.buffer.unwrap())
+                }
+                crate::AccelerationStructureEntries::Triangles(triangles) => {
+                    for triangle in triangles.iter() {
+                        read(triangle.vertex_buffer.unwrap());
+                        if let Some(indices) = &triangle.indices {
+                            read(indices.buffer.unwrap());
+                        }
+                        if let Some(transform) = &triangle.transform {
+                            read(transform.buffer);
+                        }
+                    }
+                }
+                crate::AccelerationStructureEntries::AABBs(aabbs) => {
+                    for aabb in aabbs.iter() {
+                        read(aabb.buffer.unwrap());
+                    }
+                }
+            }
+            command_encoder.useResource_usage(
+                ProtocolObject::from_ref(&*descriptor.scratch_buffer.raw),
+                MTLResourceUsage::Read | MTLResourceUsage::Write,
+            );
             let acceleration_structure_descriptor =
                 conv::map_acceleration_structure_descriptor(descriptor.entries, descriptor.flags);
+            #[cfg(test)]
+            self.trace(&command_encoder, "build");
             match descriptor.mode {
                 crate::AccelerationStructureBuildMode::Build => {
                     command_encoder
@@ -1945,17 +1982,7 @@ impl crate::CommandEncoder for super::CommandEncoder {
         &mut self,
         _barrier: crate::AccelerationStructureBarrier,
     ) {
-        // wgpu-core emits an acceleration structure barrier at every point
-        // where ordering between acceleration structure commands is required,
-        // so rather than interpret the usage flags, close the open encoder
-        // with a fence update unconditionally; the next acceleration structure
-        // encoder in this command buffer waits on it. Shader passes do not
-        // wait on the fence: a pass that binds an acceleration structure is
-        // ordered by Metal against the acceleration structure commands that
-        // precede it in the command buffer, while a build that reaches other
-        // acceleration structures through descriptor addresses (as a TLAS
-        // build reaches its instances' BLASes) is untracked by Metal either
-        // way. Ordering across command buffers is `Queue::submit`'s job.
+        // Dependent builds cannot share an AS encoder, even with tracked storage.
         self.end_acceleration_structure_builder(true);
     }
 
@@ -1973,6 +2000,13 @@ impl crate::CommandEncoder for super::CommandEncoder {
             self.end_acceleration_structure_builder(true);
         }
         let command_encoder = self.enter_acceleration_structure_builder();
+        self.state.acceleration_structure_builder_has_commands = true;
+        command_encoder.useResource_usage(
+            ProtocolObject::from_ref(&*buffer.raw),
+            MTLResourceUsage::Write,
+        );
+        #[cfg(test)]
+        self.trace(&command_encoder, "compact-size");
         command_encoder.writeCompactedAccelerationStructureSize_toBuffer_offset(
             &acceleration_structure.raw,
             &buffer.raw,
@@ -2022,45 +2056,5 @@ impl Drop for super::CommandEncoder {
     }
 }
 
-impl Drop for super::CommandBuffer {
-    fn drop(&mut self) {
-        // `command_buffer_created_not_submitted` is usually decremented when the command
-        // buffer is submitted. But if we're dropping a command buffer that was never
-        // submitted, we need to decrement the count here.
-        let status = self.raw.status();
-        if status == MTLCommandBufferStatus::NotEnqueued
-            || status == MTLCommandBufferStatus::Enqueued
-        {
-            let previous = self
-                .queue_shared
-                .command_buffer_created_not_submitted
-                .fetch_sub(1, atomic::Ordering::AcqRel);
-            debug_assert!(previous > 0);
-        }
-        // An unsubmitted command buffer needs no synchronization cleanup: its
-        // fence updates stay unconsumed because waits are only encoded for
-        // command buffers of the same buffer, and `Queue::submit` never
-        // assigned it an event value, so no other command buffer waits on it.
-    }
-}
-
 #[cfg(test)]
-mod tests {
-    use super::super::CommandState;
-
-    #[test]
-    fn reset_acceleration_structure_state_clears_per_command_buffer_flags() {
-        let mut state = CommandState {
-            contains_acceleration_structure_commands: true,
-            acceleration_structure_builder_has_commands: true,
-            acceleration_structure_fence_updated: true,
-            ..CommandState::default()
-        };
-
-        state.reset_acceleration_structure_state();
-
-        assert!(!state.contains_acceleration_structure_commands);
-        assert!(!state.acceleration_structure_builder_has_commands);
-        assert!(!state.acceleration_structure_fence_updated);
-    }
-}
+pub(super) mod tests;

--- a/wgpu-hal/src/metal/command/tests.rs
+++ b/wgpu-hal/src/metal/command/tests.rs
@@ -1,0 +1,773 @@
+//! All tests here access a real Metal GPU, including fence setup, non-ray encoder,
+//! and descriptor cases; this is not a CPU-only suite. The ignored capacity test
+//! retains 4095 native command buffers and requires explicit hardware authorization.
+
+use super::*;
+use crate::metal as m;
+use crate::{Adapter as _, Device as _, Queue as _};
+use alloc::vec;
+use core::{cell::RefCell, sync::atomic};
+use objc2_metal::{MTLCommandBufferStatus, MTLCreateSystemDefaultDevice, MTLResourceOptions};
+
+#[derive(Clone, Debug)]
+struct Event {
+    buffer: usize,
+    encoder: Option<usize>,
+    operation: &'static str,
+}
+
+std::thread_local! {
+    static EVENTS: RefCell<Vec<Event>> = const { RefCell::new(Vec::new()) };
+}
+
+pub(in crate::metal) fn identity<T: ?Sized>(object: &T) -> usize {
+    core::ptr::from_ref(object).cast::<()>() as usize
+}
+
+pub(in crate::metal) fn record(
+    buffer: &ProtocolObject<dyn MTLCommandBuffer>,
+    encoder: Option<usize>,
+    operation: &'static str,
+) {
+    std::eprintln!(
+        "Metal emission buffer={:#x} encoder={encoder:?} {operation}",
+        identity(buffer)
+    );
+    EVENTS.with_borrow_mut(|events| {
+        events.push(Event {
+            buffer: identity(buffer),
+            encoder,
+            operation,
+        })
+    });
+}
+
+impl m::CommandEncoder {
+    pub(super) fn trace<T: ?Sized>(&self, encoder: &ProtocolObject<T>, operation: &'static str) {
+        record(
+            self.raw_cmd_buf.as_ref().unwrap(),
+            Some(identity(encoder)),
+            operation,
+        );
+    }
+}
+
+fn events() -> Vec<Event> {
+    EVENTS.with_borrow(|events| events.clone())
+}
+
+fn open() -> Option<crate::OpenDevice<m::Api>> {
+    let raw = MTLCreateSystemDefaultDevice()?;
+    let exposed = m::AdapterShared::expose(raw);
+    if !exposed
+        .features
+        .contains(wgt::Features::EXPERIMENTAL_RAY_QUERY)
+    {
+        std::eprintln!("SKIP: Metal ray queries unavailable");
+        return None;
+    }
+    Some(unsafe {
+        exposed
+            .adapter
+            .open(
+                wgt::Features::EXPERIMENTAL_RAY_QUERY,
+                &exposed.capabilities.limits,
+                &wgt::MemoryHints::default(),
+            )
+            .unwrap()
+    })
+}
+
+fn encoder(device: &m::Device, queue: &m::Queue) -> m::CommandEncoder {
+    unsafe {
+        device
+            .create_command_encoder(&crate::CommandEncoderDescriptor { label: None, queue })
+            .unwrap()
+    }
+}
+
+fn buffer(device: &m::Device, size: usize) -> m::Buffer {
+    m::Buffer {
+        raw: device
+            .shared
+            .device
+            .newBufferWithLength_options(size, MTLResourceOptions::StorageModeShared)
+            .unwrap(),
+        size: size as u64,
+    }
+}
+
+fn triangles(vertex: &m::Buffer) -> crate::AccelerationStructureEntries<'_, m::Buffer> {
+    crate::AccelerationStructureEntries::Triangles(vec![crate::AccelerationStructureTriangles {
+        vertex_buffer: Some(vertex),
+        vertex_format: wgt::VertexFormat::Float32x3,
+        first_vertex: 0,
+        vertex_count: 3,
+        vertex_stride: 12,
+        indices: None,
+        transform: None,
+        flags: wgt::AccelerationStructureGeometryFlags::OPAQUE,
+    }])
+}
+
+fn storage(
+    device: &m::Device,
+    entries: &crate::AccelerationStructureEntries<'_, m::Buffer>,
+) -> (m::AccelerationStructure, m::Buffer) {
+    let sizes = unsafe {
+        device.get_acceleration_structure_build_sizes(
+            &crate::GetAccelerationStructureBuildSizesDescriptor {
+                entries,
+                flags: wgt::AccelerationStructureFlags::empty(),
+            },
+        )
+    };
+    let structure = unsafe {
+        device
+            .create_acceleration_structure(&crate::AccelerationStructureDescriptor {
+                label: None,
+                size: sizes.acceleration_structure_size,
+                format: match entries {
+                    crate::AccelerationStructureEntries::Instances(_) => {
+                        crate::AccelerationStructureFormat::TopLevel
+                    }
+                    _ => crate::AccelerationStructureFormat::BottomLevel,
+                },
+                allow_compaction: true,
+            })
+            .unwrap()
+    };
+    (structure, buffer(device, sizes.build_scratch_size as usize))
+}
+
+unsafe fn build(
+    encoder: &mut m::CommandEncoder,
+    entries: &crate::AccelerationStructureEntries<'_, m::Buffer>,
+    structure: &m::AccelerationStructure,
+    scratch: &m::Buffer,
+) {
+    unsafe {
+        encoder.build_acceleration_structures(
+            1,
+            [crate::BuildAccelerationStructureDescriptor {
+                entries,
+                mode: crate::AccelerationStructureBuildMode::Build,
+                flags: wgt::AccelerationStructureFlags::empty(),
+                source_acceleration_structure: None,
+                destination_acceleration_structure: structure,
+                scratch_buffer: scratch,
+                scratch_buffer_offset: 0,
+            }],
+        );
+    }
+}
+
+fn assert_recording(id: usize, expected: &[&str]) {
+    let recording: Vec<_> = events()
+        .into_iter()
+        .filter(|event| event.buffer == id)
+        .collect();
+    assert_eq!(
+        recording
+            .iter()
+            .map(|event| event.operation)
+            .collect::<Vec<_>>(),
+        expected
+    );
+    for group in recording.chunks(4) {
+        if group.len() == 4 && group[0].operation == "as-wait" {
+            assert!(group.iter().all(|event| event.encoder == group[0].encoder));
+        }
+    }
+}
+
+#[test]
+fn fence_setup_failure_is_fallible() {
+    let mut sync = m::AccelerationStructureSync::default();
+    assert!(matches!(
+        sync.initialize_fence(|| None),
+        Err(crate::DeviceError::OutOfMemory)
+    ));
+    assert!(sync.fence.is_none());
+    assert!(!sync.seeded);
+    let Some(opened) = open() else { return };
+    let fence = opened.device.shared.device.newFence().unwrap();
+    sync.initialize_fence(|| Some(fence.clone())).unwrap();
+    sync.initialize_fence(|| panic!("initialized fence must be reused"))
+        .unwrap();
+    assert_eq!(identity(&**sync.fence.as_ref().unwrap()), identity(&*fence));
+}
+
+#[test]
+fn non_ray_encoder_does_not_allocate_as_fence() {
+    let Some(raw) = MTLCreateSystemDefaultDevice() else {
+        return;
+    };
+    let exposed = m::AdapterShared::expose(raw);
+    let opened = unsafe {
+        exposed
+            .adapter
+            .open(
+                wgt::Features::empty(),
+                &exposed.capabilities.limits,
+                &wgt::MemoryHints::default(),
+            )
+            .unwrap()
+    };
+    let enc = encoder(&opened.device, &opened.queue);
+    assert!(opened
+        .queue
+        .shared
+        .acceleration_structure_sync
+        .lock()
+        .fence
+        .is_none());
+    drop(enc);
+}
+
+#[test]
+#[ignore = "opt-in native queue-capacity stress; may make the machine/display unresponsive"]
+fn first_as_at_native_recording_capacity() {
+    const CHILD: &str = "WGPU_METAL_CAPACITY_TEST_CHILD";
+    const CHILD_COMPLETED: i32 = 42;
+    if std::env::var_os(CHILD).is_none() {
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--ignored",
+                "--exact",
+                "metal::command::tests::first_as_at_native_recording_capacity",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .spawn()
+            .unwrap();
+        // This userspace deadline cannot protect against GPU/driver hangs or display freezes.
+        let deadline = std::time::Instant::now() + core::time::Duration::from_secs(60);
+        loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                // A zero-test libtest invocation exits 0, not CHILD_COMPLETED.
+                assert_eq!(
+                    status.code(),
+                    Some(CHILD_COMPLETED),
+                    "capacity subprocess did not complete the native test: {status}"
+                );
+                return;
+            }
+            if std::time::Instant::now() >= deadline {
+                child.kill().unwrap();
+                child.wait().unwrap();
+                panic!("native capacity subprocess failed to make bounded progress");
+            }
+            std::thread::sleep(core::time::Duration::from_millis(20));
+        }
+    }
+    assert_eq!(std::env::var(CHILD).as_deref(), Ok("1"));
+    run_native_recording_capacity();
+    // Signal completion only after the native checks and resource drops have finished.
+    std::process::exit(CHILD_COMPLETED);
+}
+
+fn run_native_recording_capacity() {
+    let crate::OpenDevice { device, queue } =
+        open().expect("opt-in native capacity test requires a Metal ray-query device");
+    let vertex = buffer(&device, 36);
+    let vertices = [-1.0f32, -1.0, 1.0, 1.0, -1.0, 1.0, 0.0, 1.0, 1.0];
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            vertices.as_ptr().cast::<u8>(),
+            vertex.raw.contents().as_ptr().cast(),
+            36,
+        );
+    }
+    let entries = triangles(&vertex);
+    let (blas, scratch) = storage(&device, &entries);
+    let mut enc = encoder(&device, &queue);
+    unsafe {
+        enc.begin_encoding(None).unwrap();
+        build(&mut enc, &entries, &blas, &scratch);
+        let participant = enc.end_encoding().unwrap();
+        let mut held = Vec::new();
+        for _ in 1..adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS {
+            enc.begin_encoding(None).unwrap();
+            held.push(enc.end_encoding().unwrap());
+        }
+        assert!(matches!(
+            enc.begin_encoding(None),
+            Err(crate::DeviceError::Lost)
+        ));
+        assert_eq!(
+            queue
+                .shared
+                .command_buffer_created_not_submitted
+                .load(atomic::Ordering::Acquire),
+            adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS
+        );
+        let fence = device.create_fence().unwrap();
+        // Internal empty-submit and idle joins must also progress with held recordings.
+        queue.submit(&[], &[], (&fence, 1)).unwrap();
+        queue.wait_for_idle().unwrap();
+        assert!(!queue.shared.acceleration_structure_sync.lock().seeded);
+        queue.submit(&[&participant], &[], (&fence, 2)).unwrap();
+        assert!(device
+            .wait(&fence, 2, Some(core::time::Duration::from_secs(30)))
+            .unwrap());
+        let emitted = events();
+        let seed = emitted
+            .iter()
+            .position(|e| e.operation == "seed-commit")
+            .unwrap();
+        let commit = emitted
+            .iter()
+            .position(|e| e.operation == "commit" && e.buffer == identity(&*participant.raw))
+            .unwrap();
+        assert!(seed < commit);
+        assert!(emitted.iter().any(|e| e.operation == "retire-wait"));
+        enc.reset_all(held.into_iter().chain([participant]));
+        assert_eq!(
+            queue
+                .shared
+                .command_buffer_created_not_submitted
+                .load(atomic::Ordering::Acquire),
+            0
+        );
+        drop(enc);
+        device.destroy_fence(fence);
+        device.destroy_acceleration_structure(blas);
+    }
+}
+
+#[test]
+fn encoder_finish_discard_reuse_and_submit_order() {
+    let Some(crate::OpenDevice { device, queue }) = open() else {
+        return;
+    };
+    let vertex = buffer(&device, 36);
+    let vertices = [-1.0f32, -1.0, 1.0, 1.0, -1.0, 1.0, 0.0, 1.0, 1.0];
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            vertices.as_ptr().cast::<u8>(),
+            vertex.raw.contents().as_ptr().cast(),
+            36,
+        );
+    }
+    let entries = triangles(&vertex);
+    let (blas, scratch) = storage(&device, &entries);
+    let mut enc = encoder(&device, &queue);
+    unsafe {
+        enc.begin_encoding(None).unwrap();
+        build(&mut enc, &entries, &blas, &scratch);
+        enc.enter_blit();
+        let abandoned = enc.end_encoding().unwrap();
+        let abandoned_id = identity(&*abandoned.raw);
+        assert_recording(abandoned_id, &["as-wait", "build", "as-update", "as-end"]);
+        assert!(abandoned.contains_acceleration_structure_commands);
+        assert!(!enc.state.contains_acceleration_structure_commands);
+
+        enc.begin_encoding(None).unwrap();
+        build(&mut enc, &entries, &blas, &scratch);
+        let discarded_raw = enc.raw_cmd_buf.as_ref().unwrap().clone();
+        let discarded_id = identity(&*discarded_raw);
+        enc.discard_encoding();
+        assert_recording(discarded_id, &["as-wait", "build", "as-end"]);
+
+        enc.begin_encoding(None).unwrap();
+        let ordinary = enc.end_encoding().unwrap();
+        assert!(!ordinary.contains_acceleration_structure_commands);
+        assert!(!queue.shared.acceleration_structure_sync.lock().seeded);
+
+        enc.begin_encoding(None).unwrap();
+        build(&mut enc, &entries, &blas, &scratch);
+        let submitted = enc.end_encoding().unwrap();
+        let submitted_id = identity(&*submitted.raw);
+        assert_recording(submitted_id, &["as-wait", "build", "as-update", "as-end"]);
+        let fence = device.create_fence().unwrap();
+        queue
+            .submit(&[&submitted, &ordinary], &[], (&fence, 1))
+            .unwrap();
+        assert!(device
+            .wait(&fence, 1, Some(core::time::Duration::from_secs(30)))
+            .unwrap());
+        assert_eq!(submitted.raw.status(), MTLCommandBufferStatus::Completed);
+        assert!(queue.shared.acceleration_structure_sync.lock().seeded);
+        let commits: Vec<_> = events()
+            .into_iter()
+            .filter(|event| event.operation.ends_with("commit"))
+            .collect();
+        assert_eq!(commits.len(), 3);
+        assert_eq!(commits[0].operation, "seed-commit");
+        assert_eq!(commits[1].buffer, submitted_id);
+        assert_eq!(commits[2].buffer, identity(&*ordinary.raw));
+        assert!(!commits.iter().any(|event| event.buffer == abandoned_id));
+        let retirement: Vec<_> = events()
+            .into_iter()
+            .filter(|event| event.operation == "retire-wait")
+            .collect();
+        assert_eq!(retirement.len(), 1);
+        assert_eq!(retirement[0].buffer, identity(&*ordinary.raw));
+
+        EVENTS.with_borrow_mut(Vec::clear);
+        enc.begin_encoding(None).unwrap();
+        enc.enter_blit();
+        let post = enc.end_encoding().unwrap();
+        queue.submit(&[&post], &[], (&fence, 2)).unwrap();
+        queue.submit(&[], &[], (&fence, 3)).unwrap();
+        assert!(device
+            .wait(&fence, 3, Some(core::time::Duration::from_secs(30)))
+            .unwrap());
+        assert_eq!(
+            events()
+                .iter()
+                .map(|event| event.operation)
+                .collect::<Vec<_>>(),
+            ["commit"]
+        );
+        drop(abandoned);
+        assert_eq!(
+            queue
+                .shared
+                .command_buffer_created_not_submitted
+                .load(atomic::Ordering::Acquire),
+            0
+        );
+        device.destroy_fence(fence);
+    }
+}
+
+#[test]
+fn query_only_compute_and_render_passes_join_once() {
+    let Some(crate::OpenDevice { device, queue }) = open() else {
+        return;
+    };
+    let vertex = buffer(&device, 36);
+    let entries = triangles(&vertex);
+    let (blas, _) = storage(&device, &entries);
+    let mut group = m::BindGroup::default();
+    group
+        .buffers
+        .push(m::BufferLikeResource::AccelerationStructure(NonNull::from(
+            &*blas.raw,
+        )));
+    group.counters.cs.buffers = 1;
+    group.counters.vs.buffers = 1;
+    group.counters.fs.buffers = 1;
+    let info = m::BindGroupLayoutInfo {
+        base_resource_indices: Default::default(),
+    };
+    let mut enc = encoder(&device, &queue);
+    let texture_desc = objc2_metal::MTLTextureDescriptor::new();
+    texture_desc.setPixelFormat(objc2_metal::MTLPixelFormat::RGBA8Unorm);
+    unsafe {
+        texture_desc.setWidth(1);
+        texture_desc.setHeight(1);
+    }
+    texture_desc.setUsage(objc2_metal::MTLTextureUsage::RenderTarget);
+    let target = m::TextureView {
+        raw: device
+            .shared
+            .device
+            .newTextureWithDescriptor(&texture_desc)
+            .unwrap(),
+        aspects: crate::FormatAspects::COLOR,
+    };
+    unsafe {
+        enc.begin_encoding(None).unwrap();
+        enc.begin_compute_pass(&crate::ComputePassDescriptor {
+            label: None,
+            timestamp_writes: None,
+        });
+        let raw = enc.state.compute.as_ref().unwrap().clone();
+        for _ in 0..2 {
+            enc.update_bind_group_state(
+                Encoder::Compute(&raw),
+                Default::default(),
+                &info,
+                &[],
+                0,
+                &group,
+            );
+        }
+        enc.end_compute_pass();
+        let compute = enc.end_encoding().unwrap();
+        assert!(compute.contains_acceleration_structure_commands);
+        assert_recording(identity(&*compute.raw), &["compute-wait", "compute-update"]);
+
+        enc.begin_encoding(None).unwrap();
+        enc.begin_render_pass(&crate::RenderPassDescriptor {
+            label: None,
+            extent: wgt::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            sample_count: 1,
+            color_attachments: &[Some(crate::ColorAttachment {
+                target: crate::Attachment {
+                    view: &target,
+                    usage: wgt::TextureUses::COLOR_TARGET,
+                },
+                depth_slice: None,
+                resolve_target: None,
+                ops: crate::AttachmentOps::STORE | crate::AttachmentOps::LOAD_CLEAR,
+                clear_value: wgt::Color::BLACK,
+            })],
+            depth_stencil_attachment: None,
+            multiview_mask: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        })
+        .unwrap();
+        let raw = enc.state.render.as_ref().unwrap().clone();
+        enc.update_bind_group_state(
+            Encoder::Vertex(&raw),
+            Default::default(),
+            &info,
+            &[],
+            0,
+            &group,
+        );
+        enc.update_bind_group_state(
+            Encoder::Fragment(&raw),
+            Default::default(),
+            &info,
+            &[],
+            0,
+            &group,
+        );
+        enc.end_render_pass();
+        let render = enc.end_encoding().unwrap();
+        assert!(render.contains_acceleration_structure_commands);
+        assert_recording(identity(&*render.raw), &["render-wait", "render-update"]);
+        assert!(!queue.shared.acceleration_structure_sync.lock().seeded);
+        // These bindings deliberately never dispatch or draw against the unbuilt AS.
+        drop((compute, render));
+        enc.begin_encoding(None).unwrap();
+        enc.begin_compute_pass(&crate::ComputePassDescriptor {
+            label: None,
+            timestamp_writes: None,
+        });
+        enc.end_compute_pass();
+        assert!(
+            !enc.end_encoding()
+                .unwrap()
+                .contains_acceleration_structure_commands
+        );
+    }
+}
+
+#[test]
+fn tlas_recorded_before_blas_and_compact_size_retirement() {
+    let Some(crate::OpenDevice { mut device, queue }) = open() else {
+        return;
+    };
+    Arc::get_mut(&mut device.shared)
+        .unwrap()
+        .settings
+        .retain_command_buffer_references = false;
+    let vertex = buffer(&device, 36);
+    let vertices = [-1.0f32, -1.0, 1.0, 1.0, -1.0, 1.0, 0.0, 1.0, 1.0];
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            vertices.as_ptr().cast::<u8>(),
+            vertex.raw.contents().as_ptr().cast(),
+            36,
+        );
+    }
+    let entries = triangles(&vertex);
+    let (blas, scratch) = storage(&device, &entries);
+    let instances = device.tlas_instance_to_bytes(crate::TlasInstance {
+        transform: [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+        custom_data: 7,
+        mask: 255,
+        blas_address: unsafe { device.get_acceleration_structure_device_address(&blas) },
+    });
+    let instance_buffer = buffer(&device, instances.len());
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            instances.as_ptr(),
+            instance_buffer.raw.contents().as_ptr().cast(),
+            instances.len(),
+        );
+    }
+    let tlas_entries =
+        crate::AccelerationStructureEntries::Instances(crate::AccelerationStructureInstances {
+            buffer: Some(&instance_buffer),
+            offset: 0,
+            count: 1,
+        });
+    let (tlas, tlas_scratch) = storage(&device, &tlas_entries);
+    let compact_size = buffer(&device, 8);
+    let fence = unsafe { device.create_fence().unwrap() };
+    let mut producer = encoder(&device, &queue);
+    let mut consumer = encoder(&device, &queue);
+    for split in [false, true] {
+        EVENTS.with_borrow_mut(Vec::clear);
+        unsafe {
+            consumer.begin_encoding(None).unwrap();
+            build(&mut consumer, &tlas_entries, &tlas, &tlas_scratch);
+            consumer.read_acceleration_structure_compact_size(&tlas, &compact_size);
+            let consumer_buffer = consumer.end_encoding().unwrap();
+            producer.begin_encoding(None).unwrap();
+            build(&mut producer, &entries, &blas, &scratch);
+            let producer_buffer = producer.end_encoding().unwrap();
+            m::CommandEncoder::set_acceleration_structure_dependencies(
+                &[&consumer_buffer],
+                &[&blas],
+            );
+            let consumer_id = identity(&*consumer_buffer.raw);
+            assert_recording(
+                consumer_id,
+                &[
+                    "as-wait",
+                    "build",
+                    "as-update",
+                    "as-end",
+                    "as-wait",
+                    "compact-size",
+                    "as-update",
+                    "as-end",
+                ],
+            );
+            if split {
+                queue.submit(&[&producer_buffer], &[], (&fence, 2)).unwrap();
+                queue.submit(&[&consumer_buffer], &[], (&fence, 3)).unwrap();
+            } else {
+                queue
+                    .submit(&[&producer_buffer, &consumer_buffer], &[], (&fence, 1))
+                    .unwrap();
+            }
+            assert!(device
+                .wait(
+                    &fence,
+                    if split { 3 } else { 1 },
+                    Some(core::time::Duration::from_secs(30))
+                )
+                .unwrap());
+            assert_eq!(
+                consumer_buffer.raw.status(),
+                MTLCommandBufferStatus::Completed
+            );
+            assert_ne!(compact_size.raw.contents().cast::<u32>().as_ptr().read(), 0);
+            let commits: Vec<_> = events()
+                .into_iter()
+                .filter(|event| event.operation == "commit")
+                .map(|event| event.buffer)
+                .collect();
+            assert_eq!(commits, [identity(&*producer_buffer.raw), consumer_id]);
+            let retirement: Vec<_> = events()
+                .into_iter()
+                .filter(|event| event.operation == "retire-wait")
+                .map(|event| event.buffer)
+                .collect();
+            if split {
+                assert_eq!(retirement, [identity(&*producer_buffer.raw), consumer_id]);
+            } else {
+                assert_eq!(retirement, [consumer_id]);
+            }
+        }
+    }
+    unsafe {
+        device.destroy_fence(fence);
+    }
+}
+
+#[test]
+fn independent_build_batch_shares_encoder_and_queue_fence() {
+    let Some(crate::OpenDevice { device, queue }) = open() else {
+        return;
+    };
+    let vertex = buffer(&device, 36);
+    let entries = triangles(&vertex);
+    let (first, first_scratch) = storage(&device, &entries);
+    let (second, second_scratch) = storage(&device, &entries);
+    let mut first_encoder = encoder(&device, &queue);
+    let mut second_encoder = encoder(&device, &queue);
+    let fence = first_encoder.acceleration_structure_fence();
+    assert_eq!(
+        identity(&*fence),
+        identity(&*second_encoder.acceleration_structure_fence())
+    );
+    unsafe {
+        first_encoder.begin_encoding(None).unwrap();
+        second_encoder.begin_encoding(None).unwrap();
+        first_encoder.build_acceleration_structures(
+            2,
+            [(&first, &first_scratch), (&second, &second_scratch)].map(|(destination, scratch)| {
+                crate::BuildAccelerationStructureDescriptor {
+                    entries: &entries,
+                    mode: crate::AccelerationStructureBuildMode::Build,
+                    flags: wgt::AccelerationStructureFlags::empty(),
+                    source_acceleration_structure: None,
+                    destination_acceleration_structure: destination,
+                    scratch_buffer: scratch,
+                    scratch_buffer_offset: 0,
+                }
+            }),
+        );
+        let batch = first_encoder.end_encoding().unwrap();
+        assert_recording(
+            identity(&*batch.raw),
+            &["as-wait", "build", "build", "as-update", "as-end"],
+        );
+        let ids: Vec<_> = events()
+            .into_iter()
+            .filter(|event| event.buffer == identity(&*batch.raw))
+            .map(|event| event.encoder)
+            .collect();
+        assert!(ids.iter().all(|id| *id == ids[0]));
+        second_encoder.discard_encoding();
+        assert!(!queue.shared.acceleration_structure_sync.lock().seeded);
+    }
+}
+
+#[test]
+fn concurrent_recordings_use_commit_order() {
+    let Some(crate::OpenDevice { device, queue }) = open() else {
+        return;
+    };
+    let vertex = buffer(&device, 36);
+    let vertices = [-1.0f32, -1.0, 1.0, 1.0, -1.0, 1.0, 0.0, 1.0, 1.0];
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            vertices.as_ptr().cast::<u8>(),
+            vertex.raw.contents().as_ptr().cast(),
+            36,
+        );
+    }
+    let entries = triangles(&vertex);
+    let (first, first_scratch) = storage(&device, &entries);
+    let (second, second_scratch) = storage(&device, &entries);
+    let rendezvous = std::sync::Barrier::new(2);
+    let record_build = |structure: &m::AccelerationStructure, scratch: &m::Buffer| {
+        let mut enc = encoder(&device, &queue);
+        unsafe {
+            enc.begin_encoding(None).unwrap();
+            build(&mut enc, &entries, structure, scratch);
+            rendezvous.wait();
+            let buffer = enc.end_encoding().unwrap();
+            assert_recording(
+                identity(&*buffer.raw),
+                &["as-wait", "build", "as-update", "as-end"],
+            );
+            buffer
+        }
+    };
+    let (first, second) = std::thread::scope(|scope| {
+        let first = scope.spawn(|| record_build(&first, &first_scratch));
+        let second = scope.spawn(|| record_build(&second, &second_scratch));
+        (first.join().unwrap(), second.join().unwrap())
+    });
+    unsafe {
+        let fence = device.create_fence().unwrap();
+        queue.submit(&[&second, &first], &[], (&fence, 1)).unwrap();
+        assert!(device
+            .wait(&fence, 1, Some(core::time::Duration::from_secs(30)))
+            .unwrap());
+        let commits: Vec<_> = events()
+            .into_iter()
+            .filter(|event| event.operation == "commit")
+            .map(|event| event.buffer)
+            .collect();
+        assert_eq!(commits, [identity(&*second.raw), identity(&*first.raw)]);
+        device.destroy_fence(fence);
+    }
+}

--- a/wgpu-hal/src/metal/command_buffer_slot.rs
+++ b/wgpu-hal/src/metal/command_buffer_slot.rs
@@ -1,0 +1,205 @@
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+/// Admission held from before native allocation until commit or native buffer drop.
+#[derive(Debug)]
+pub(super) struct CommandBufferSlot {
+    count: Arc<AtomicUsize>,
+    submitted: AtomicBool,
+}
+
+impl CommandBufferSlot {
+    pub(super) fn reserve(count: &Arc<AtomicUsize>, limit: usize) -> Result<Self, usize> {
+        count.fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+            (count < limit).then_some(count + 1)
+        })?;
+        Ok(Self {
+            count: Arc::clone(count),
+            submitted: AtomicBool::new(false),
+        })
+    }
+
+    pub(super) fn mark_submitted(&self) {
+        assert!(!self.submitted.swap(true, Ordering::AcqRel));
+        self.release();
+    }
+
+    fn release(&self) {
+        let previous = self.count.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0);
+    }
+}
+
+impl Drop for CommandBufferSlot {
+    fn drop(&mut self) {
+        if !*self.submitted.get_mut() {
+            self.release();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Barrier;
+
+    #[test]
+    fn cpu_admission_refusal_and_reuse() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let first = CommandBufferSlot::reserve(&count, 3).unwrap();
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        let second = CommandBufferSlot::reserve(&count, 3).unwrap();
+        assert_eq!(count.load(Ordering::Acquire), 2);
+        let third = CommandBufferSlot::reserve(&count, 3).unwrap();
+        assert_eq!(count.load(Ordering::Acquire), 3);
+        for _ in 0..2 {
+            assert_eq!(CommandBufferSlot::reserve(&count, 3).unwrap_err(), 3);
+            assert_eq!(count.load(Ordering::Acquire), 3);
+        }
+        drop(second);
+        assert_eq!(count.load(Ordering::Acquire), 2);
+        let replacement = CommandBufferSlot::reserve(&count, 3).unwrap();
+        assert_eq!(count.load(Ordering::Acquire), 3);
+        drop((first, third, replacement));
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        assert_eq!(Arc::strong_count(&count), 1);
+    }
+
+    #[test]
+    fn cpu_discard_clears_encoder_reservation() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let mut encoder_slot = Some(CommandBufferSlot::reserve(&count, 1).unwrap());
+        assert!(encoder_slot.is_some());
+        // discard_encoding clears the raw buffer before clearing this Option.
+        encoder_slot = None;
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        drop(encoder_slot.take());
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        encoder_slot = Some(CommandBufferSlot::reserve(&count, 1).unwrap());
+        drop(encoder_slot);
+        assert_eq!(count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn cpu_finish_transfers_reservation_until_buffer_drop() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let mut encoder_slot = Some(CommandBufferSlot::reserve(&count, 2).unwrap());
+        // end_encoding moves the slot without releasing it; reset_all drops buffers.
+        let finished_slot = encoder_slot.take().unwrap();
+        drop(encoder_slot);
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        let next_recording = CommandBufferSlot::reserve(&count, 2).unwrap();
+        drop(finished_slot);
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        drop(next_recording);
+        assert_eq!(count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn cpu_submit_releases_before_buffer_drop_once() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let submitted = CommandBufferSlot::reserve(&count, 1).unwrap();
+        // Queue::submit calls this after raw.commit(), not at finish or completion.
+        submitted.mark_submitted();
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        let next_recording = CommandBufferSlot::reserve(&count, 1).unwrap();
+        drop(submitted);
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        drop(next_recording);
+        assert_eq!(count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn cpu_duplicate_submission_does_not_double_release() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let submitted = CommandBufferSlot::reserve(&count, 1).unwrap();
+        submitted.mark_submitted();
+        let next_recording = CommandBufferSlot::reserve(&count, 1).unwrap();
+        assert!(std::panic::catch_unwind(|| submitted.mark_submitted()).is_err());
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        drop(submitted);
+        assert_eq!(count.load(Ordering::Acquire), 1);
+        drop(next_recording);
+        assert_eq!(count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn cpu_allocation_unwind_releases_reservation() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let result = std::panic::catch_unwind(|| {
+            let _slot = CommandBufferSlot::reserve(&count, 1).unwrap();
+            // begin_encoding keeps the reservation local while native allocation runs.
+            panic!("simulate allocation failure before storing the raw buffer");
+        });
+        assert!(result.is_err());
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        let slot = CommandBufferSlot::reserve(&count, 1).unwrap();
+        drop(slot);
+        assert_eq!(Arc::strong_count(&count), 1);
+    }
+
+    #[test]
+    fn cpu_concurrent_admissions_respect_limit() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let start = Barrier::new(9);
+        let admitted = Barrier::new(9);
+        let release = Barrier::new(9);
+        std::thread::scope(|scope| {
+            let mut threads = alloc::vec::Vec::new();
+            for _ in 0..8 {
+                threads.push(scope.spawn(|| {
+                    start.wait();
+                    let slot = CommandBufferSlot::reserve(&count, 3);
+                    admitted.wait();
+                    release.wait();
+                    match slot {
+                        Ok(slot) => {
+                            drop(slot);
+                            true
+                        }
+                        Err(current) => {
+                            assert_eq!(current, 3);
+                            false
+                        }
+                    }
+                }));
+            }
+            start.wait();
+            admitted.wait();
+            let held = count.load(Ordering::Acquire);
+            release.wait();
+            assert_eq!(held, 3);
+            let successes = threads
+                .into_iter()
+                .map(|thread| usize::from(thread.join().unwrap()))
+                .sum::<usize>();
+            assert_eq!(successes, 3);
+        });
+        assert_eq!(count.load(Ordering::Acquire), 0);
+        assert_eq!(Arc::strong_count(&count), 1);
+    }
+
+    #[test]
+    fn cpu_reservation_keeps_counter_alive() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let weak = Arc::downgrade(&count);
+        let slot = CommandBufferSlot::reserve(&count, 1).unwrap();
+        drop(count);
+        assert_eq!(weak.upgrade().unwrap().load(Ordering::Acquire), 1);
+        slot.mark_submitted();
+        assert_eq!(weak.upgrade().unwrap().load(Ordering::Acquire), 0);
+        drop(slot);
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn cpu_production_capacity_reserves_one_internal_slot() {
+        assert_eq!(super::super::adapter::MAX_COMMAND_BUFFERS, 4096);
+        assert_eq!(super::super::adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS, 4095);
+        assert_eq!(
+            super::super::adapter::MAX_COMMAND_BUFFERS
+                - super::super::adapter::MAX_UNSUBMITTED_COMMAND_BUFFERS,
+            1
+        );
+    }
+}

--- a/wgpu-hal/src/metal/completion.rs
+++ b/wgpu-hal/src/metal/completion.rs
@@ -1,0 +1,305 @@
+use core::time::Duration;
+use std::time::Instant;
+
+use parking_lot::{Condvar, Mutex};
+
+#[derive(Debug, Default)]
+pub(super) struct Completion {
+    value: Mutex<crate::FenceValue>,
+    changed: Condvar,
+}
+
+impl Completion {
+    pub(super) fn value(&self) -> crate::FenceValue {
+        *self.value.lock()
+    }
+
+    pub(super) fn publish(&self, value: crate::FenceValue, succeeded: bool) -> crate::FenceValue {
+        let mut completed = self.value.lock();
+        // Native callbacks may arrive out of order. Failed buffers only wake
+        // waiters so they can report the native error, not successful completion.
+        if succeeded && value > *completed {
+            *completed = value;
+            self.changed.notify_all();
+        } else if !succeeded {
+            self.changed.notify_all();
+        }
+        *completed
+    }
+
+    pub(super) fn wait(
+        &self,
+        value: crate::FenceValue,
+        timeout: Option<Duration>,
+        mut native_status: impl FnMut() -> Result<bool, crate::DeviceError>,
+    ) -> Result<bool, crate::DeviceError> {
+        // Represent the fixed deadline as origin + duration to avoid overflowing
+        // Instant for large timeouts. Wakeups never reset this origin.
+        let start = Instant::now();
+        let mut completed = self.value.lock();
+        loop {
+            if native_status()? || *completed >= value {
+                return Ok(true);
+            }
+            match timeout {
+                Some(timeout) => {
+                    let remaining = timeout.saturating_sub(start.elapsed());
+                    if remaining.is_zero() {
+                        return Ok(false);
+                    }
+                    self.changed.wait_for(&mut completed, remaining);
+                }
+                None => self.changed.wait(&mut completed),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::sync::Arc;
+    use std::{
+        sync::{mpsc, Barrier},
+        thread,
+    };
+
+    const BOUND: Duration = Duration::from_secs(5);
+
+    #[test]
+    fn cpu_early_completion_and_zero_timeout() {
+        let completion = Completion::default();
+        assert!(!completion
+            .wait(1, Some(Duration::ZERO), || Ok(false))
+            .unwrap());
+        completion.publish(1, true);
+        assert!(completion
+            .wait(1, Some(Duration::ZERO), || Ok(false))
+            .unwrap());
+        assert!(completion.wait(1, None, || Ok(false)).unwrap());
+    }
+
+    #[test]
+    fn cpu_native_status_shortcuts() {
+        let completion = Completion::default();
+        assert!(completion
+            .wait(1, Some(Duration::ZERO), || Ok(true))
+            .unwrap());
+        assert!(matches!(
+            completion.wait(1, None, || Err(crate::DeviceError::Lost)),
+            Err(crate::DeviceError::Lost)
+        ));
+    }
+
+    #[test]
+    fn cpu_check_to_wait_handoff() {
+        let completion = Completion::default();
+        let handoff = Barrier::new(2);
+        thread::scope(|scope| {
+            let publisher = scope.spawn(|| {
+                handoff.wait();
+                // The waiter still owns the predicate lock at the barrier.
+                completion.publish(1, true);
+            });
+            let mut first = true;
+            assert!(completion
+                .wait(1, Some(BOUND), || {
+                    if first {
+                        first = false;
+                        handoff.wait();
+                    }
+                    Ok(false)
+                })
+                .unwrap());
+            publisher.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn cpu_completion_during_lock_acquisition() {
+        let completion = Completion::default();
+        let mut guard = completion.value.lock();
+        let (started, ready) = mpsc::channel();
+        thread::scope(|scope| {
+            let waiter = scope.spawn(|| {
+                started.send(()).unwrap();
+                completion.wait(1, Some(BOUND), || Ok(false)).unwrap()
+            });
+            ready.recv_timeout(BOUND).unwrap();
+            *guard = 1;
+            completion.changed.notify_all();
+            drop(guard);
+            assert!(waiter.join().unwrap());
+        });
+    }
+
+    #[test]
+    fn cpu_indefinite_wait_and_multiple_targets() {
+        let completion = Completion::default();
+        let (checked, checks) = mpsc::channel();
+        let (finished, finishes) = mpsc::channel();
+        thread::scope(|scope| {
+            for target in [1, 2, 2] {
+                let checked = checked.clone();
+                let finished = finished.clone();
+                let completion = &completion;
+                scope.spawn(move || {
+                    let result = completion.wait(target, None, || {
+                        checked.send(target).unwrap();
+                        Ok(false)
+                    });
+                    finished.send((target, result.unwrap())).unwrap();
+                });
+            }
+            for _ in 0..3 {
+                checks.recv_timeout(BOUND).unwrap();
+            }
+            completion.publish(1, true);
+            let first = finishes.recv_timeout(BOUND);
+            assert!(finishes.try_recv().is_err());
+            // Release all waiters even if the first assertion below fails.
+            completion.publish(2, true);
+            assert_eq!(first.unwrap(), (1, true));
+            for _ in 0..2 {
+                assert_eq!(finishes.recv_timeout(BOUND).unwrap(), (2, true));
+            }
+        });
+    }
+
+    #[test]
+    fn cpu_irrelevant_and_spurious_wakeups_keep_deadline() {
+        let completion = Completion::default();
+        let (checked, checks) = mpsc::channel();
+        let (finished, finishes) = mpsc::channel();
+        let (stop, stopped) = mpsc::channel();
+        thread::scope(|scope| {
+            scope.spawn(|| {
+                let start = Instant::now();
+                let result = completion.wait(100, Some(Duration::from_millis(200)), || {
+                    checked.send(()).unwrap();
+                    Ok(false)
+                });
+                finished.send((result.unwrap(), start.elapsed())).unwrap();
+            });
+            checks.recv_timeout(BOUND).unwrap();
+            let completion = &completion;
+            scope.spawn(move || {
+                while matches!(
+                    stopped.recv_timeout(Duration::from_millis(10)),
+                    Err(mpsc::RecvTimeoutError::Timeout)
+                ) {
+                    completion.publish(1, true);
+                    completion.changed.notify_all();
+                }
+            });
+            let result = finishes.recv_timeout(BOUND);
+            stop.send(()).unwrap();
+            let (ready, elapsed) = result.unwrap();
+            assert!(!ready);
+            assert!(elapsed >= Duration::from_millis(200));
+            assert!(elapsed < BOUND);
+            assert!(checks.try_iter().count() > 1);
+        });
+    }
+
+    #[test]
+    fn cpu_ready_status_wins_at_timeout_boundary() {
+        let completion = Completion::default();
+        let (_send, receive) = mpsc::channel::<()>();
+        assert!(completion
+            .wait(1, Some(Duration::from_millis(10)), || {
+                assert_eq!(
+                    receive.recv_timeout(Duration::from_millis(20)),
+                    Err(mpsc::RecvTimeoutError::Timeout)
+                );
+                Ok(true)
+            })
+            .unwrap());
+    }
+
+    #[test]
+    fn cpu_submillisecond_timeout() {
+        let completion = Completion::default();
+        let timeout = Duration::from_micros(100);
+        let start = Instant::now();
+        assert!(!completion.wait(1, Some(timeout), || Ok(false)).unwrap());
+        assert!(start.elapsed() >= timeout);
+        assert!(start.elapsed() < BOUND);
+    }
+
+    #[test]
+    fn cpu_large_timeout_wakes_without_overflow() {
+        let completion = Completion::default();
+        let handoff = Barrier::new(2);
+        thread::scope(|scope| {
+            scope.spawn(|| {
+                handoff.wait();
+                completion.publish(1, true);
+            });
+            let mut first = true;
+            assert!(completion
+                .wait(1, Some(Duration::MAX), || {
+                    if first {
+                        first = false;
+                        handoff.wait();
+                    }
+                    Ok(false)
+                })
+                .unwrap());
+        });
+    }
+
+    #[test]
+    fn cpu_publication_is_monotonic() {
+        let completion = Completion::default();
+        for value in [3, 1, 2, 3, 0] {
+            completion.publish(value, true);
+            assert_eq!(completion.value(), 3);
+        }
+        completion.publish(4, false);
+        assert_eq!(completion.value(), 3);
+        assert!(completion
+            .wait(3, Some(Duration::ZERO), || Ok(false))
+            .unwrap());
+    }
+
+    #[test]
+    fn cpu_failed_completion_wakes_native_error() {
+        let completion = Completion::default();
+        let (checked, checks) = mpsc::channel();
+        thread::scope(|scope| {
+            let completion = &completion;
+            scope.spawn(move || {
+                checks.recv_timeout(BOUND).unwrap();
+                completion.publish(1, false);
+            });
+            let mut first = true;
+            assert!(matches!(
+                completion.wait(1, Some(BOUND), || {
+                    if first {
+                        first = false;
+                        checked.send(()).unwrap();
+                        Ok(false)
+                    } else {
+                        Err(crate::DeviceError::Lost)
+                    }
+                }),
+                Err(crate::DeviceError::Lost)
+            ));
+        });
+        assert_eq!(completion.value(), 0);
+    }
+
+    #[test]
+    fn cpu_completed_block_keeps_state_alive() {
+        let completion = Arc::new(Completion::default());
+        let weak = Arc::downgrade(&completion);
+        let captured = Arc::clone(&completion);
+        let block = block2::RcBlock::new(move || captured.publish(1, true));
+        drop(completion);
+        block.call(());
+        assert_eq!(weak.upgrade().unwrap().value(), 1);
+        drop(block);
+        assert!(weak.upgrade().is_none());
+    }
+}

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -740,6 +740,7 @@ impl crate::Device for super::Device {
             shared: Arc::clone(&self.shared),
             queue_shared: Arc::clone(&desc.queue.shared),
             raw_cmd_buf: None,
+            acceleration_structure_fence: None,
             state: super::CommandState::default(),
             temp: super::Temp::default(),
             counters: Arc::clone(&self.counters),

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1,7 +1,6 @@
 use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
-use core::{ptr::NonNull, sync::atomic};
+use core::ptr::NonNull;
 use parking_lot::RwLock;
-use std::{thread, time};
 
 use bytemuck::TransparentWrapper;
 use objc2::{
@@ -415,6 +414,14 @@ impl super::Device {
         }
     }
 
+    /// # Safety
+    ///
+    /// `raw` must belong to the device using this buffer, and `size` must not
+    /// exceed its allocation. Its resolved hazard tracking mode must be tracked,
+    /// or the caller must independently synchronize all conflicting accesses,
+    /// including compute/blit writes before acceleration-structure input reads.
+    /// Resource-use declarations provide residency but do not synchronize an
+    /// untracked import; the AS fence does not cover preceding non-AS producers.
     pub unsafe fn buffer_from_raw(
         raw: Retained<ProtocolObject<dyn MTLBuffer>>,
         size: wgt::BufferAddress,
@@ -735,12 +742,22 @@ impl crate::Device for super::Device {
         &self,
         desc: &crate::CommandEncoderDescriptor<super::Queue>,
     ) -> Result<super::CommandEncoder, crate::DeviceError> {
+        if self
+            .features
+            .contains(wgt::Features::EXPERIMENTAL_RAY_QUERY)
+        {
+            desc.queue
+                .shared
+                .acceleration_structure_sync
+                .lock()
+                .initialize_fence(|| self.shared.device.newFence())?;
+        }
         self.counters.command_encoders.add(1);
         Ok(super::CommandEncoder {
             shared: Arc::clone(&self.shared),
             queue_shared: Arc::clone(&desc.queue.shared),
             raw_cmd_buf: None,
-            acceleration_structure_fence: None,
+            command_buffer_slot: None,
             state: super::CommandState::default(),
             temp: super::Temp::default(),
             counters: Arc::clone(&self.counters),
@@ -1887,7 +1904,7 @@ impl crate::Device for super::Device {
             None
         };
         Ok(super::Fence {
-            completed_value: Arc::new(atomic::AtomicU64::new(0)),
+            completed_value: Arc::new(super::completion::Completion::default()),
             pending_command_buffers: RwLock::new(Vec::new()),
             shared_event,
         })
@@ -1898,14 +1915,7 @@ impl crate::Device for super::Device {
     }
 
     unsafe fn get_fence_value(&self, fence: &super::Fence) -> DeviceResult<crate::FenceValue> {
-        let mut max_value = fence.completed_value.load(atomic::Ordering::Acquire);
-        let pending_command_buffers = fence.pending_command_buffers.read();
-        for &(value, ref cmd_buf) in pending_command_buffers.iter() {
-            if cmd_buf.status() == MTLCommandBufferStatus::Completed {
-                max_value = value;
-            }
-        }
-        Ok(max_value)
+        Ok(fence.get_latest())
     }
     unsafe fn wait(
         &self,
@@ -1913,7 +1923,7 @@ impl crate::Device for super::Device {
         wait_value: crate::FenceValue,
         timeout: Option<core::time::Duration>,
     ) -> DeviceResult<bool> {
-        if wait_value <= fence.completed_value.load(atomic::Ordering::Acquire) {
+        if wait_value <= fence.completed_value.value() {
             return Ok(true);
         }
 
@@ -1925,6 +1935,11 @@ impl crate::Device for super::Device {
         {
             Some((_, cmd_buf)) => cmd_buf.clone(),
             None => {
+                drop(pending_command_buffers);
+                // Maintenance may have retired the buffer since the fast check.
+                if wait_value <= fence.completed_value.value() {
+                    return Ok(true);
+                }
                 log::error!("No active command buffers for fence value {wait_value}");
                 return Err(crate::DeviceError::Lost);
             }
@@ -1933,18 +1948,13 @@ impl crate::Device for super::Device {
         // Make sure that nothing is blocked during the actual wait.
         drop(pending_command_buffers);
 
-        let start = time::Instant::now();
-        loop {
-            if let MTLCommandBufferStatus::Completed = cmd_buf.status() {
-                return Ok(true);
-            }
-            if let Some(timeout) = timeout {
-                if start.elapsed() >= timeout {
-                    return Ok(false);
-                }
-            }
-            thread::sleep(core::time::Duration::from_millis(1));
-        }
+        fence
+            .completed_value
+            .wait(wait_value, timeout, || match cmd_buf.status() {
+                MTLCommandBufferStatus::Completed => Ok(true),
+                MTLCommandBufferStatus::Error => Err(crate::DeviceError::Lost),
+                _ => Ok(false),
+            })
     }
 
     unsafe fn start_graphics_debugger_capture(&self) -> bool {

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -48,7 +48,7 @@ use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLArgumentBuffersTier,
     MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue,
     MTLComputeCommandEncoder, MTLComputePipelineState, MTLCounterSampleBuffer, MTLCullMode,
-    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLIndexType,
+    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLFence, MTLIndexType,
     MTLLanguageVersion, MTLLibrary, MTLPrimitiveType, MTLReadWriteTextureTier,
     MTLRenderCommandEncoder, MTLRenderPipelineState, MTLRenderStages, MTLResource,
     MTLResourceUsage, MTLSamplerState, MTLSharedEvent, MTLSize, MTLTexture, MTLTextureType,
@@ -1084,6 +1084,20 @@ struct CommandState {
     blit: Option<Retained<ProtocolObject<dyn MTLBlitCommandEncoder>>>,
     acceleration_structure_builder:
         Option<Retained<ProtocolObject<dyn MTLAccelerationStructureCommandEncoder>>>,
+    /// Fence used to order acceleration structure encoders split by
+    /// `CommandEncoder::split_acceleration_structure_builder`. Created lazily
+    /// and kept alive for the lifetime of the encoder. Command buffers
+    /// created with unretained references do not retain this fence, so the
+    /// encoder (which owns it) must be kept alive until its submitted
+    /// command buffers have finished executing.
+    acceleration_structure_fence: Option<Retained<ProtocolObject<dyn MTLFence>>>,
+    /// Whether the next acceleration structure encoder must wait on
+    /// [`Self::acceleration_structure_fence`] before encoding any commands.
+    pending_acceleration_structure_fence_wait: bool,
+    /// Whether the current acceleration structure encoder has encoded any
+    /// builds, i.e. whether commands consuming their results must split the
+    /// encoder first.
+    acceleration_structure_builder_has_builds: bool,
     render: Option<Retained<ProtocolObject<dyn MTLRenderCommandEncoder>>>,
     compute: Option<Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>>,
     raw_primitive_type: MTLPrimitiveType,

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -22,6 +22,8 @@ end of the VS buffer table.
 )]
 mod adapter;
 mod command;
+mod command_buffer_slot;
+mod completion;
 mod conv;
 mod device;
 mod library_from_metallib;
@@ -46,9 +48,9 @@ use objc2::{
 use objc2_foundation::ns_string;
 use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLArgumentBuffersTier,
-    MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue,
-    MTLComputeCommandEncoder, MTLComputePipelineState, MTLCounterSampleBuffer, MTLCullMode,
-    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLEvent, MTLFence,
+    MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandEncoder,
+    MTLCommandQueue, MTLComputeCommandEncoder, MTLComputePipelineState, MTLCounterSampleBuffer,
+    MTLCullMode, MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLFence,
     MTLIndexType, MTLLanguageVersion, MTLLibrary, MTLPrimitiveType, MTLReadWriteTextureTier,
     MTLRenderCommandEncoder, MTLRenderPipelineState, MTLRenderStages, MTLResource,
     MTLResourceUsage, MTLSamplerState, MTLSharedEvent, MTLSize, MTLTexture, MTLTextureType,
@@ -458,6 +460,10 @@ pub struct Queue {
 static_assertions::assert_impl_all!(Queue: Send, Sync);
 
 impl Queue {
+    /// # Safety
+    ///
+    /// The queue must support at least `MAX_COMMAND_BUFFERS` (4096) live command
+    /// buffers. External users must not consume that budget while wgpu uses it.
     pub unsafe fn queue_from_raw(
         raw: Retained<ProtocolObject<dyn MTLCommandQueue>>,
         timestamp_period: f32,
@@ -465,7 +471,7 @@ impl Queue {
         Self {
             shared: Arc::new(QueueShared {
                 raw,
-                command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
+                command_buffer_created_not_submitted: Arc::new(atomic::AtomicUsize::new(0)),
                 acceleration_structure_sync: Mutex::default(),
             }),
             timestamp_period,
@@ -487,48 +493,42 @@ pub struct QueueShared {
     // (In a few places we call `.commandBuffer{,WithUnretainedReferences}` directly
     // to create command buffers for internal purposes. In those cases we always
     // commit the buffer immediately, so we don't adjust the counter for them.)
-    command_buffer_created_not_submitted: atomic::AtomicUsize,
-    // Synchronization for acceleration structure command encoders. Metal does
-    // not order acceleration structure commands against each other, whether
-    // they share an encoder or not. Within one command buffer,
-    // `CommandEncoder` orders the encoders with an `MTLFence`. Across command
-    // buffers, `Queue::submit` links whole command buffers with the event in
-    // here, in commit order. See `AccelerationStructureSync`.
+    command_buffer_created_not_submitted: Arc<atomic::AtomicUsize>,
+    // Serializes commits and internal allocations through commit, not recording.
+    // The single reserved native slot cannot be held by another uncommitted
+    // internal buffer. Fence dependencies are evaluated at commit.
     acceleration_structure_sync: Mutex<AccelerationStructureSync>,
 }
 
-/// Cross-command-buffer ordering of acceleration structure commands.
-///
-/// Metal orders a command buffer against the command buffers committed before
-/// it, but acceleration structure commands are exempt: a build in one command
-/// buffer can observe an acceleration structure mid-build of an earlier
-/// command buffer, even though the two are committed back to back. The
-/// exemption is not limited to acceleration structure work on either side: a
-/// build races *any* earlier command buffer, including one that encodes data
-/// the build consumes.
-///
-/// The pairing is decided at submit time, not encode time, because Metal
-/// defines it in terms of commits: once a submission contains acceleration
-/// structure commands, every command buffer of that submission, and of every
-/// later submission on the queue, waits, before it starts executing, on the
-/// value the previous chained command buffer signals when its commands
-/// complete, and signals a fresh value after its own commands. Chaining whole
-/// submissions closes the exemption against all earlier work; values are
-/// assigned and encoded under the enclosing mutex, which `submit` holds until
-/// the command buffers are committed, so every wait references a value whose
-/// command buffer has been or is being committed and therefore will signal. A
-/// command buffer dropped without submission never takes part, so no wait can
-/// outlive the command buffer that satisfies it.
 #[derive(Debug, Default)]
 struct AccelerationStructureSync {
-    /// The queue-wide event, created on first use. Acceleration structure
-    /// commands only exist on hardware and OS versions where `MTLEvent` is
-    /// available.
-    event: Option<Retained<ProtocolObject<dyn MTLEvent>>>,
-    /// The value the next chained command buffer must wait on; 0 means there
-    /// is no acceleration structure work on the queue yet, so no submission
-    /// is chained.
-    last_signaled_value: u64,
+    // Apple evaluates wait-before-update reuse when buffers are committed,
+    // so recording order and abandoned buffers do not reserve dependencies.
+    fence: Option<Retained<ProtocolObject<dyn MTLFence>>>,
+    seeded: bool,
+}
+
+impl AccelerationStructureSync {
+    fn initialize_fence(
+        &mut self,
+        allocate: impl FnOnce() -> Option<Retained<ProtocolObject<dyn MTLFence>>>,
+    ) -> Result<(), crate::DeviceError> {
+        if self.fence.is_none() {
+            self.fence = Some(allocate().ok_or(crate::DeviceError::OutOfMemory)?);
+        }
+        Ok(())
+    }
+}
+
+impl QueueShared {
+    fn acceleration_structure_fence(&self) -> Retained<ProtocolObject<dyn MTLFence>> {
+        self.acceleration_structure_sync
+            .lock()
+            .fence
+            .as_ref()
+            .expect("ray-query encoder setup must initialize the queue fence")
+            .clone()
+    }
 }
 
 pub struct Device {
@@ -583,66 +583,35 @@ impl crate::Queue for Queue {
         (signal_fence, signal_value): (&Fence, crate::FenceValue),
     ) -> Result<(), crate::DeviceError> {
         autoreleasepool(|_| -> Result<(), crate::DeviceError> {
-            // Link command buffers into the commit-order chain (see
-            // `AccelerationStructureSync`). The mutex is held until the
-            // command buffers are committed so that a concurrent submission
-            // cannot commit between this submission's value assignments and
-            // its commits.
-            let mut acceleration_structure_sync = self.shared.acceleration_structure_sync.lock();
-            // Metal exempts acceleration structure commands from the
-            // back-to-back execution of command buffers committed in order,
-            // so an acceleration structure build is not ordered against any
-            // earlier command buffer: not even against a copy in the same
-            // submission of data the build consumes (for example the
-            // instance buffer of a top level acceleration structure, which
-            // wgpu-core encodes onto an internal command buffer of the same
-            // submission). The event chain therefore serializes whole
-            // command buffers from the first submission that contains
-            // acceleration structure commands onward: every command buffer
-            // of such a submission waits on the value the previous chained
-            // command buffer signals at completion, which orders the
-            // acceleration structure commands against all earlier work on
-            // the queue, and signals a fresh value that later submissions
-            // wait on in turn.
-            let chain_entire_submission = acceleration_structure_sync.last_signaled_value > 0
-                || command_buffers
-                    .iter()
-                    .any(|cmd_buffer| cmd_buffer.contains_acceleration_structure_commands);
-            for cmd_buffer in command_buffers {
-                if !chain_entire_submission {
-                    continue;
-                }
-                let event = match acceleration_structure_sync.event.clone() {
-                    Some(event) => event,
-                    None => {
-                        let event = self
-                            .shared
-                            .raw
-                            .device()
-                            .newEvent()
-                            .ok_or(crate::DeviceError::OutOfMemory)?;
-                        acceleration_structure_sync.event = Some(event.clone());
-                        event
-                    }
-                };
-                if acceleration_structure_sync.last_signaled_value > 0 {
-                    cmd_buffer.raw.encodeWaitForEvent_value(
-                        event.as_ref(),
-                        acceleration_structure_sync.last_signaled_value,
-                    );
-                }
-                acceleration_structure_sync.last_signaled_value += 1;
-                cmd_buffer.raw.encodeSignalEvent_value(
-                    event.as_ref(),
-                    acceleration_structure_sync.last_signaled_value,
-                );
+            let mut sync = self.shared.acceleration_structure_sync.lock();
+            let participates = command_buffers
+                .iter()
+                .any(|buffer| buffer.contains_acceleration_structure_commands);
+            if participates && !sync.seeded {
+                // Every participant waits before updating. Seed the fence with a
+                // committed producer, independently of recording or discard order.
+                let raw = self.shared.raw.commandBuffer().unwrap();
+                let encoder = raw.blitCommandEncoder().unwrap();
+                encoder.updateFence(sync.fence.as_ref().unwrap());
+                encoder.endEncoding();
+                #[cfg(test)]
+                command::tests::record(&raw, None, "seed-commit");
+                raw.commit();
+                sync.seeded = true;
             }
 
             let extra_command_buffer = {
                 let completed_value = Arc::clone(&signal_fence.completed_value);
-                let block = block2::RcBlock::new(move |_cmd_buf| {
-                    completed_value.store(signal_value, atomic::Ordering::Release);
-                });
+                // Keep the domain fence alive even for unretained command buffers.
+                let queue_shared = Arc::clone(&self.shared);
+                let block = block2::RcBlock::new(
+                    move |cmd_buf: NonNull<ProtocolObject<dyn MTLCommandBuffer>>| {
+                        let _keep_alive = &queue_shared;
+                        let succeeded = unsafe { cmd_buf.as_ref() }.status()
+                            == MTLCommandBufferStatus::Completed;
+                        completed_value.publish(signal_value, succeeded);
+                    },
+                );
 
                 let raw = match command_buffers.last() {
                     Some(&cmd_buf) => cmd_buf.raw.clone(),
@@ -655,6 +624,19 @@ impl crate::Queue for Queue {
                             .unwrap()
                     }
                 };
+                if participates {
+                    // This tail wait joins AS work for submission retirement;
+                    // producer/consumer waits are already in the relevant passes.
+                    let encoder = raw.blitCommandEncoder().unwrap();
+                    encoder.waitForFence(sync.fence.as_ref().unwrap());
+                    #[cfg(test)]
+                    command::tests::record(
+                        &raw,
+                        Some(command::tests::identity(&*encoder)),
+                        "retire-wait",
+                    );
+                    encoder.endEncoding();
+                }
                 raw.setLabel(Some(ns_string!("(wgpu internal) Signal")));
                 unsafe { raw.addCompletedHandler(block2::RcBlock::as_ptr(&block)) };
 
@@ -675,15 +657,10 @@ impl crate::Queue for Queue {
             };
 
             for cmd_buffer in command_buffers {
+                #[cfg(test)]
+                command::tests::record(&cmd_buffer.raw, None, "commit");
                 cmd_buffer.raw.commit();
-                // One command buffer per `end_encoding` call moves from the
-                // "created but not yet submitted" bucket into the submitted
-                // set, so update the counter.
-                let previous = self
-                    .shared
-                    .command_buffer_created_not_submitted
-                    .fetch_sub(1, atomic::Ordering::AcqRel);
-                debug_assert!(previous > 0);
+                cmd_buffer.slot.mark_submitted();
             }
 
             if let Some(raw) = extra_command_buffer {
@@ -699,6 +676,7 @@ impl crate::Queue for Queue {
         texture: SurfaceTexture,
     ) -> Result<(), crate::SurfaceError> {
         autoreleasepool(|_| {
+            let _sync = self.shared.acceleration_structure_sync.lock();
             // We do not bother adjusting `command_buffer_created_not_submitted`
             // because we immediately commit this buffer.
             let command_buffer = self.shared.raw.commandBuffer().unwrap();
@@ -725,6 +703,7 @@ impl crate::Queue for Queue {
 
     unsafe fn wait_for_idle(&self) -> Result<(), crate::DeviceError> {
         autoreleasepool(|_| {
+            let _sync = self.shared.acceleration_structure_sync.lock();
             let command_buffer = self.shared.raw.commandBuffer().unwrap();
             command_buffer.setLabel(Some(ns_string!("(wgpu internal) wait_for_idle")));
             command_buffer.commit();
@@ -970,6 +949,10 @@ pub struct BindGroup {
 
     argument_buffers: Vec<Retained<ProtocolObject<dyn MTLBuffer>>>,
     resources_to_use: HashMap<NonNull<ProtocolObject<dyn MTLResource>>, UseResourceInfo>,
+    /// True when the group contains acceleration structures encoded into an
+    /// argument buffer. Those ride on the argument-buffer bind path, which
+    /// would otherwise skip the acceleration structure build fence wait.
+    uses_acceleration_structures: bool,
 }
 
 impl crate::DynBindGroup for BindGroup {}
@@ -1126,7 +1109,7 @@ unsafe impl Sync for QuerySet {}
 
 #[derive(Debug)]
 pub struct Fence {
-    completed_value: Arc<atomic::AtomicU64>,
+    completed_value: Arc<completion::Completion>,
     /// The pending fence values have to be ascending.
     pending_command_buffers: RwLock<Vec<PendingCommandBuffer>>,
     shared_event: Option<Retained<ProtocolObject<dyn MTLSharedEvent>>>,
@@ -1144,14 +1127,16 @@ unsafe impl Sync for Fence {}
 
 impl Fence {
     fn get_latest(&self) -> crate::FenceValue {
-        let mut max_value = self.completed_value.load(atomic::Ordering::Acquire);
+        let mut max_value = self.completed_value.value();
         let pending_command_buffers = self.pending_command_buffers.read();
         for &(value, ref cmd_buf) in pending_command_buffers.iter() {
             if cmd_buf.status() == MTLCommandBufferStatus::Completed {
-                max_value = value;
+                max_value = max_value.max(value);
             }
         }
-        max_value
+        drop(pending_command_buffers);
+        // Cache native status observations before maintain can discard them.
+        self.completed_value.publish(max_value, true)
     }
 
     fn maintain(&self) {
@@ -1182,9 +1167,7 @@ struct CommandState {
     blit: Option<Retained<ProtocolObject<dyn MTLBlitCommandEncoder>>>,
     acceleration_structure_builder:
         Option<Retained<ProtocolObject<dyn MTLAccelerationStructureCommandEncoder>>>,
-    /// Whether this command buffer has encoded any acceleration structure
-    /// commands. `Queue::submit` orders command buffers with acceleration
-    /// structure commands against each other based on this.
+    /// Whether this recording builds, copies, or queries an acceleration structure.
     contains_acceleration_structure_commands: bool,
     /// Whether the current acceleration structure encoder has encoded any
     /// acceleration structure commands, i.e. whether a later
@@ -1192,11 +1175,8 @@ struct CommandState {
     /// first. wgpu-core emits a barrier between all other pairs of
     /// acceleration structure commands, which closes the encoder anyway.
     acceleration_structure_builder_has_commands: bool,
-    /// Whether an earlier acceleration structure encoder in this command
-    /// buffer updated `CommandEncoder::acceleration_structure_fence` and no
-    /// encoder has waited on it yet. The next acceleration structure encoder
-    /// in this command buffer must wait before encoding commands.
-    acceleration_structure_fence_updated: bool,
+    /// Whether the current compute/render pass has joined the AS domain.
+    acceleration_structure_pass: bool,
     render: Option<Retained<ProtocolObject<dyn MTLRenderCommandEncoder>>>,
     compute: Option<Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>>,
     raw_primitive_type: MTLPrimitiveType,
@@ -1236,13 +1216,7 @@ pub struct CommandEncoder {
     shared: Arc<AdapterShared>,
     queue_shared: Arc<QueueShared>,
     raw_cmd_buf: Option<Retained<ProtocolObject<dyn MTLCommandBuffer>>>,
-    /// Fence ordering the acceleration structure encoders of this command
-    /// buffer against each other. It is created on first use and belongs to
-    /// this command buffer alone: Metal requires the command buffer whose
-    /// pass updates a fence to be committed before the command buffer whose
-    /// pass waits on it, so a fence shared with other command buffers would
-    /// reintroduce an encode-order requirement that wgpu does not guarantee.
-    acceleration_structure_fence: Option<Retained<ProtocolObject<dyn MTLFence>>>,
+    command_buffer_slot: Option<command_buffer_slot::CommandBufferSlot>,
     state: CommandState,
     temp: Temp,
     counters: Arc<wgt::HalCounters>,
@@ -1262,11 +1236,11 @@ unsafe impl Sync for CommandEncoder {}
 #[derive(Debug)]
 pub struct CommandBuffer {
     raw: Retained<ProtocolObject<dyn MTLCommandBuffer>>,
-    queue_shared: Arc<QueueShared>,
-    /// Whether this command buffer encoded any acceleration structure
-    /// commands. A submission containing such a command buffer is chained
-    /// whole by `Queue::submit` based on this. See
-    /// `AccelerationStructureSync`.
+    // Field order drops the native buffer before releasing unsubmitted admission.
+    slot: command_buffer_slot::CommandBufferSlot,
+    // Keep the queue's AS fence alive for unretained command buffers.
+    _queue_shared: Arc<QueueShared>,
+    /// Includes query-only compute and render passes.
     contains_acceleration_structure_commands: bool,
 }
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -48,8 +48,8 @@ use objc2_metal::{
     MTLAccelerationStructure, MTLAccelerationStructureCommandEncoder, MTLArgumentBuffersTier,
     MTLBlitCommandEncoder, MTLBuffer, MTLCommandBuffer, MTLCommandBufferStatus, MTLCommandQueue,
     MTLComputeCommandEncoder, MTLComputePipelineState, MTLCounterSampleBuffer, MTLCullMode,
-    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLFence, MTLIndexType,
-    MTLLanguageVersion, MTLLibrary, MTLPrimitiveType, MTLReadWriteTextureTier,
+    MTLDepthClipMode, MTLDepthStencilState, MTLDevice, MTLDrawable, MTLEvent, MTLFence,
+    MTLIndexType, MTLLanguageVersion, MTLLibrary, MTLPrimitiveType, MTLReadWriteTextureTier,
     MTLRenderCommandEncoder, MTLRenderPipelineState, MTLRenderStages, MTLResource,
     MTLResourceUsage, MTLSamplerState, MTLSharedEvent, MTLSize, MTLTexture, MTLTextureType,
     MTLTriangleFillMode, MTLWinding,
@@ -466,6 +466,7 @@ impl Queue {
             shared: Arc::new(QueueShared {
                 raw,
                 command_buffer_created_not_submitted: atomic::AtomicUsize::new(0),
+                acceleration_structure_sync: Mutex::default(),
             }),
             timestamp_period,
         }
@@ -487,6 +488,47 @@ pub struct QueueShared {
     // to create command buffers for internal purposes. In those cases we always
     // commit the buffer immediately, so we don't adjust the counter for them.)
     command_buffer_created_not_submitted: atomic::AtomicUsize,
+    // Synchronization for acceleration structure command encoders. Metal does
+    // not order acceleration structure commands against each other, whether
+    // they share an encoder or not. Within one command buffer,
+    // `CommandEncoder` orders the encoders with an `MTLFence`. Across command
+    // buffers, `Queue::submit` links whole command buffers with the event in
+    // here, in commit order. See `AccelerationStructureSync`.
+    acceleration_structure_sync: Mutex<AccelerationStructureSync>,
+}
+
+/// Cross-command-buffer ordering of acceleration structure commands.
+///
+/// Metal orders a command buffer against the command buffers committed before
+/// it, but acceleration structure commands are exempt: a build in one command
+/// buffer can observe an acceleration structure mid-build of an earlier
+/// command buffer, even though the two are committed back to back. The
+/// exemption is not limited to acceleration structure work on either side: a
+/// build races *any* earlier command buffer, including one that encodes data
+/// the build consumes.
+///
+/// The pairing is decided at submit time, not encode time, because Metal
+/// defines it in terms of commits: once a submission contains acceleration
+/// structure commands, every command buffer of that submission, and of every
+/// later submission on the queue, waits, before it starts executing, on the
+/// value the previous chained command buffer signals when its commands
+/// complete, and signals a fresh value after its own commands. Chaining whole
+/// submissions closes the exemption against all earlier work; values are
+/// assigned and encoded under the enclosing mutex, which `submit` holds until
+/// the command buffers are committed, so every wait references a value whose
+/// command buffer has been or is being committed and therefore will signal. A
+/// command buffer dropped without submission never takes part, so no wait can
+/// outlive the command buffer that satisfies it.
+#[derive(Debug, Default)]
+struct AccelerationStructureSync {
+    /// The queue-wide event, created on first use. Acceleration structure
+    /// commands only exist on hardware and OS versions where `MTLEvent` is
+    /// available.
+    event: Option<Retained<ProtocolObject<dyn MTLEvent>>>,
+    /// The value the next chained command buffer must wait on; 0 means there
+    /// is no acceleration structure work on the queue yet, so no submission
+    /// is chained.
+    last_signaled_value: u64,
 }
 
 pub struct Device {
@@ -540,7 +582,62 @@ impl crate::Queue for Queue {
         _surface_textures: &[&SurfaceTexture],
         (signal_fence, signal_value): (&Fence, crate::FenceValue),
     ) -> Result<(), crate::DeviceError> {
-        autoreleasepool(|_| {
+        autoreleasepool(|_| -> Result<(), crate::DeviceError> {
+            // Link command buffers into the commit-order chain (see
+            // `AccelerationStructureSync`). The mutex is held until the
+            // command buffers are committed so that a concurrent submission
+            // cannot commit between this submission's value assignments and
+            // its commits.
+            let mut acceleration_structure_sync = self.shared.acceleration_structure_sync.lock();
+            // Metal exempts acceleration structure commands from the
+            // back-to-back execution of command buffers committed in order,
+            // so an acceleration structure build is not ordered against any
+            // earlier command buffer: not even against a copy in the same
+            // submission of data the build consumes (for example the
+            // instance buffer of a top level acceleration structure, which
+            // wgpu-core encodes onto an internal command buffer of the same
+            // submission). The event chain therefore serializes whole
+            // command buffers from the first submission that contains
+            // acceleration structure commands onward: every command buffer
+            // of such a submission waits on the value the previous chained
+            // command buffer signals at completion, which orders the
+            // acceleration structure commands against all earlier work on
+            // the queue, and signals a fresh value that later submissions
+            // wait on in turn.
+            let chain_entire_submission = acceleration_structure_sync.last_signaled_value > 0
+                || command_buffers
+                    .iter()
+                    .any(|cmd_buffer| cmd_buffer.contains_acceleration_structure_commands);
+            for cmd_buffer in command_buffers {
+                if !chain_entire_submission {
+                    continue;
+                }
+                let event = match acceleration_structure_sync.event.clone() {
+                    Some(event) => event,
+                    None => {
+                        let event = self
+                            .shared
+                            .raw
+                            .device()
+                            .newEvent()
+                            .ok_or(crate::DeviceError::OutOfMemory)?;
+                        acceleration_structure_sync.event = Some(event.clone());
+                        event
+                    }
+                };
+                if acceleration_structure_sync.last_signaled_value > 0 {
+                    cmd_buffer.raw.encodeWaitForEvent_value(
+                        event.as_ref(),
+                        acceleration_structure_sync.last_signaled_value,
+                    );
+                }
+                acceleration_structure_sync.last_signaled_value += 1;
+                cmd_buffer.raw.encodeSignalEvent_value(
+                    event.as_ref(),
+                    acceleration_structure_sync.last_signaled_value,
+                );
+            }
+
             let extra_command_buffer = {
                 let completed_value = Arc::clone(&signal_fence.completed_value);
                 let block = block2::RcBlock::new(move |_cmd_buf| {
@@ -592,8 +689,9 @@ impl crate::Queue for Queue {
             if let Some(raw) = extra_command_buffer {
                 raw.commit();
             }
-        });
-        Ok(())
+
+            Ok(())
+        })
     }
     unsafe fn present(
         &self,
@@ -1084,20 +1182,21 @@ struct CommandState {
     blit: Option<Retained<ProtocolObject<dyn MTLBlitCommandEncoder>>>,
     acceleration_structure_builder:
         Option<Retained<ProtocolObject<dyn MTLAccelerationStructureCommandEncoder>>>,
-    /// Fence used to order acceleration structure encoders split by
-    /// `CommandEncoder::split_acceleration_structure_builder`. Created lazily
-    /// and kept alive for the lifetime of the encoder. Command buffers
-    /// created with unretained references do not retain this fence, so the
-    /// encoder (which owns it) must be kept alive until its submitted
-    /// command buffers have finished executing.
-    acceleration_structure_fence: Option<Retained<ProtocolObject<dyn MTLFence>>>,
-    /// Whether the next acceleration structure encoder must wait on
-    /// [`Self::acceleration_structure_fence`] before encoding any commands.
-    pending_acceleration_structure_fence_wait: bool,
+    /// Whether this command buffer has encoded any acceleration structure
+    /// commands. `Queue::submit` orders command buffers with acceleration
+    /// structure commands against each other based on this.
+    contains_acceleration_structure_commands: bool,
     /// Whether the current acceleration structure encoder has encoded any
-    /// builds, i.e. whether commands consuming their results must split the
-    /// encoder first.
-    acceleration_structure_builder_has_builds: bool,
+    /// acceleration structure commands, i.e. whether a later
+    /// `read_acceleration_structure_compact_size` must close the encoder
+    /// first. wgpu-core emits a barrier between all other pairs of
+    /// acceleration structure commands, which closes the encoder anyway.
+    acceleration_structure_builder_has_commands: bool,
+    /// Whether an earlier acceleration structure encoder in this command
+    /// buffer updated `CommandEncoder::acceleration_structure_fence` and no
+    /// encoder has waited on it yet. The next acceleration structure encoder
+    /// in this command buffer must wait before encoding commands.
+    acceleration_structure_fence_updated: bool,
     render: Option<Retained<ProtocolObject<dyn MTLRenderCommandEncoder>>>,
     compute: Option<Retained<ProtocolObject<dyn MTLComputeCommandEncoder>>>,
     raw_primitive_type: MTLPrimitiveType,
@@ -1137,6 +1236,13 @@ pub struct CommandEncoder {
     shared: Arc<AdapterShared>,
     queue_shared: Arc<QueueShared>,
     raw_cmd_buf: Option<Retained<ProtocolObject<dyn MTLCommandBuffer>>>,
+    /// Fence ordering the acceleration structure encoders of this command
+    /// buffer against each other. It is created on first use and belongs to
+    /// this command buffer alone: Metal requires the command buffer whose
+    /// pass updates a fence to be committed before the command buffer whose
+    /// pass waits on it, so a fence shared with other command buffers would
+    /// reintroduce an encode-order requirement that wgpu does not guarantee.
+    acceleration_structure_fence: Option<Retained<ProtocolObject<dyn MTLFence>>>,
     state: CommandState,
     temp: Temp,
     counters: Arc<wgt::HalCounters>,
@@ -1157,6 +1263,11 @@ unsafe impl Sync for CommandEncoder {}
 pub struct CommandBuffer {
     raw: Retained<ProtocolObject<dyn MTLCommandBuffer>>,
     queue_shared: Arc<QueueShared>,
+    /// Whether this command buffer encoded any acceleration structure
+    /// commands. A submission containing such a command buffer is chained
+    /// whole by `Queue::submit` based on this. See
+    /// `AccelerationStructureSync`.
+    contains_acceleration_structure_commands: bool,
 }
 
 impl crate::DynCommandBuffer for CommandBuffer {}

--- a/wgpu/src/api/device.rs
+++ b/wgpu/src/api/device.rs
@@ -392,6 +392,11 @@ impl Device {
     /// - `hal_buffer` must be created respecting `desc`
     /// - `hal_buffer` must be initialized
     /// - `hal_buffer` must not have zero size
+    /// - On Metal, the buffer's resolved hazard tracking mode must be tracked,
+    ///   or the caller must independently synchronize all conflicting accesses,
+    ///   including compute/blit writes before acceleration-structure input reads.
+    ///   wgpu's resource-use declarations do not synchronize untracked imports,
+    ///   and its AS fence does not cover preceding non-AS producers.
     #[cfg(wgpu_core)]
     #[must_use]
     pub unsafe fn create_buffer_from_hal<A: hal::Api>(


### PR DESCRIPTION
**Connections**

Supersedes #9645. All of the original analysis and the first fix are @jtbirdsell's — this branch is his `fix/metal-as-sync` history plus two follow-up commits (`ac6935b11` regression tests, `14f3ea9ab` the sync rework below). Push access to the original head branch was not available, so the follow-ups land here. Fixes #9215.

**Description**

`place_acceleration_structure_barrier` was a no-op on Metal and Metal does not order acceleration structure commands within one `MTLAccelerationStructureCommandEncoder`, so a TLAS build could consume a still-building BLAS (#9215). The base design (per #9645) split the encoder at sync points with `updateFence:`/`waitForFence:` and chained events across unsubmitted command buffers.

Stress testing that design on hardware (GPU frame capture, `MTL_SHADER_VALIDATION` enabled) showed two problems: it serialized every subsequent unsubmitted command buffer behind acceleration structure work, and it could not express "wait only for builds this pass actually consumes." The follow-up commit reworks the core mechanism into a **seeded encoder fence**:

- One lazily created `MTLFence` per encoder lifetime. Every participating command buffer waits on it before its first update and updates it when it submits — ordering is expressed per participating encoder instead of by chaining events across the queue.
- The fence is **seeded** by a dedicated committed command buffer before first use, so the first waiter also synchronizes with work that completed before the fence existed (no stale-signaled-fence hazard).
- A retiring tail command buffer waits and re-signals, so later waiters depend only on the most recent unwaited submission instead of the full history.
- Passes consult per-bind-group acceleration structure usage, so ray-query passes wait on their own behalf, and `useResourceUsage` declares build inputs (read), scratch (read-write), and compaction sizes (write) explicitly.
- Fence allocation moved into fallible encoder creation; one native command-buffer slot is reserved for internal submissions (`MAX_UNSUBMITTED_COMMAND_BUFFERS = MAX_COMMAND_BUFFERS - 1`), and the completion handler — not the dropped `CommandBuffer` — keeps the queue alive.
- `Device::poll`/wait wakeups come from native completed handlers instead of one-millisecond polling.

**Testing**

All on Apple M4 Max (macOS, Metal, hardware RT), single-device via `cargo nextest`, fresh `.gpuconfig` per checkout:

- `cargo test -p wgpu-hal --features metal` (single-threaded): 31 tests pass, 0 fail (1 ignored: 4096-command-buffer capacity test).
- New hardware sync-trace unit tests in `wgpu-hal`: record/consumer identity tracking, per-command-buffer fence events.
- `wgpu-gpu` regression group `issue_9215 + as_*`: 38/38, including three new `issue_9215` tests — recording a consumer before the producer, rejecting a consumer submitted before its producer's recording, and first-build-after-compute-upload ordering.
- `ray_traced_triangle` and `ray_scene` examples render (bounded runs, frame-time logs inspected).
- `cargo fmt --check` clean; `cargo clippy -p wgpu-hal -p wgpu-types` clean.

**Squash or Rebase?**

Squash (same as #9645).

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] Validation and feature gates are in place to confine behavioral changes.
- [x] Tests demonstrate the validation and altered logic works.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
