### PR TITLE
Add `Utf16SourceLocation` and support having it in `CompilationMessage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
 - Zero-size vertex and index buffer bindings are now accepted by `set_vertex_buffer` and `set_index_buffer`. By @andyleiserson in [#9848](https://github.com/gfx-rs/wgpu/pull/9848).
 - Added the `snorm10-10-10-2` vertex format on Metal and Vulkan. Not yet supported on DX12. By @andyleiserson in [#10226](https://github.com/gfx-rs/wgpu/pull/10226).
+- Added `Utf16SourceLocation` which is analogue to `SourceLocation` but using UTF-16 code units. Added `Utf16SourceLocation::to_utf8` and `SourceLocation::to_utf16` to convert between them. By @sagudev in [#10294](https://github.com/gfx-rs/wgpu/pull/10294).
 
 #### Naga
 

--- a/deno_webgpu/shader.rs
+++ b/deno_webgpu/shader.rs
@@ -129,22 +129,15 @@ impl GPUCompilationMessage {
 
     match loc {
       Some(loc) => {
-        let len_utf16 = |s: &str| s.chars().map(|c| c.len_utf16() as u64).sum();
-
-        let start = loc.offset as usize;
-
-        // Naga reports a `line_pos` using UTF-8 bytes, so we cannot use it.
-        let line_start =
-          source[0..start].rfind('\n').map(|pos| pos + 1).unwrap_or(0);
-        let line_pos = len_utf16(&source[line_start..start]) + 1;
+        let loc = loc.to_utf16(source);
 
         Self {
           message,
           r#type: GPUCompilationMessageType::Error,
           line_num: loc.line_number.into(),
-          line_pos,
-          offset: len_utf16(&source[0..start]),
-          length: len_utf16(&source[start..start + loc.length as usize]),
+          line_pos: loc.line_position.into(),
+          offset: loc.offset.into(),
+          length: loc.length.into(),
         }
       }
       _ => Self {

--- a/wgpu-types/src/compilation_info.rs
+++ b/wgpu-types/src/compilation_info.rs
@@ -7,27 +7,27 @@ use serde::{Deserialize, Serialize};
 /// Compilation information for a shader module.
 ///
 /// Corresponds to [WebGPU `GPUCompilationInfo`](https://gpuweb.github.io/gpuweb/#gpucompilationinfo).
-/// The source locations use bytes, and index a UTF-8 encoded string.
+/// The source locations use bytes, and index a UTF-8 or UTF-16 encoded string.
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct CompilationInfo {
+pub struct CompilationInfo<SL = SourceLocation> {
     /// The messages from the shader compilation process.
-    pub messages: Vec<CompilationMessage>,
+    pub messages: Vec<CompilationMessage<SL>>,
 }
 
 /// A single message from the shader compilation process.
 ///
 /// Roughly corresponds to [`GPUCompilationMessage`](https://www.w3.org/TR/webgpu/#gpucompilationmessage),
-/// except that the location uses UTF-8 for all positions.
+/// except that the location may use UTF-8 for all positions.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct CompilationMessage {
+pub struct CompilationMessage<SL = SourceLocation> {
     /// The text of the message.
     pub message: String,
     /// The type of the message.
     pub message_type: CompilationMessageType,
     /// Where in the source code the message points at.
-    pub location: Option<SourceLocation>,
+    pub location: Option<SL>,
 }
 
 /// The type of a compilation message.
@@ -51,7 +51,7 @@ pub enum CompilationMessageType {
 /// - `line_position` is in bytes (UTF-8 code units), and is usually not directly intended for humans.
 ///
 /// [gcm]: https://www.w3.org/TR/webgpu/#gpucompilationmessage
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SourceLocation {
     /// 1-based line number.
@@ -63,4 +63,82 @@ pub struct SourceLocation {
     pub offset: u32,
     /// Length in code units (in bytes) of the span.
     pub length: u32,
+}
+
+/// A human-readable representation for a span, tailored for text source.
+///
+/// Corresponds to the positional members of [`GPUCompilationMessage`][gcm] from
+/// the WebGPU specification.
+///
+/// Instead of using UTF-8 code units, this uses UTF-16 code units,
+/// which is what the WebGPU specification uses.
+///
+/// [gcm]: https://www.w3.org/TR/webgpu/#gpucompilationmessage
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Utf16SourceLocation {
+    /// 1-based line number.
+    pub line_number: u32,
+    /// 1-based column in code units (in bytes) of the start of the span.
+    /// Remember to convert accordingly when displaying to the user.
+    pub line_position: u32,
+    /// 0-based Offset in code units (in bytes) of the start of the span.
+    pub offset: u32,
+    /// Length in code units (in bytes) of the span.
+    pub length: u32,
+}
+
+impl SourceLocation {
+    /// Converts a `SourceLocation` in UTF-8 code units to UTF-16 code units.
+    pub fn to_utf16(&self, source: &str) -> Utf16SourceLocation {
+        let len_utf16 = |s: &str| s.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
+        let start = self.offset as usize;
+        let end = start + self.length as usize;
+        let utf16_offset = len_utf16(&source[..start]);
+        let utf16_length = len_utf16(&source[start..end]);
+
+        let line_start = source[..start].rfind('\n').map_or(0, |pos| pos + 1);
+        let utf16_line_position = len_utf16(&source[line_start..start]) + 1;
+
+        Utf16SourceLocation {
+            line_number: self.line_number,
+            line_position: utf16_line_position,
+            offset: utf16_offset,
+            length: utf16_length,
+        }
+    }
+}
+
+impl Utf16SourceLocation {
+    /// Converts a `SourceLocation` in UTF-16 code units to UTF-8 code units.
+    pub fn to_utf8(&self, source: &str) -> SourceLocation {
+        fn map_utf16_to_utf8_offset(utf16_offset: u32, text: &str) -> u32 {
+            let mut utf16_i = 0;
+            for (utf8_index, c) in text.char_indices() {
+                if utf16_i >= utf16_offset {
+                    return utf8_index as u32;
+                }
+                utf16_i += c.len_utf16() as u32;
+            }
+            if utf16_i >= utf16_offset {
+                text.len() as u32
+            } else {
+                log::error!("UTF16 offset {utf16_offset} is out of bounds for string {text}");
+                u32::MAX
+            }
+        }
+        let utf8_offset = map_utf16_to_utf8_offset(self.offset, source);
+        let utf8_length = map_utf16_to_utf8_offset(self.length, &source[utf8_offset as usize..]);
+
+        let prefix = &source[..utf8_offset as usize];
+        let line_start = prefix.rfind('\n').map(|pos| pos + 1).unwrap_or(0) as u32;
+        let utf8_line_position = utf8_offset - line_start + 1; // Counting UTF-8 bytes
+
+        SourceLocation {
+            line_number: self.line_number,
+            line_position: utf8_line_position,
+            offset: utf8_offset,
+            length: utf8_length,
+        }
+    }
 }

--- a/wgpu/src/backend/webgpu.rs
+++ b/wgpu/src/backend/webgpu.rs
@@ -147,22 +147,6 @@ enum WebShaderCompilationInfo {
     },
 }
 
-fn map_utf16_to_utf8_offset(utf16_offset: u32, text: &str) -> u32 {
-    let mut utf16_i = 0;
-    for (utf8_index, c) in text.char_indices() {
-        if utf16_i >= utf16_offset {
-            return utf8_index as u32;
-        }
-        utf16_i += c.len_utf16() as u32;
-    }
-    if utf16_i >= utf16_offset {
-        text.len() as u32
-    } else {
-        log::error!("UTF16 offset {utf16_offset} is out of bounds for string {text}");
-        u32::MAX
-    }
-}
-
 fn compilation_message_from_js(
     js_message: webgpu_sys::GpuCompilationMessage,
     compilation_info: &WebShaderCompilationInfo,
@@ -178,20 +162,18 @@ fn compilation_message_from_js(
     let span = match compilation_info {
         WebShaderCompilationInfo::Wgsl { .. } if utf16_offset == 0 && utf16_length == 0 => None,
         WebShaderCompilationInfo::Wgsl { source } => {
-            let offset = map_utf16_to_utf8_offset(utf16_offset, source);
-            let length = map_utf16_to_utf8_offset(utf16_length, &source[offset as usize..]);
             let line_number = js_message.line_num() as u32; // That's legal, because we're counting lines the same way
+            let utf16_line_position = js_message.line_pos() as u32;
 
-            let prefix = &source[..offset as usize];
-            let line_start = prefix.rfind('\n').map(|pos| pos + 1).unwrap_or(0) as u32;
-            let line_position = offset - line_start + 1; // Counting UTF-8 byte indices
-
-            Some(crate::SourceLocation {
-                offset,
-                length,
-                line_number,
-                line_position,
-            })
+            Some(
+                wgt::Utf16SourceLocation {
+                    offset: utf16_offset,
+                    length: utf16_length,
+                    line_number,
+                    line_position: utf16_line_position,
+                }
+                .to_utf8(source),
+            )
         }
         WebShaderCompilationInfo::Transformed { .. } => None,
     };


### PR DESCRIPTION
**Description**
Make `CompilationInfo` and `CompilationMessage` generic over `SourceLocation`, so one can use it in newly added `Utf16SourceLocation` which has location encoded in UTF-16 CodePoints. This allows us to centralize conversions between them in wgpu-types. to_utf8 is needed by webgpu backend and to_uft16 is used by deno and will also be used by Servo and Firefox.

**Testing**
Just refactor.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
