### PR TITLE
Implement unconfigure in wgc and use it for configure

### DIFF
--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -109,7 +109,7 @@ impl GPUCanvasContext {
 
     let err = self.wgpu_surface.configure(&device.wgpu_device, &conf);
 
-    device.error_handler.push_error(err);
+    device.error_handler.push_error(err.err());
 
     self.config.borrow_mut().replace(Configuration {
       device,
@@ -204,7 +204,7 @@ impl GPUCanvasContext {
       .wgpu_surface
       .configure(&config.device.wgpu_device, &config.surface_config);
 
-    config.device.error_handler.push_error(err);
+    config.device.error_handler.push_error(err.err());
   }
 }
 

--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -107,9 +107,9 @@ impl GPUCanvasContext {
 
     let device = configuration.device;
 
-    let err = self.wgpu_surface.configure(&device.wgpu_device, &conf);
+    let result = self.wgpu_surface.configure(&device.wgpu_device, &conf);
 
-    device.error_handler.push_error(err.err());
+    device.error_handler.push_error(result.err());
 
     self.config.borrow_mut().replace(Configuration {
       device,
@@ -200,11 +200,11 @@ impl GPUCanvasContext {
     config.surface_config.width = width;
     config.surface_config.height = height;
 
-    let err = self
+    let result = self
       .wgpu_surface
       .configure(&config.device.wgpu_device, &config.surface_config);
 
-    config.device.error_handler.push_error(err.err());
+    config.device.error_handler.push_error(result.err());
   }
 }
 

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -193,7 +193,7 @@ fn main() {
                                     } else {
                                         let error = surface.configure(self.device, &config);
                                         self.configured_surface_id = Some(surface_id);
-                                        if let Some(e) = error {
+                                        if let Err(e) = error {
                                             panic!("{e:?}");
                                         }
                                     }
@@ -250,7 +250,7 @@ fn main() {
                     WindowEvent::Resized(_) => {
                         if let Some(config) = self.resize_config.take() {
                             let error = surface.configure(self.device, &config);
-                            if let Some(e) = error {
+                            if let Err(e) = error {
                                 panic!("{e:?}");
                             }
                         }

--- a/player/src/bin/play.rs
+++ b/player/src/bin/play.rs
@@ -191,9 +191,9 @@ fn main() {
                                         self.resize_config = Some(config);
                                         break;
                                     } else {
-                                        let error = surface.configure(self.device, &config);
+                                        let result = surface.configure(self.device, &config);
                                         self.configured_surface_id = Some(surface_id);
-                                        if let Err(e) = error {
+                                        if let Err(e) = result {
                                             panic!("{e:?}");
                                         }
                                     }
@@ -249,8 +249,8 @@ fn main() {
                     }
                     WindowEvent::Resized(_) => {
                         if let Some(config) = self.resize_config.take() {
-                            let error = surface.configure(self.device, &config);
-                            if let Err(e) = error {
+                            let result = surface.configure(self.device, &config);
+                            if let Err(e) = result {
                                 panic!("{e:?}");
                             }
                         }

--- a/wgpu-core/src/device/mod.rs
+++ b/wgpu-core/src/device/mod.rs
@@ -173,6 +173,7 @@ impl RenderPassContext {
 
 pub type BufferMapPendingClosure = (BufferMapOperation, BufferAccessResult);
 
+#[must_use]
 #[derive(Default)]
 pub struct UserClosures {
     pub mappings: Vec<BufferMapPendingClosure>,

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -856,11 +856,42 @@ impl Surface {
             .map(|surface| surface.as_ref())
     }
 
+    fn unconfigure_inner(&self) {
+        if let Some(mut present) = self.presentation.lock().take() {
+            if let Some(texture) = present.acquired_texture.take() {
+                texture.destroy();
+            }
+
+            let user_callbacks;
+            {
+                // Wait for all work to finish
+                let snatch_guard = present.device.snatchable_lock.read();
+
+                (user_callbacks, _) = present
+                    .device
+                    .maintain(wgt::PollType::wait_indefinitely(), snatch_guard);
+            }
+
+            for (&backend, surface) in &self.surface_per_backend {
+                if backend == present.device.backend() {
+                    unsafe { surface.unconfigure(present.device.raw()) };
+                }
+            }
+
+            user_callbacks.fire();
+        }
+    }
+
+    pub fn unconfigure(self: &Arc<Self>) {
+        profiling::scope!("Surface::unconfigure");
+        self.unconfigure_inner();
+    }
+
     pub fn configure(
         self: &Arc<Self>,
         device: &Arc<Device>,
         config: &wgt::SurfaceConfiguration<Vec<wgt::TextureFormat>>,
-    ) -> Option<ConfigureSurfaceError> {
+    ) -> Result<(), ConfigureSurfaceError> {
         use ConfigureSurfaceError as E;
         profiling::scope!("Surface::configure");
 
@@ -873,152 +904,92 @@ impl Surface {
 
         log::debug!("configuring surface with {config:?}");
 
-        let error = 'error: {
-            // User callbacks must not be called while we are holding locks.
-            let user_callbacks;
-            {
-                if let Err(e) = device.check_is_valid() {
-                    break 'error e.into();
-                }
+        let caps = self
+            .get_hal_capabilities(&device.adapter)
+            .map_err(|_| E::UnsupportedQueueFamily)?;
 
-                let caps = match self.get_hal_capabilities(&device.adapter) {
-                    Ok(caps) => caps,
-                    Err(_) => break 'error E::UnsupportedQueueFamily,
-                };
-
-                let mut hal_view_formats = Vec::new();
-                for format in config.view_formats.iter() {
-                    if *format == config.format {
-                        continue;
-                    }
-                    if !caps.formats.iter().any(|fc| fc.format == config.format) {
-                        break 'error E::UnsupportedFormat {
-                            requested: config.format,
-                            available: caps.texture_formats().collect(),
-                        };
-                    }
-                    if config.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
-                        break 'error E::InvalidViewFormat(*format, config.format);
-                    }
-                    hal_view_formats.push(*format);
-                }
-
-                if !hal_view_formats.is_empty() {
-                    if let Err(missing_flag) =
-                        device.require_downlevel_flags(wgt::DownlevelFlags::SURFACE_VIEW_FORMATS)
-                    {
-                        break 'error E::MissingDownlevelFlags(missing_flag);
-                    }
-                }
-
-                let maximum_frame_latency = config.desired_maximum_frame_latency.clamp(
-                    *caps.maximum_frame_latency.start(),
-                    *caps.maximum_frame_latency.end(),
-                );
-                let mut hal_config = hal::SurfaceConfiguration {
-                    maximum_frame_latency,
-                    present_mode: config.present_mode,
-                    composite_alpha_mode: config.alpha_mode,
-                    format: config.format,
-                    color_space: config.color_space,
-                    extent: wgt::Extent3d {
-                        width: config.width,
-                        height: config.height,
-                        depth_or_array_layers: 1,
-                    },
-                    usage: crate::conv::map_texture_usage(
-                        config.usage,
-                        hal::FormatAspects::COLOR,
-                        wgt::TextureFormatFeatureFlags::STORAGE_READ_ONLY
-                            | wgt::TextureFormatFeatureFlags::STORAGE_WRITE_ONLY
-                            | wgt::TextureFormatFeatureFlags::STORAGE_READ_WRITE,
-                    ),
-                    view_formats: hal_view_formats,
-                };
-
-                if let Err(error) = crate::device::surface_config::validate_surface_configuration(
-                    &mut hal_config,
-                    &caps,
-                    device.limits.max_texture_dimension_2d,
-                ) {
-                    break 'error error;
-                }
-
-                // Wait for all work to finish before configuring the surface.
-                let snatch_guard = device.snatchable_lock.read();
-
-                let maintain_result;
-                (user_callbacks, maintain_result) =
-                    device.maintain(wgt::PollType::wait_indefinitely(), snatch_guard);
-
-                match maintain_result {
-                    // We're happy
-                    Ok(wgt::PollStatus::QueueEmpty) => {}
-                    Ok(wgt::PollStatus::WaitSucceeded) => {
-                        // After the wait, the queue should be empty. It can only be non-empty
-                        // if another thread is submitting at the same time.
-                        break 'error E::GpuWaitTimeout;
-                    }
-                    Ok(wgt::PollStatus::Poll) => {
-                        unreachable!("Cannot get a Poll result from a Wait action.")
-                    }
-                    Err(WaitIdleError::Timeout) if cfg!(target_family = "wasm") => {
-                        // On wasm, you cannot actually successfully wait for the surface.
-                        // However WebGL does not actually require you do this, so ignoring
-                        // the failure is totally fine. See
-                        // https://github.com/gfx-rs/wgpu/issues/7363
-                    }
-                    Err(e) => {
-                        break 'error e.into();
-                    }
-                }
-
-                // All textures must be destroyed before the surface can be re-configured.
-                if let Some(present) = self.presentation.lock().take() {
-                    if present.acquired_texture.is_some() {
-                        break 'error E::PreviousOutputExists;
-                    }
-                }
-
-                // TODO: Texture views may still be alive that point to the texture.
-                // this will allow the user to render to the surface texture, long after
-                // it has been removed.
-                //
-                // https://github.com/gfx-rs/wgpu/issues/4105
-
-                let surface_raw = self.raw(device.backend()).unwrap();
-                match unsafe { surface_raw.configure(device.raw(), &hal_config) } {
-                    Ok(()) => (),
-                    Err(error) => {
-                        break 'error match error {
-                            hal::SurfaceError::Outdated
-                            | hal::SurfaceError::Lost
-                            | hal::SurfaceError::Occluded
-                            | hal::SurfaceError::Timeout => E::InvalidSurface,
-                            hal::SurfaceError::Device(error) => {
-                                E::Device(device.handle_hal_error(error))
-                            }
-                            hal::SurfaceError::Other(message) => {
-                                log::error!("surface configuration failed: {message}");
-                                E::InvalidSurface
-                            }
-                        }
-                    }
-                }
-
-                let mut presentation = self.presentation.lock();
-                *presentation = Some(Presentation {
-                    device: Arc::clone(device),
-                    config: config.clone(),
-                    acquired_texture: None,
+        let mut hal_view_formats = Vec::new();
+        for format in config.view_formats.iter() {
+            if *format == config.format {
+                continue;
+            }
+            if !caps.formats.iter().any(|fc| fc.format == config.format) {
+                return Err(E::UnsupportedFormat {
+                    requested: config.format,
+                    available: caps.texture_formats().collect(),
                 });
             }
+            if config.format.remove_srgb_suffix() != format.remove_srgb_suffix() {
+                return Err(E::InvalidViewFormat(*format, config.format));
+            }
+            hal_view_formats.push(*format);
+        }
 
-            user_callbacks.fire();
-            return None;
+        if !hal_view_formats.is_empty() {
+            device.require_downlevel_flags(wgt::DownlevelFlags::SURFACE_VIEW_FORMATS)?;
+        }
+
+        let maximum_frame_latency = config.desired_maximum_frame_latency.clamp(
+            *caps.maximum_frame_latency.start(),
+            *caps.maximum_frame_latency.end(),
+        );
+        let mut hal_config = hal::SurfaceConfiguration {
+            maximum_frame_latency,
+            present_mode: config.present_mode,
+            composite_alpha_mode: config.alpha_mode,
+            format: config.format,
+            color_space: config.color_space,
+            extent: wgt::Extent3d {
+                width: config.width,
+                height: config.height,
+                depth_or_array_layers: 1,
+            },
+            usage: crate::conv::map_texture_usage(
+                config.usage,
+                hal::FormatAspects::COLOR,
+                wgt::TextureFormatFeatureFlags::STORAGE_READ_ONLY
+                    | wgt::TextureFormatFeatureFlags::STORAGE_WRITE_ONLY
+                    | wgt::TextureFormatFeatureFlags::STORAGE_READ_WRITE,
+            ),
+            view_formats: hal_view_formats,
         };
 
-        Some(error)
+        crate::device::surface_config::validate_surface_configuration(
+            &mut hal_config,
+            &caps,
+            device.limits.max_texture_dimension_2d,
+        )?;
+
+        self.unconfigure_inner();
+
+        device.check_is_valid()?;
+
+        let surface_raw = self.raw(device.backend()).unwrap();
+        match unsafe { surface_raw.configure(device.raw(), &hal_config) } {
+            Ok(()) => (),
+            Err(error) => {
+                return Err(match error {
+                    hal::SurfaceError::Outdated
+                    | hal::SurfaceError::Lost
+                    | hal::SurfaceError::Occluded
+                    | hal::SurfaceError::Timeout => E::InvalidSurface,
+                    hal::SurfaceError::Device(error) => E::Device(device.handle_hal_error(error)),
+                    hal::SurfaceError::Other(message) => {
+                        log::error!("surface configuration failed: {message}");
+                        E::InvalidSurface
+                    }
+                });
+            }
+        }
+
+        let mut presentation = self.presentation.lock();
+        *presentation = Some(Presentation {
+            device: Arc::clone(device),
+            config: config.clone(),
+            acquired_texture: None,
+        });
+
+        Ok(())
     }
 }
 
@@ -1028,13 +999,7 @@ impl Drop for Surface {
         profiling::scope!("Surface::drop");
 
         api_log!("Surface::drop {:?}", self as *const _);
-        if let Some(present) = self.presentation.lock().take() {
-            for (&backend, surface) in &self.surface_per_backend {
-                if backend == present.device.backend() {
-                    unsafe { surface.unconfigure(present.device.raw()) };
-                }
-            }
-        }
+        self.unconfigure_inner();
     }
 }
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -868,12 +868,25 @@ impl Surface {
 
             let user_callbacks;
             {
-                // Wait for all work to finish
+                // Wait for all work that uses the surface texture to finish
                 let snatch_guard = present.device.snatchable_lock.read();
 
-                (user_callbacks, _) = present
+                let result;
+                (user_callbacks, result) = present
                     .device
                     .maintain(wgt::PollType::wait_indefinitely(), snatch_guard);
+                match result {
+                    Ok(_) => {}
+                    Err(WaitIdleError::Device(_)) => {
+                        // we can ignore device lost errors here, since we are just cleaning up
+                    }
+                    Err(WaitIdleError::Timeout) => {
+                        unreachable!("wait_indefinitely() should never timeout")
+                    }
+                    Err(WaitIdleError::WrongSubmissionIndex(_, _)) => {
+                        unreachable!("no submission index was provided")
+                    }
+                }
             }
             result.extend(user_callbacks);
 

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     id::markers,
     limits::{self, check_limits, FailedLimit},
-    lock::{rank, Mutex},
+    lock::{rank, Mutex, MutexGuard},
     present::{ConfigureSurfaceError, Presentation},
     resource::ResourceType,
     resource_log,
@@ -856,8 +856,12 @@ impl Surface {
             .map(|surface| surface.as_ref())
     }
 
-    fn unconfigure_inner(&self) {
-        if let Some(mut present) = self.presentation.lock().take() {
+    fn unconfigure_inner<'a>(
+        &self,
+        presentation: &mut MutexGuard<'a, Option<Presentation>>,
+    ) -> UserClosures {
+        let mut result = UserClosures::default();
+        if let Some(mut present) = presentation.take() {
             if let Some(texture) = present.acquired_texture.take() {
                 texture.destroy();
             }
@@ -871,20 +875,25 @@ impl Surface {
                     .device
                     .maintain(wgt::PollType::wait_indefinitely(), snatch_guard);
             }
+            result.extend(user_callbacks);
 
             for (&backend, surface) in &self.surface_per_backend {
                 if backend == present.device.backend() {
                     unsafe { surface.unconfigure(present.device.raw()) };
                 }
             }
-
-            user_callbacks.fire();
         }
+        result
     }
 
     pub fn unconfigure(self: &Arc<Self>) {
         profiling::scope!("Surface::unconfigure");
-        self.unconfigure_inner();
+        let user_callbacks;
+        {
+            let mut presentation = self.presentation.lock();
+            user_callbacks = self.unconfigure_inner(&mut presentation);
+        }
+        user_callbacks.fire();
     }
 
     pub fn configure(
@@ -960,34 +969,43 @@ impl Surface {
             device.limits.max_texture_dimension_2d,
         )?;
 
-        self.unconfigure_inner();
-
         device.check_is_valid()?;
 
-        let surface_raw = self.raw(device.backend()).unwrap();
-        match unsafe { surface_raw.configure(device.raw(), &hal_config) } {
-            Ok(()) => (),
-            Err(error) => {
-                return Err(match error {
-                    hal::SurfaceError::Outdated
-                    | hal::SurfaceError::Lost
-                    | hal::SurfaceError::Occluded
-                    | hal::SurfaceError::Timeout => E::InvalidSurface,
-                    hal::SurfaceError::Device(error) => E::Device(device.handle_hal_error(error)),
-                    hal::SurfaceError::Other(message) => {
-                        log::error!("surface configuration failed: {message}");
-                        E::InvalidSurface
-                    }
-                });
-            }
-        }
+        let user_callbacks;
+        {
+            // we keep presentation locked for the entire duration of the configure call,
+            // so that no change can happen in the middle of it.
+            let mut presentation = self.presentation.lock();
 
-        let mut presentation = self.presentation.lock();
-        *presentation = Some(Presentation {
-            device: Arc::clone(device),
-            config: config.clone(),
-            acquired_texture: None,
-        });
+            user_callbacks = self.unconfigure_inner(&mut presentation);
+
+            let surface_raw = self.raw(device.backend()).unwrap();
+            match unsafe { surface_raw.configure(device.raw(), &hal_config) } {
+                Ok(()) => (),
+                Err(error) => {
+                    return Err(match error {
+                        hal::SurfaceError::Outdated
+                        | hal::SurfaceError::Lost
+                        | hal::SurfaceError::Occluded
+                        | hal::SurfaceError::Timeout => E::InvalidSurface,
+                        hal::SurfaceError::Device(error) => {
+                            E::Device(device.handle_hal_error(error))
+                        }
+                        hal::SurfaceError::Other(message) => {
+                            log::error!("surface configuration failed: {message}");
+                            E::InvalidSurface
+                        }
+                    });
+                }
+            }
+
+            *presentation = Some(Presentation {
+                device: Arc::clone(device),
+                config: config.clone(),
+                acquired_texture: None,
+            });
+        }
+        user_callbacks.fire();
 
         Ok(())
     }
@@ -999,7 +1017,12 @@ impl Drop for Surface {
         profiling::scope!("Surface::drop");
 
         api_log!("Surface::drop {:?}", self as *const _);
-        self.unconfigure_inner();
+        let user_closures;
+        {
+            let mut presentation = self.presentation.lock();
+            user_closures = self.unconfigure_inner(&mut presentation);
+        }
+        user_closures.fire();
     }
 }
 

--- a/wgpu/src/api/surface.rs
+++ b/wgpu/src/api/surface.rs
@@ -111,7 +111,6 @@ impl Surface<'_> {
     ///
     /// # Panics
     ///
-    /// - An old [`SurfaceTexture`] is still alive referencing an old surface.
     /// - Texture format requested is unsupported on the surface.
     /// - The requested color space is unsupported for the requested format
     ///   (see [`SurfaceCapabilities::format_capabilities`]).

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2737,7 +2737,7 @@ impl dispatch::SurfaceInterface for CoreSurface {
         let device = device.as_core();
 
         let error = self.wgpu_surface.configure(&device.wgpu_device, config);
-        if let Some(e) = error {
+        if let Some(e) = error.err() {
             device
                 .wgpu_device
                 .handle_error_nolabel(e, "Surface::configure");

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2736,8 +2736,8 @@ impl dispatch::SurfaceInterface for CoreSurface {
     fn configure(&self, device: &dispatch::DispatchDevice, config: &crate::SurfaceConfiguration) {
         let device = device.as_core();
 
-        let error = self.wgpu_surface.configure(&device.wgpu_device, config);
-        if let Some(e) = error.err() {
+        let result = self.wgpu_surface.configure(&device.wgpu_device, config);
+        if let Some(e) = result.err() {
             device
                 .wgpu_device
                 .handle_error_nolabel(e, "Surface::configure");


### PR DESCRIPTION
**Connections**
Fixes #9900
Fixes #4105
Fixes #9899

**Description**
In webgpu spec unconfigure does https://www.w3.org/TR/webgpu/#abstract-opdef-replace-the-drawing-buffer which for us translates to destroying the texture.
We now also call proper unconfigure on configure (as per spec), meaning that we also destroy the texture beforehand so this also fixes #4105. For that reason we also do not keep the device snatch guard read lock alive so long anymore as the texture of the surface will not be used in the queue anymore as it is destroyed.
We now keep presentation locked for the whole unconfigure-configure cycle to prevent any thread going inbetween.

**Testing**
Existing test, but we should probably write more tests.

**Squash or Rebase?**
Squash

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
