### PR TITLE
fix(core): Check for device loss before mapping buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - Fixed a deadlock between `Queue::compact_blas` and `Queue::submit`, which acquired `Device::command_indices` and `Queue::pending_writes` in opposite orders. By @mstampfli in [#10118](https://github.com/gfx-rs/wgpu/pull/10118).
 - Fixed some cases of passing object labels to platform APIs despite `InstanceFlags::DISCARD_HAL_LABELS` being set. By @andyleiserson in [#10121](https://github.com/gfx-rs/wgpu/pull/10121) and [#10123](https://github.com/gfx-rs/wgpu/pull/10123).
 - Clean up resources properly when `Device::new` fails, to avoid a leak or panic. By @andyleiserson in [#10160](https://github.com/gfx-rs/wgpu/pull/10160).
+- Fix pending buffer mappings incorrectly succeeding when the device is lost before they are processed. By @jinleili in [#10301](https://github.com/gfx-rs/wgpu/pull/10301).
 
 #### naga
 

--- a/tests/tests/wgpu-validation/api/buffer_mapping.rs
+++ b/tests/tests/wgpu-validation/api/buffer_mapping.rs
@@ -229,6 +229,40 @@ fn map_async_on_invalid_buffer_calls_callback() {
     );
 }
 
+#[test]
+fn map_async_pending_when_device_destroyed() {
+    use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
+    use std::sync::Arc;
+
+    for (mode, usage) in [
+        (wgpu::MapMode::Read, wgpu::BufferUsages::MAP_READ),
+        (wgpu::MapMode::Write, wgpu::BufferUsages::MAP_WRITE),
+    ] {
+        for size in [0, 16] {
+            let (device, _queue) = wgpu::Device::noop(&wgpu::DeviceDescriptor::default());
+            let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: None,
+                size,
+                usage,
+                mapped_at_creation: false,
+            });
+            let callback_called = Arc::new(AtomicBool::new(false));
+            let callback_called2 = callback_called.clone();
+
+            buffer.map_async(mode, .., move |result| {
+                assert!(result.is_err(), "{mode:?}, size={size}");
+                callback_called2.store(true, SeqCst);
+            });
+            assert!(!callback_called.load(SeqCst));
+
+            device.destroy();
+            device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+            assert!(callback_called.load(SeqCst));
+            assert!(buffer.get_mapped_range(..).is_err());
+        }
+    }
+}
+
 /// Ensure that you cannot unmap a buffer while there are still accessible mapped views.
 #[test]
 #[should_panic(expected = "You cannot unmap a buffer that still has accessible mapped views")]

--- a/wgpu-core/src/resource.rs
+++ b/wgpu-core/src/resource.rs
@@ -996,7 +996,9 @@ impl Buffer {
             }
             _ => panic!("No pending mapping."),
         };
-        let status = if pending_mapping.range.start != pending_mapping.range.end {
+        let status = if let Err(error) = self.device.check_is_valid() {
+            Err(error.into())
+        } else if pending_mapping.range.start != pending_mapping.range.end {
             let host = pending_mapping.op.host;
             let size = pending_mapping.range.end - pending_mapping.range.start;
             match crate::device::map_buffer(


### PR DESCRIPTION
**Connections**

Fixes #10246.

**Description**

A device can become lost after a mapping request is accepted but before `Buffer::map` processes it. Previously, the pending mapping could still complete successfully because the device state was not checked again.

Check for device loss before mapping the buffer, including zero-length ranges. If the device is lost, report the error through the pending mapping callback and leave the buffer unmapped.

**Testing**

Added a regression test using the noop backend. It requests a mapping, destroys the device before polling, and verifies that the callback reports an error and the mapped range is inaccessible. It covers both read and write mappings with zero and nonzero sizes.

The regression test fails without the fix and passes with it.

- `cargo test -p wgpu-test --test wgpu-validation`: 100 tests passed.
- `cargo clippy --tests -p wgpu-test -p wgpu-core`: passed.
- `cargo fmt --all --check`: passed.
