### PR TITLE
fix(metal): permit acquiring drawables until the window has been visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 - BREAKING: Advertise `CompositeAlphaMode::PreMultiplied` instead of `PostMultiplied`, matching the premultiplied alpha compositing that Core Animation actually performs for a non-opaque `CAMetalLayer`. By @nicoburns in [#9922](https://github.com/gfx-rs/wgpu/pull/9922).
   - If you previously hard-coded `PostMultiplied` to get a transparent macOS window, you will start receiving `UnsupportedAlphaMode` validation errors for this. Those affected should migrate to `PreMultiplied` instead.
 - Fix a crash when creating a declared alternate sRGB view of a render-attachment-only surface with Metal API Validation enabled. By @jinleili in [#10280](https://github.com/gfx-rs/wgpu/pull/10280).
+- Fix `Surface::get_current_texture` returning `Occluded` for a window that hasn't been visible yet: before it is shown, or right after, while AppKit hasn't updated its occlusion state. Applications render into such a window to avoid a flash of empty content on first show, and that frame was dropped. Acquisition is now only skipped once the window has been visible and then got occluded. By @tronical in [#10302](https://github.com/gfx-rs/wgpu/pull/10302).
 
 #### GLES
 

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -645,6 +645,9 @@ pub struct Surface {
     render_layer: Mutex<Retained<CAMetalLayer>>,
     swapchain_format: RwLock<Option<wgt::TextureFormat>>,
     extent: RwLock<wgt::Extent3d>,
+    /// Whether the hosting window has been visible at some point, see `acquire_texture`.
+    #[cfg(target_os = "macos")]
+    has_been_visible: atomic::AtomicBool,
 }
 
 unsafe impl Send for Surface {}

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -38,6 +38,8 @@ impl super::Surface {
             render_layer: Mutex::new(layer),
             swapchain_format: RwLock::new(None),
             extent: RwLock::new(wgt::Extent3d::default()),
+            #[cfg(target_os = "macos")]
+            has_been_visible: wgpu_sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -365,14 +367,23 @@ impl crate::Surface for super::Surface {
             // When the window is occluded on macOS, presented drawables get stuck waiting
             // for vsync. Check the window's occlusion state and skip acquisition if
             // the window is not visible - this avoids a 1-second hang in nextDrawable().
+            //
+            // Only drawables presented while the window was visible get stuck, so this
+            // waits until the window has been visible once. Until then, nextDrawable()
+            // returns right away, and applications rely on that to render a first frame
+            // before the window is shown, or right after, while AppKit hasn't updated the
+            // occlusion state yet.
             use objc2::rc::Retained;
+            use wgpu_sync::atomic;
 
             // The CAMetalLayer is typically a sublayer; find the hosting window
             // and skip acquisition while it is occluded.
             if let Some(window) = hosting_window(Retained::into_super(render_layer.clone())) {
                 const NS_WINDOW_OCCLUSION_STATE_VISIBLE: usize = 1 << 1;
                 let occlusion_state: usize = unsafe { objc2::msg_send![&*window, occlusionState] };
-                if occlusion_state & NS_WINDOW_OCCLUSION_STATE_VISIBLE == 0 {
+                if occlusion_state & NS_WINDOW_OCCLUSION_STATE_VISIBLE != 0 {
+                    self.has_been_visible.store(true, atomic::Ordering::Relaxed);
+                } else if self.has_been_visible.load(atomic::Ordering::Relaxed) {
                     return Err(crate::SurfaceError::Occluded);
                 }
             }


### PR DESCRIPTION
fix(metal): permit acquiring drawables until the window has been visible

**Connections**
Fixes #9430. Narrows the workaround from #9141 for #8309.

**Description**
The occlusion check skipped acquisition for any window without the
Visible occlusion bit. That includes a window that hasn't been shown
yet, and one just ordered onto the screen for which AppKit hasn't
updated the occlusion state yet, so `get_current_texture` returned
`Occluded` for an application's first frame although `nextDrawable`
returns right away in both states. Applications render into such a
window to avoid a flash of empty content on first show.

Only drawables presented while the window was visible get stuck once it
is occluded. The surface now remembers whether it has seen the Visible
bit and skips acquisition only after that.

**Testing**
Manual on macOS 26. `hello_triangle` with its `Occluded` handling
removed presents its first frame while the occlusion state is still
stale. The same window minimized after being visible returns `Occluded`
without calling `nextDrawable`. A hidden window rendered into before
`orderFront` (Slint) acquires a drawable in about 1 ms. No `nextDrawable`
call exceeded 50 ms in any run.

**Squash or Rebase?**
Single commit, ready to rebase.

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
