### PR TITLE
Extension API proposal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4967,6 +4973,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "drm",
+ "dyn-clone",
  "env_logger",
  "glam",
  "glow",

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -21,7 +21,10 @@ use crate::{
     DOWNLEVEL_WARNING_MESSAGE,
 };
 
-use wgt::{Backend, BackendAdapterOptionsMap, Backends, InstanceFlags, PowerPreference};
+use wgt::{
+    Backend, BackendAdapterOptionsMap, BackendDeviceOptions, Backends, InstanceFlags,
+    PowerPreference,
+};
 
 #[test]
 fn downlevel_default_limits_less_than_default_limits() {
@@ -1319,6 +1322,34 @@ impl Adapter {
         self: &Arc<Self>,
         desc: &DeviceDescriptor,
     ) -> Result<(Arc<Device>, Arc<Queue>), RequestDeviceError> {
+        // SAFETY: Passing no backend-specific options imposes no additional
+        // safety requirements over the safe `request_device`.
+        unsafe { self.request_device_ext(desc, None) }
+    }
+
+    /// Request a device, passing backend-specific options.
+    ///
+    /// This behaves like [`Adapter::request_device`], but additionally accepts
+    /// a backend-specific options value which informs device creation (e.g. a
+    /// [`hal::vulkan::VulkanDeviceOptions`], which can install a callback that
+    /// customizes the Vulkan device creation parameters). The device is still
+    /// created through the normal, validated wgpu-core path.
+    ///
+    /// [`hal::vulkan::VulkanDeviceOptions`]: hal/vulkan/struct.VulkanDeviceOptions.html
+    ///
+    /// # Safety
+    ///
+    /// - If `options` is `Some`, it must satisfy any safety requirements
+    ///   applicable to its type. Passing `None` for `options` is safe.
+    ///
+    /// # Panics
+    ///
+    /// - If `options` is not of this adapter's backend's options type.
+    pub unsafe fn request_device_ext(
+        self: &Arc<Self>,
+        desc: &DeviceDescriptor,
+        options: Option<Box<dyn BackendDeviceOptions>>,
+    ) -> Result<(Arc<Device>, Arc<Queue>), RequestDeviceError> {
         profiling::scope!("Adapter::request_device");
         api_log!("Adapter::request_device");
 
@@ -1330,6 +1361,7 @@ impl Adapter {
                 desc.required_features,
                 &desc.required_limits,
                 &desc.memory_hints,
+                options,
             )
         }
         .map_err(DeviceError::from_hal)?;

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -20,7 +20,7 @@ use crate::{
     DOWNLEVEL_WARNING_MESSAGE,
 };
 
-use wgt::{Backend, Backends, InstanceFlags, PowerPreference};
+use wgt::{Backend, BackendAdapterOptionsMap, Backends, InstanceFlags, PowerPreference};
 
 #[test]
 fn downlevel_default_limits_less_than_default_limits() {
@@ -502,7 +502,7 @@ impl Instance {
             // macro emits no code, so unused code linting changes depending on the backend.
             profiling::scope!("enumerating", &*alloc::format!("{_backend:?}"));
 
-            let hal_adapters = unsafe { instance.enumerate_adapters(None) };
+            let hal_adapters = unsafe { instance.enumerate_adapters(None, None) };
 
             adapters.extend(
                 hal_adapters
@@ -542,6 +542,15 @@ impl Instance {
         desc: &wgt::RequestAdapterOptions<&Surface>,
         backends: Backends,
     ) -> Result<Arc<Adapter>, wgt::RequestAdapterError> {
+        unsafe { self.request_adapter_ext(desc, backends, None) }
+    }
+
+    pub unsafe fn request_adapter_ext(
+        self: &Arc<Self>,
+        desc: &wgt::RequestAdapterOptions<&Surface>,
+        backends: Backends,
+        backend_options: Option<&BackendAdapterOptionsMap>,
+    ) -> Result<Arc<Adapter>, wgt::RequestAdapterError> {
         profiling::scope!("Instance::request_adapter");
         api_log!("Instance::request_adapter");
 
@@ -559,8 +568,12 @@ impl Instance {
                 .compatible_surface
                 .and_then(|surface| surface.raw(backend));
 
-            let mut backend_adapters =
-                unsafe { instance.enumerate_adapters(compatible_hal_surface) };
+            let mut backend_adapters = unsafe {
+                instance.enumerate_adapters(
+                    compatible_hal_surface,
+                    backend_options,
+                )
+            };
             if backend_adapters.is_empty() {
                 log::debug!("enabled backend `{backend:?}` has no adapters");
                 no_adapter_backends |= Backends::from(backend);

--- a/wgpu-core/src/instance.rs
+++ b/wgpu-core/src/instance.rs
@@ -1,4 +1,5 @@
 use alloc::{borrow::ToOwned as _, boxed::Box, string::String, sync::Arc, vec, vec::Vec};
+use hal::RawSurfaceConfiguration;
 use core::fmt;
 
 use hashbrown::HashMap;
@@ -874,6 +875,28 @@ impl Surface {
         device: &Arc<Device>,
         config: &wgt::SurfaceConfiguration<Vec<wgt::TextureFormat>>,
     ) -> Option<ConfigureSurfaceError> {
+        unsafe {
+            // SAFETY: Passing `None` for `raw_config` is safe.
+            self.configure_ext(device, config, None)
+        }
+    }
+
+    /// Configure the surface, passing platform-specific configuration.
+    ///
+    /// # Safety
+    ///
+    /// - If `raw_config` is `Some`, it must satisfy any safety requirements
+    ///   applicable to its type. Passing `None` for `raw_config` is safe.
+    ///
+    /// # Panics
+    ///
+    /// - If `raw_config` does not have the correct type for this adapter.
+    pub unsafe fn configure_ext(
+        self: &Arc<Self>,
+        device: &Arc<Device>,
+        config: &wgt::SurfaceConfiguration<Vec<wgt::TextureFormat>>,
+        raw_config: Option<Box<dyn RawSurfaceConfiguration>>,
+    ) -> Option<ConfigureSurfaceError> {
         use ConfigureSurfaceError as E;
         profiling::scope!("Surface::configure");
 
@@ -1000,7 +1023,7 @@ impl Surface {
                 // https://github.com/gfx-rs/wgpu/issues/4105
 
                 let surface_raw = self.raw(device.backend()).unwrap();
-                match unsafe { surface_raw.configure(device.raw(), &hal_config) } {
+                match unsafe { surface_raw.configure(device.raw(), &hal_config, raw_config) } {
                     Ok(()) => (),
                     Err(error) => {
                         break 'error match error {

--- a/wgpu-hal/Cargo.toml
+++ b/wgpu-hal/Cargo.toml
@@ -216,6 +216,7 @@ wgpu-types = { workspace = true, default-features = false }
 # Dependencies in the lib and empty backend
 bitflags.workspace = true
 cfg-if.workspace = true
+dyn-clone = "1"
 log = { workspace = true }
 raw-window-handle.workspace = true
 thiserror.workspace = true

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -160,7 +160,7 @@ impl<A: hal::Api> Example<A> {
             view_formats: vec![],
         };
         unsafe {
-            surface.configure(&device, &surface_config).unwrap();
+            surface.configure(&device, &surface_config, None).unwrap();
         };
 
         let naga_shader = {

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -137,6 +137,7 @@ impl<A: hal::Api> Example<A> {
                     wgpu_types::Features::empty(),
                     &wgpu_types::Limits::default(),
                     &wgpu_types::MemoryHints::default(),
+                    None,
                 )
                 .unwrap()
         };

--- a/wgpu-hal/examples/halmark/main.rs
+++ b/wgpu-hal/examples/halmark/main.rs
@@ -119,7 +119,7 @@ impl<A: hal::Api> Example<A> {
         };
 
         let (adapter, capabilities) = unsafe {
-            let mut adapters = instance.enumerate_adapters(Some(&surface));
+            let mut adapters = instance.enumerate_adapters(Some(&surface), None);
             if adapters.is_empty() {
                 return Err("no adapters found".into());
             }

--- a/wgpu-hal/examples/raw-gles.rs
+++ b/wgpu-hal/examples/raw-gles.rs
@@ -332,6 +332,7 @@ fn fill_screen(exposed: &hal::ExposedAdapter<hal::api::Gles>, width: u32, height
             wgpu_types::Features::empty(),
             &wgpu_types::Limits::downlevel_defaults(),
             &wgpu_types::MemoryHints::default(),
+            None,
         )
     }
     .unwrap();

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -268,7 +268,7 @@ impl<A: hal::Api> Example<A> {
         };
 
         let (adapter, features) = unsafe {
-            let mut adapters = instance.enumerate_adapters(Some(&surface));
+            let mut adapters = instance.enumerate_adapters(Some(&surface), None);
             if adapters.is_empty() {
                 panic!("No adapters found");
             }

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -318,7 +318,7 @@ impl<A: hal::Api> Example<A> {
             view_formats: vec![surface_format],
         };
         unsafe {
-            surface.configure(&device, &surface_config).unwrap();
+            surface.configure(&device, &surface_config, None).unwrap();
         };
 
         #[allow(dead_code)]

--- a/wgpu-hal/examples/ray-traced-triangle/main.rs
+++ b/wgpu-hal/examples/ray-traced-triangle/main.rs
@@ -286,6 +286,7 @@ impl<A: hal::Api> Example<A> {
                     features,
                     &wgpu_types::Limits::default(),
                     &wgpu_types::MemoryHints::Performance,
+                    None,
                 )
                 .unwrap()
         };

--- a/wgpu-hal/src/dx12/adapter.rs
+++ b/wgpu-hal/src/dx12/adapter.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use core::ptr;
 use std::thread;
 
@@ -1060,11 +1060,14 @@ impl super::Adapter {
 impl crate::Adapter for super::Adapter {
     type A = super::Api;
 
+    type DeviceOptions = super::Dx12DeviceOptions;
+
     unsafe fn open(
         &self,
         features: wgt::Features,
         limits: &wgt::Limits,
         memory_hints: &wgt::MemoryHints,
+        _options: Option<Box<super::Dx12DeviceOptions>>,
     ) -> Result<crate::OpenDevice<super::Api>, crate::DeviceError> {
         let queue: Direct3D12::ID3D12CommandQueue = {
             profiling::scope!("ID3D12Device::CreateCommandQueue");

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -11,8 +11,17 @@ use crate::{
     },
 };
 
+crate::adapter_options! {
+    /// Options for enumerating DX12 adapters.
+    #[backend(wgt::Backend::Dx12)]
+    #[derive(Clone, Debug)]
+    pub struct Dx12AdapterOptions;
+}
+
 impl crate::Instance for super::Instance {
     type A = super::Api;
+
+    type AdapterOptions = Dx12AdapterOptions;
 
     unsafe fn init(desc: &crate::InstanceDescriptor<'_>) -> Result<Self, crate::InstanceError> {
         profiling::scope!("Init DX12 Backend");
@@ -166,6 +175,7 @@ impl crate::Instance for super::Instance {
     unsafe fn enumerate_adapters(
         &self,
         _surface_hint: Option<&super::Surface>,
+        _options: Option<&Self::AdapterOptions>,
     ) -> Vec<crate::ExposedAdapter<super::Api>> {
         let adapters = auxil::dxgi::factory::enumerate_adapters(self.factory.clone());
 

--- a/wgpu-hal/src/dx12/instance.rs
+++ b/wgpu-hal/src/dx12/instance.rs
@@ -15,7 +15,11 @@ crate::adapter_options! {
     /// Options for enumerating DX12 adapters.
     #[backend(wgt::Backend::Dx12)]
     #[derive(Clone, Debug)]
-    pub struct Dx12AdapterOptions;
+    pub struct Dx12AdapterOptions {
+        /// LUID of the desired adapter. If `Some`, only the adapter with this LUID
+        /// will be enumerated.
+        pub luid: Option<Foundation::LUID>,
+    }
 }
 
 impl crate::Instance for super::Instance {
@@ -175,12 +179,24 @@ impl crate::Instance for super::Instance {
     unsafe fn enumerate_adapters(
         &self,
         _surface_hint: Option<&super::Surface>,
-        _options: Option<&Self::AdapterOptions>,
+        options: Option<&Self::AdapterOptions>,
     ) -> Vec<crate::ExposedAdapter<super::Api>> {
         let adapters = auxil::dxgi::factory::enumerate_adapters(self.factory.clone());
 
         adapters
             .into_iter()
+            .filter(|raw| {
+                let Some(luid) = options.and_then(|o| o.luid) else {
+                    return true;
+                };
+                match unsafe { raw.GetDesc() } {
+                    Ok(desc) => luid == desc.AdapterLuid,
+                    Err(e) => {
+                        log::error!("GetDesc failed for dxgi adapter: {e}");
+                        false
+                    }
+                }
+            })
             .filter_map(|raw| {
                 super::Adapter::expose(
                     raw,

--- a/wgpu-hal/src/dx12/mod.rs
+++ b/wgpu-hal/src/dx12/mod.rs
@@ -603,6 +603,11 @@ pub struct Adapter {
 unsafe impl Send for Adapter {}
 unsafe impl Sync for Adapter {}
 
+#[derive(Clone, Debug)]
+pub struct Dx12DeviceOptions;
+
+impl wgt::BackendDeviceOptions for Dx12DeviceOptions {}
+
 impl Adapter {
     pub fn as_raw(&self) -> &Dxgi::IDXGIAdapter3 {
         &self.raw

--- a/wgpu-hal/src/dynamic/adapter.rs
+++ b/wgpu-hal/src/dynamic/adapter.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use core::any::Any;
 
 use crate::{
     Adapter, Api, DeviceError, OpenDevice, SurfaceCapabilities, TextureFormatCapabilities,
@@ -22,11 +23,20 @@ impl<A: Api> From<OpenDevice<A>> for DynOpenDevice {
 }
 
 pub trait DynAdapter: DynResource {
+    /// # Safety
+    ///
+    /// - Same as [`Adapter::open`].
+    ///
+    /// # Panics
+    ///
+    /// - If `options` is not of this adapter's backend's
+    ///   [`DeviceOptions`](Adapter::DeviceOptions) type.
     unsafe fn open(
         &self,
         features: wgt::Features,
         limits: &wgt::Limits,
         memory_hints: &wgt::MemoryHints,
+        options: Option<Box<dyn wgt::BackendDeviceOptions>>,
     ) -> Result<DynOpenDevice, DeviceError>;
 
     unsafe fn texture_format_capabilities(
@@ -54,10 +64,17 @@ impl<A: Adapter + DynResource> DynAdapter for A {
         features: wgt::Features,
         limits: &wgt::Limits,
         memory_hints: &wgt::MemoryHints,
+        options: Option<Box<dyn wgt::BackendDeviceOptions>>,
     ) -> Result<DynOpenDevice, DeviceError> {
-        unsafe { A::open(self, features, limits, memory_hints) }.map(|open_device| DynOpenDevice {
-            device: Box::new(open_device.device),
-            queue: Box::new(open_device.queue),
+        let options = options.map(|options| {
+            Box::<dyn Any>::downcast(options)
+                .expect("Device options don't have the expected backend type.")
+        });
+        unsafe { A::open(self, features, limits, memory_hints, options) }.map(|open_device| {
+            DynOpenDevice {
+                device: Box::new(open_device.device),
+                queue: Box::new(open_device.queue),
+            }
         })
     }
 

--- a/wgpu-hal/src/dynamic/device.rs
+++ b/wgpu-hal/src/dynamic/device.rs
@@ -1,3 +1,5 @@
+use core::any::Any;
+
 use alloc::{borrow::ToOwned as _, boxed::Box, vec::Vec};
 
 use crate::{
@@ -43,6 +45,11 @@ pub trait DynDevice: DynResource {
     ) -> Result<Box<dyn DynTexture>, DeviceError>;
     unsafe fn destroy_texture(&self, texture: Box<dyn DynTexture>);
     unsafe fn add_raw_texture(&self, texture: &dyn DynTexture);
+    unsafe fn texture_from_raw(
+        &self,
+        hal_texture: Box<dyn crate::RawTexture>,
+        desc: &TextureDescriptor,
+    ) -> Result<Box<dyn DynTexture>, DeviceError>;
 
     unsafe fn create_texture_view(
         &self,
@@ -241,6 +248,19 @@ impl<D: Device + DynResource> DynDevice for D {
     unsafe fn add_raw_texture(&self, texture: &dyn DynTexture) {
         let texture = texture.expect_downcast_ref();
         unsafe { D::add_raw_texture(self, texture) };
+    }
+
+    unsafe fn texture_from_raw(
+        &self,
+        hal_texture: Box<dyn crate::RawTexture>,
+        desc: &TextureDescriptor,
+    ) -> Result<Box<dyn DynTexture>, DeviceError> {
+        let hal_texture = Box::<dyn Any>::downcast(hal_texture).unwrap();
+        unsafe { D::texture_from_raw(self, hal_texture, desc) }.map(|b| {
+            let boxed_texture: Box<dyn DynTexture> = Box::new(b);
+            boxed_texture
+        })
+
     }
 
     unsafe fn create_texture_view(

--- a/wgpu-hal/src/dynamic/instance.rs
+++ b/wgpu-hal/src/dynamic/instance.rs
@@ -40,6 +40,7 @@ pub trait DynInstance: DynResource {
     unsafe fn enumerate_adapters(
         &self,
         surface_hint: Option<&dyn DynSurface>,
+        options: Option<&wgt::BackendAdapterOptionsMap>,
     ) -> Vec<DynExposedAdapter>;
 }
 
@@ -56,9 +57,11 @@ impl<I: Instance + DynResource> DynInstance for I {
     unsafe fn enumerate_adapters(
         &self,
         surface_hint: Option<&dyn DynSurface>,
+        options: Option<&wgt::BackendAdapterOptionsMap>,
     ) -> Vec<DynExposedAdapter> {
         let surface_hint = surface_hint.map(|s| s.expect_downcast_ref());
-        unsafe { I::enumerate_adapters(self, surface_hint) }
+        let options = options.and_then(|map| map.get::<I::AdapterOptions>());
+        unsafe { I::enumerate_adapters(self, surface_hint, options) }
             .into_iter()
             .map(|exposed| DynExposedAdapter {
                 adapter: Box::new(exposed.adapter),

--- a/wgpu-hal/src/dynamic/surface.rs
+++ b/wgpu-hal/src/dynamic/surface.rs
@@ -2,8 +2,7 @@ use alloc::boxed::Box;
 use core::time::Duration;
 
 use crate::{
-    DynDevice, DynFence, DynResource, DynSurfaceTexture, Surface, SurfaceConfiguration,
-    SurfaceError,
+    DynDevice, DynFence, DynResource, DynSurfaceTexture, RawSurfaceConfiguration, Surface, SurfaceConfiguration, SurfaceError
 };
 
 use super::DynResourceExt as _;
@@ -22,6 +21,7 @@ pub trait DynSurface: DynResource {
         &self,
         device: &dyn DynDevice,
         config: &SurfaceConfiguration,
+        raw_config: Option<Box<dyn RawSurfaceConfiguration>>,
     ) -> Result<(), SurfaceError>;
 
     unsafe fn unconfigure(&self, device: &dyn DynDevice);
@@ -40,9 +40,13 @@ impl<S: Surface + DynResource> DynSurface for S {
         &self,
         device: &dyn DynDevice,
         config: &SurfaceConfiguration,
+        raw_config: Option<Box<dyn RawSurfaceConfiguration>>,
     ) -> Result<(), SurfaceError> {
+        // Normally, we would downcast `config.raw` here as well, but surfaces are special
+        // because Vulkan can have either a native or DXGI swapchain, so we defer
+        // downcasting to the backend.
         let device = device.expect_downcast_ref();
-        unsafe { S::configure(self, device, config) }
+        unsafe { S::configure(self, device, config, raw_config) }
     }
 
     unsafe fn unconfigure(&self, device: &dyn DynDevice) {

--- a/wgpu-hal/src/gles/adapter.rs
+++ b/wgpu-hal/src/gles/adapter.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::ToOwned as _, format, string::String, sync::Arc, vec, vec::Vec};
+use alloc::{borrow::ToOwned as _, boxed::Box, format, string::String, sync::Arc, vec, vec::Vec};
 
 use glow::HasContext;
 use wgpu_sync::{atomic::AtomicU8, Mutex};
@@ -1086,11 +1086,14 @@ impl super::Adapter {
 impl crate::Adapter for super::Adapter {
     type A = super::Api;
 
+    type DeviceOptions = super::GlDeviceOptions;
+
     unsafe fn open(
         &self,
         features: wgt::Features,
         _limits: &wgt::Limits,
         _memory_hints: &wgt::MemoryHints,
+        _options: Option<Box<super::GlDeviceOptions>>,
     ) -> Result<crate::OpenDevice<super::Api>, crate::DeviceError> {
         let gl = &self.shared.context.lock();
         unsafe { gl.pixel_store_i32(glow::UNPACK_ALIGNMENT, 1) };

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use core::{ffi, mem::ManuallyDrop, ptr, time::Duration};
 
 use glow::HasContext;
@@ -1255,6 +1255,7 @@ impl crate::Surface for Surface {
         &self,
         device: &super::Device,
         config: &crate::SurfaceConfiguration,
+        _raw_config: Option<Box<dyn crate::RawSurfaceConfiguration>>,
     ) -> Result<(), crate::SurfaceError> {
         use raw_window_handle::RawWindowHandle as Rwh;
 

--- a/wgpu-hal/src/gles/egl.rs
+++ b/wgpu-hal/src/gles/egl.rs
@@ -718,8 +718,19 @@ impl Instance {
 #[cfg(send_sync)]
 static_assertions::assert_impl_all!(Instance: Send, Sync);
 
+#[derive(Clone, Debug)]
+pub struct GlAdapterOptions;
+
+impl wgt::DynBackendMapValue<dyn wgt::BackendAdapterOptions> for GlAdapterOptions { }
+
+impl wgt::BackendMapValue<dyn wgt::BackendAdapterOptions> for GlAdapterOptions {
+    const BACKEND: wgt::Backend = wgt::Backend::Gl;
+}
+
 impl crate::Instance for Instance {
     type A = super::Api;
+
+    type AdapterOptions = GlAdapterOptions;
 
     unsafe fn init(desc: &crate::InstanceDescriptor<'_>) -> Result<Self, crate::InstanceError> {
         use raw_window_handle::RawDisplayHandle as Rdh;
@@ -1014,6 +1025,7 @@ impl crate::Instance for Instance {
     unsafe fn enumerate_adapters(
         &self,
         _surface_hint: Option<&Surface>,
+        _options: Option<&Self::AdapterOptions>,
     ) -> Vec<crate::ExposedAdapter<super::Api>> {
         let inner = self.inner.lock();
         inner.egl.make_current();

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -332,6 +332,11 @@ pub struct Adapter {
     shared: Arc<AdapterShared>,
 }
 
+#[derive(Clone, Debug)]
+pub struct GlDeviceOptions;
+
+impl wgt::BackendDeviceOptions for GlDeviceOptions {}
+
 #[derive(Debug)]
 pub struct Device {
     shared: Arc<AdapterShared>,

--- a/wgpu-hal/src/gles/wgl.rs
+++ b/wgpu-hal/src/gles/wgl.rs
@@ -447,8 +447,17 @@ fn create_instance_device() -> Result<InstanceDevice, crate::InstanceError> {
     Ok(InstanceDevice { dc, _tx: drop_tx })
 }
 
+crate::adapter_options! {
+    /// Options for enumerating GL adapters.
+    #[backend(wgt::Backend::Gl)]
+    #[derive(Clone, Debug)]
+    pub struct GlAdapterOptions;
+}
+
 impl crate::Instance for Instance {
     type A = super::Api;
+
+    type AdapterOptions = GlAdapterOptions;
 
     unsafe fn init(desc: &crate::InstanceDescriptor<'_>) -> Result<Self, crate::InstanceError> {
         profiling::scope!("Init OpenGL (WGL) Backend");
@@ -590,6 +599,7 @@ impl crate::Instance for Instance {
     unsafe fn enumerate_adapters(
         &self,
         _surface_hint: Option<&Surface>,
+        _options: Option<&Self::AdapterOptions>,
     ) -> Vec<crate::ExposedAdapter<super::Api>> {
         unsafe {
             super::Adapter::expose(

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -718,6 +718,10 @@ pub trait Surface: WasmNotSendSync {
 
     /// Configure `self` to use `device`.
     ///
+    /// Normally, this method would take a concrete type for `raw_config`, but surfaces
+    /// are special because Vulkan has an additional layer to dispatch to either a native
+    /// or DXGI swapchain, so we defer downcasting to within the backend.
+    ///
     /// # Safety
     ///
     /// - All GPU work using `self` must have been completed.
@@ -728,6 +732,7 @@ pub trait Surface: WasmNotSendSync {
         &self,
         device: &<Self::A as Api>::Device,
         config: &SurfaceConfiguration,
+        raw_config: Option<Box<dyn RawSurfaceConfiguration>>,
     ) -> Result<(), SurfaceError>;
 
     /// Unconfigure `self` on `device`.
@@ -2779,7 +2784,7 @@ pub struct RayTracingPipelineDescriptor<
     pub cache: Option<&'a Pc>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct SurfaceConfiguration {
     /// Maximum number of queued frames. Must be in
     /// `SurfaceCapabilities::maximum_frame_latency` range.
@@ -2805,6 +2810,8 @@ pub struct SurfaceConfiguration {
     /// than the texture does.
     pub view_formats: Vec<wgt::TextureFormat>,
 }
+
+pub trait RawSurfaceConfiguration: fmt::Debug + core::any::Any + Send + Sync { }
 
 #[derive(Debug, Clone)]
 pub struct Rect<T> {

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -297,12 +297,7 @@ pub use dynamic::{
 use alloc::boxed::Box;
 use alloc::{borrow::Cow, string::String, vec::Vec};
 use core::{
-    borrow::Borrow,
-    error::Error,
-    fmt,
-    num::NonZeroU32,
-    ops::{Range, RangeInclusive},
-    ptr::NonNull,
+    any::Any, borrow::Borrow, error::Error, fmt, num::NonZeroU32, ops::{Range, RangeInclusive}, ptr::NonNull
 };
 
 use bitflags::bitflags;
@@ -336,6 +331,8 @@ pub type Label<'a> = Option<&'a str>;
 pub type MemoryRange = Range<wgt::BufferAddress>;
 pub type FenceValue = u64;
 pub type AtomicFenceValue = wgpu_sync::atomic::AtomicU64;
+
+pub trait RawTexture: Any { }
 
 /// A callback to signal that wgpu is no longer using a resource.
 #[cfg(all(any(gles, vulkan, metal), not(webgl)))]
@@ -1095,6 +1092,15 @@ pub trait Device: WasmNotSendSync {
 
     /// A hook for when a wgpu-core texture is created from a raw wgpu-hal texture.
     unsafe fn add_raw_texture(&self, texture: &<Self::A as Api>::Texture);
+
+    type RawTexture: RawTexture;
+
+    /// Create a texture from from a raw platform texture reference.
+    unsafe fn texture_from_raw(
+        &self,
+        hal_texture: Box<Self::RawTexture>,
+        desc: &TextureDescriptor,
+    ) -> Result<<Self::A as Api>::Texture, DeviceError>;
 
     unsafe fn create_texture_view(
         &self,
@@ -2829,7 +2835,7 @@ pub struct SurfaceConfiguration {
     pub view_formats: Vec<wgt::TextureFormat>,
 }
 
-pub trait RawSurfaceConfiguration: fmt::Debug + core::any::Any + Send + Sync { }
+pub trait RawSurfaceConfiguration: fmt::Debug + Any + Send + Sync { }
 
 #[derive(Debug, Clone)]
 pub struct Rect<T> {

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -828,11 +828,29 @@ pub trait Surface: WasmNotSendSync {
 pub trait Adapter: WasmNotSendSync {
     type A: Api;
 
+    // TODO: should probably move to Api
+    type DeviceOptions: wgt::BackendDeviceOptions;
+
+    /// Open a device on this adapter.
+    ///
+    /// `options` carries backend-specific device creation parameters, for
+    /// example a [`vulkan::VulkanDeviceOptions`], which can install a callback
+    /// that customizes the [`vk::DeviceCreateInfo`]. Options bypass the
+    /// validation that a higher-level crate such as `wgpu-core` would normally
+    /// perform.
+    ///
+    /// [`vulkan::VulkanDeviceOptions`]: vulkan/struct.VulkanDeviceOptions.html
+    /// [`vk::DeviceCreateInfo`]: https://docs.rs/ash/latest/ash/vk/struct.DeviceCreateInfo.html
+    ///
+    /// # Safety
+    ///
+    /// - `options` must uphold the safety contract documented on its type.
     unsafe fn open(
         &self,
         features: wgt::Features,
         limits: &wgt::Limits,
         memory_hints: &wgt::MemoryHints,
+        options: Option<Box<Self::DeviceOptions>>,
     ) -> Result<OpenDevice<Self::A>, DeviceError>;
 
     /// Return the set of supported capabilities for a texture format.

--- a/wgpu-hal/src/lib.rs
+++ b/wgpu-hal/src/lib.rs
@@ -309,7 +309,7 @@ use bitflags::bitflags;
 use raw_window_handle::DisplayHandle;
 use thiserror::Error;
 use wgpu_sync::Arc;
-use wgt::WasmNotSendSync;
+use wgt::{WasmNotSendSync, backend_map_type, backend_type};
 
 // - Vertex + Fragment
 // - Compute
@@ -679,8 +679,25 @@ pub trait Api: Clone + fmt::Debug + Sized + WasmNotSendSync + 'static {
     type AccelerationStructure: DynAccelerationStructure + 'static;
 }
 
+backend_map_type!(
+    adapter_options,
+    dyn wgt::BackendAdapterOptions,
+    AdapterOptionsType,
+    AdapterOptionsTypeAssignment,
+);
+
+backend_type!(
+    device_options,
+    wgt::BackendDeviceOptions,
+    DeviceOptionsType,
+    DeviceOptionsTypeAssignment,
+);
+
 pub trait Instance: Sized + WasmNotSendSync {
     type A: Api;
+
+    // TODO: should probably move to Api
+    type AdapterOptions: wgt::BackendMapValue<dyn wgt::BackendAdapterOptions>;
 
     unsafe fn init(desc: &InstanceDescriptor<'_>) -> Result<Self, InstanceError>;
     unsafe fn create_surface(
@@ -692,6 +709,7 @@ pub trait Instance: Sized + WasmNotSendSync {
     unsafe fn enumerate_adapters(
         &self,
         surface_hint: Option<&<Self::A as Api>::Surface>,
+        options: Option<&Self::AdapterOptions>,
     ) -> Vec<ExposedAdapter<Self::A>>;
 }
 

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -9,7 +9,7 @@ use objc2_metal::{
 };
 use wgt::{AstcBlock, AstcChannel};
 
-use alloc::{string::ToString as _, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::ToString as _, sync::Arc, vec::Vec};
 use wgpu_sync::{atomic, Mutex, OnceCell};
 
 use crate::metal::QueueShared;
@@ -63,11 +63,14 @@ impl super::Adapter {
 impl crate::Adapter for super::Adapter {
     type A = super::Api;
 
+    type DeviceOptions = super::MetalDeviceOptions;
+
     unsafe fn open(
         &self,
         features: wgt::Features,
         limits: &wgt::Limits,
         _memory_hints: &wgt::MemoryHints,
+        _options: Option<Box<super::MetalDeviceOptions>>,
     ) -> Result<crate::OpenDevice<super::Api>, crate::DeviceError> {
         autoreleasepool(|_| {
             let queue = self

--- a/wgpu-hal/src/metal/device.rs
+++ b/wgpu-hal/src/metal/device.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::ToOwned as _, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, borrow::ToOwned as _, sync::Arc, vec::Vec};
 use core::{mem::align_of, ptr::NonNull};
 
 use bytemuck::TransparentWrapper;
@@ -456,8 +456,18 @@ impl super::Device {
     }
 }
 
+pub struct MetalRawTexture {
+    texture: Retained<ProtocolObject<dyn MTLTexture>>,
+    raw_type: MTLTextureType,
+    drop_callback: Option<DropCallback>,
+}
+
+impl crate::RawTexture for MetalRawTexture { }
+
 impl crate::Device for super::Device {
     type A = super::Api;
+
+    type RawTexture = MetalRawTexture;
 
     unsafe fn create_buffer(
         &self,
@@ -608,6 +618,22 @@ impl crate::Device for super::Device {
 
     unsafe fn add_raw_texture(&self, _texture: &super::Texture) {
         self.counters.textures.add(1);
+    }
+
+    unsafe fn texture_from_raw(
+        &self,
+        texture: Box<MetalRawTexture>,
+        desc: &crate::TextureDescriptor,
+    ) -> DeviceResult<super::Texture> {
+        Ok(super::Texture {
+            raw: texture.texture,
+            format: desc.format,
+            raw_type: texture.raw_type,
+            array_layers: desc.array_layer_count(),
+            mip_levels: desc.mip_level_count,
+            copy_size: desc.copy_extent(),
+            _drop_guard: DropGuard::from_option(texture.drop_callback),
+        })
     }
 
     unsafe fn create_texture_view(

--- a/wgpu-hal/src/metal/mod.rs
+++ b/wgpu-hal/src/metal/mod.rs
@@ -135,6 +135,20 @@ impl OsFeatures {
     }
 }
 
+crate::adapter_options! {
+    /// Options for enumerating Metal adapters.
+    #[backend(wgt::Backend::Metal)]
+    #[derive(Clone, Debug)]
+    pub struct MetalAdapterOptions;
+}
+
+crate::device_options! {
+    /// Options for opening Metal devices.
+    #[backend(wgt::Backend::Metal)]
+    #[derive(Clone, Debug)]
+    pub struct MetalDeviceOptions;
+}
+
 #[derive(Debug)]
 pub struct Instance {
     flags: wgt::InstanceFlags,
@@ -148,6 +162,8 @@ impl Instance {
 
 impl crate::Instance for Instance {
     type A = Api;
+
+    type AdapterOptions = MetalAdapterOptions;
 
     unsafe fn init(desc: &crate::InstanceDescriptor<'_>) -> Result<Self, crate::InstanceError> {
         profiling::scope!("Init Metal Backend");
@@ -189,6 +205,7 @@ impl crate::Instance for Instance {
     unsafe fn enumerate_adapters(
         &self,
         _surface_hint: Option<&Surface>,
+        _options: Option<&Self::AdapterOptions>,
     ) -> Vec<crate::ExposedAdapter<Api>> {
         let devices = objc2_metal::MTLCopyAllDevices();
         let instance_flags = self.flags;

--- a/wgpu-hal/src/metal/surface.rs
+++ b/wgpu-hal/src/metal/surface.rs
@@ -1,4 +1,4 @@
-use alloc::borrow::ToOwned as _;
+use alloc::{boxed::Box, borrow::ToOwned as _};
 
 use objc2::{
     available,
@@ -249,6 +249,7 @@ impl crate::Surface for super::Surface {
         &self,
         device: &super::Device,
         config: &crate::SurfaceConfiguration,
+        _raw_config: Option<Box<dyn crate::RawSurfaceConfiguration>>,
     ) -> Result<(), crate::SurfaceError> {
         log::debug!("build swapchain {config:?}");
 

--- a/wgpu-hal/src/noop/mod.rs
+++ b/wgpu-hal/src/noop/mod.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)]
 
-use alloc::{string::String, sync::Arc, vec, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc, vec, vec::Vec};
 use core::{ptr, sync::atomic::Ordering, time::Duration};
 
 use wgpu_sync::atomic::AtomicU64;
@@ -215,6 +215,7 @@ impl crate::Surface for Context {
         &self,
         device: &Context,
         config: &crate::SurfaceConfiguration,
+        _raw_config: Option<Box<dyn crate::RawSurfaceConfiguration>>,
     ) -> Result<(), crate::SurfaceError> {
         Ok(())
     }

--- a/wgpu-hal/src/noop/mod.rs
+++ b/wgpu-hal/src/noop/mod.rs
@@ -235,11 +235,14 @@ impl crate::Surface for Context {
 impl crate::Adapter for Context {
     type A = Api;
 
+    type DeviceOptions = NoopDeviceOptions;
+
     unsafe fn open(
         &self,
         features: wgt::Features,
         _limits: &wgt::Limits,
         _memory_hints: &wgt::MemoryHints,
+        _options: Option<Box<NoopDeviceOptions>>,
     ) -> DeviceResult<crate::OpenDevice<Api>> {
         Ok(crate::OpenDevice {
             device: Context {

--- a/wgpu-hal/src/noop/mod.rs
+++ b/wgpu-hal/src/noop/mod.rs
@@ -88,8 +88,24 @@ impl core::borrow::Borrow<dyn crate::DynTexture> for Resource {
     }
 }
 
+crate::adapter_options! {
+    /// Options for enumerating Noop adapters.
+    #[backend(wgt::Backend::Noop)]
+    #[derive(Clone, Debug)]
+    pub struct NoopAdapterOptions;
+}
+
+crate::device_options!{
+    /// Options for opening Noop devices.
+    #[backend(wgt::Backend::Noop)]
+    #[derive(Clone, Debug)]
+    pub struct NoopDeviceOptions;
+}
+
 impl crate::Instance for Context {
     type A = Api;
+
+    type AdapterOptions = NoopAdapterOptions;
 
     unsafe fn init(desc: &crate::InstanceDescriptor<'_>) -> Result<Self, crate::InstanceError> {
         let options = Arc::new(desc.backend_options.noop.clone());
@@ -113,6 +129,7 @@ impl crate::Instance for Context {
     unsafe fn enumerate_adapters(
         &self,
         _surface_hint: Option<&Context>,
+        _options: Option<&Self::AdapterOptions>,
     ) -> Vec<crate::ExposedAdapter<Api>> {
         let device_type = self.options.device_type.unwrap_or(wgt::DeviceType::Other);
         let subgroup_min_size = self

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -3166,13 +3166,17 @@ impl super::Adapter {
 impl crate::Adapter for super::Adapter {
     type A = super::Api;
 
+    type DeviceOptions = super::VulkanDeviceOptions;
+
     unsafe fn open(
         &self,
         features: wgt::Features,
         limits: &wgt::Limits,
         memory_hints: &wgt::MemoryHints,
+        options: Option<Box<super::VulkanDeviceOptions>>,
     ) -> Result<crate::OpenDevice<super::Api>, crate::DeviceError> {
-        unsafe { self.open_with_callback(features, limits, memory_hints, None) }
+        let callback = options.and_then(|options| options.create_device_callback);
+        unsafe { self.open_with_callback(features, limits, memory_hints, callback) }
     }
 
     unsafe fn texture_format_capabilities(

--- a/wgpu-hal/src/vulkan/adapter.rs
+++ b/wgpu-hal/src/vulkan/adapter.rs
@@ -1,5 +1,5 @@
 use alloc::{borrow::ToOwned as _, boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
-use core::{ffi::CStr, marker::PhantomData};
+use core::ffi::CStr;
 
 use ash::{ext, google, khr, vk};
 use wgpu_sync::Mutex;
@@ -3090,12 +3090,12 @@ impl super::Adapter {
     /// - Same as `open` plus
     /// - The callback may not change anything that the device does not support.
     /// - The callback may not remove features.
-    pub unsafe fn open_with_callback<'a>(
+    pub unsafe fn open_with_callback(
         &self,
         features: wgt::Features,
         limits: &wgt::Limits,
         memory_hints: &wgt::MemoryHints,
-        callback: Option<Box<super::CreateDeviceCallback<'a>>>,
+        callback: Option<Box<super::CreateDeviceCallback>>,
     ) -> Result<crate::OpenDevice<super::Api>, crate::DeviceError> {
         let mut enabled_extensions = self.required_device_extensions(features);
         let mut enabled_phd_features = self.physical_device_features(&enabled_extensions, features);
@@ -3113,7 +3113,6 @@ impl super::Adapter {
                 device_features: &mut enabled_phd_features,
                 queue_create_infos: &mut family_infos,
                 create_info: &mut pre_info,
-                _phantom: PhantomData,
             })
         }
 

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -1,7 +1,6 @@
 use alloc::{borrow::ToOwned as _, boxed::Box, ffi::CString, string::String, sync::Arc, vec::Vec};
 use core::{
     ffi::{c_void, CStr},
-    marker::PhantomData,
     slice,
     str::FromStr,
 };
@@ -812,7 +811,6 @@ impl super::Instance {
                 extensions: &mut extensions,
                 create_info: &mut create_info,
                 entry: &entry,
-                _phantom: PhantomData,
             });
         }
 

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -1053,8 +1053,17 @@ impl Drop for super::InstanceShared {
     }
 }
 
+crate::adapter_options! {
+    /// Options for enumerating Vulkan adapters.
+    #[backend(wgt::Backend::Vulkan)]
+    #[derive(Clone, Debug)]
+    pub struct VulkanAdapterOptions;
+}
+
 impl crate::Instance for super::Instance {
     type A = super::Api;
+
+    type AdapterOptions = VulkanAdapterOptions;
 
     unsafe fn init(desc: &crate::InstanceDescriptor<'_>) -> Result<Self, crate::InstanceError> {
         unsafe { Self::init_with_callback(desc, None) }
@@ -1121,6 +1130,7 @@ impl crate::Instance for super::Instance {
     unsafe fn enumerate_adapters(
         &self,
         _surface_hint: Option<&super::Surface>,
+        _options: Option<&Self::AdapterOptions>,
     ) -> Vec<crate::ExposedAdapter<super::Api>> {
         use crate::auxil::db;
 

--- a/wgpu-hal/src/vulkan/instance.rs
+++ b/wgpu-hal/src/vulkan/instance.rs
@@ -1196,6 +1196,7 @@ impl crate::Surface for super::Surface {
         &self,
         device: &super::Device,
         config: &crate::SurfaceConfiguration,
+        raw_config: Option<Box<dyn crate::RawSurfaceConfiguration>>,
     ) -> Result<(), crate::SurfaceError> {
         // SAFETY: `configure`'s contract guarantees there are no resources derived from the swapchain in use.
         let mut swap_chain = self.swapchain.write();
@@ -1205,7 +1206,7 @@ impl crate::Surface for super::Surface {
             unsafe { old.release_resources(device) };
         }
 
-        let swapchain = unsafe { self.inner.create_swapchain(device, config, old)? };
+        let swapchain = unsafe { self.inner.create_swapchain(device, config, raw_config, old)? };
         *swap_chain = Some(swapchain);
 
         Ok(())

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -1904,6 +1904,26 @@ pub struct CreateDeviceCallbackArgs<'arg, 'pnext> {
 pub type CreateDeviceCallback =
     dyn for<'arg, 'pnext> FnOnce(CreateDeviceCallbackArgs<'arg, 'pnext>) + 'static;
 
+/// Vulkan-specific options for [`Adapter::open`](crate::Adapter::open).
+///
+/// Pass this (boxed as `Box<dyn wgt::BackendDeviceOptions>`) in the `options`
+/// argument of [`crate::Adapter::open`], or, from `wgpu-core`, via
+/// `request_device_ext`. It is the type-erased equivalent of the inherent
+/// [`Adapter::open_with_callback`] method; because it is passed as an
+/// [`Any`](core::any::Any), the callback must be `'static`.
+#[derive(Default)]
+#[expect(missing_debug_implementations, reason = "contains a callback")]
+pub struct VulkanDeviceOptions {
+    /// Callback allowing the Vulkan device creation parameters to be customized.
+    ///
+    /// # Safety
+    ///
+    /// See [`CreateDeviceCallback`].
+    pub create_device_callback: Option<Box<CreateDeviceCallback>>,
+}
+
+impl wgt::BackendDeviceOptions for VulkanDeviceOptions {}
+
 /// Arguments to the [`CreateInstanceCallback`].
 #[expect(missing_debug_implementations, reason = "TODO?")]
 pub struct CreateInstanceCallbackArgs<'arg, 'pnext> {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -323,6 +323,8 @@ impl Surface {
         unsafe { swapchain.set_next_present_chain(chain) };
     }
 
+    // TODO: relocate any portion of this comment that is still relevant.
+    //
     /// Set a `pNext` chain of extension structs to attach to the
     /// [`vk::SwapchainCreateInfoKHR`] used by the next configuration of this surface.
     ///
@@ -351,15 +353,19 @@ impl Surface {
     ///
     /// [VK_NV_low_latency2]: https://registry.khronos.org/vulkan/specs/latest/man/html/VK_NV_low_latency2.html
     #[track_caller]
-    pub unsafe fn set_next_swapchain_create_chain(&self, chain: *mut c_void) {
-        let surface = self
-            .inner
-            .as_any()
-            .downcast_ref::<swapchain::NativeSurface>()
-            .expect("Surface should be a native Vulkan surface");
-        unsafe { surface.set_next_swapchain_create_chain(chain) };
+    pub unsafe fn set_next_swapchain_create_chain(&self, _chain: *mut c_void) {
+        unimplemented!()
     }
 }
+
+#[derive(Debug)]
+pub struct VulkanSurfaceConfiguration {
+    /// A caller-provided `pNext` chain to attach to the [`vk::SwapchainCreateInfoKHR`]
+    /// of the swapchain created for this surface.
+    pub swapchain_create_chain: Option<PnextChain>,
+}
+
+impl crate::RawSurfaceConfiguration for VulkanSurfaceConfiguration { }
 
 #[derive(Debug)]
 pub struct SurfaceTexture {

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -363,6 +363,9 @@ pub struct VulkanSurfaceConfiguration {
     /// A caller-provided `pNext` chain to attach to the [`vk::SwapchainCreateInfoKHR`]
     /// of the swapchain created for this surface.
     pub swapchain_create_chain: Option<PnextChain>,
+    /// Caller-provided flags to include in [`vk::SwapchainCreateFlagsKHR`] when
+    /// creating the swapchain.
+    pub swapchain_create_flags: vk::SwapchainCreateFlagsKHR,
 }
 
 impl crate::RawSurfaceConfiguration for VulkanSurfaceConfiguration { }

--- a/wgpu-hal/src/vulkan/mod.rs
+++ b/wgpu-hal/src/vulkan/mod.rs
@@ -1877,10 +1877,7 @@ struct RawTlasInstance {
 
 /// Arguments to the [`CreateDeviceCallback`].
 #[derive(Debug)]
-pub struct CreateDeviceCallbackArgs<'arg, 'pnext, 'this>
-where
-    'this: 'pnext,
-{
+pub struct CreateDeviceCallbackArgs<'arg, 'pnext> {
     /// The extensions to enable for the device. You must not remove anything from this list,
     /// but you may add to it.
     pub extensions: &'arg mut Vec<&'static CStr>,
@@ -1895,10 +1892,6 @@ where
     /// do not turn features off. Additionally, do not add things to the list of extensions,
     /// or to the feature set, as all changes to that member will be overwritten.
     pub create_info: &'arg mut vk::DeviceCreateInfo<'pnext>,
-    /// We need to have `'this` in the struct, so we can declare that all lifetimes coming from
-    /// captures in the closure will live longer (and hence satisfy) `'pnext`. However, we
-    /// don't actually directly use `'this`
-    _phantom: PhantomData<&'this ()>,
 }
 
 /// Callback to allow changing the vulkan device creation parameters.
@@ -1908,15 +1901,12 @@ where
 ///   as the create info value will be overwritten.
 /// - Callback must not remove features.
 /// - Callback must not change anything to what the instance does not support.
-pub type CreateDeviceCallback<'this> =
-    dyn for<'arg, 'pnext> FnOnce(CreateDeviceCallbackArgs<'arg, 'pnext, 'this>) + 'this;
+pub type CreateDeviceCallback =
+    dyn for<'arg, 'pnext> FnOnce(CreateDeviceCallbackArgs<'arg, 'pnext>) + 'static;
 
 /// Arguments to the [`CreateInstanceCallback`].
 #[expect(missing_debug_implementations, reason = "TODO?")]
-pub struct CreateInstanceCallbackArgs<'arg, 'pnext, 'this>
-where
-    'this: 'pnext,
-{
+pub struct CreateInstanceCallbackArgs<'arg, 'pnext> {
     /// The extensions to enable for the instance. You must not remove anything from this list,
     /// but you may add to it.
     pub extensions: &'arg mut Vec<&'static CStr>,
@@ -1926,10 +1916,6 @@ where
     pub create_info: &'arg mut vk::InstanceCreateInfo<'pnext>,
     /// Vulkan entry point.
     pub entry: &'arg ash::Entry,
-    /// We need to have `'this` in the struct, so we can declare that all lifetimes coming from
-    /// captures in the closure will live longer (and hence satisfy) `'pnext`. However, we
-    /// don't actually directly use `'this`
-    _phantom: PhantomData<&'this ()>,
 }
 
 /// Callback to allow changing the vulkan instance creation parameters.
@@ -1940,4 +1926,4 @@ where
 /// - Callback must not remove features.
 /// - Callback must not change anything to what the instance does not support.
 pub type CreateInstanceCallback<'this> =
-    dyn for<'arg, 'pnext> FnOnce(CreateInstanceCallbackArgs<'arg, 'pnext, 'this>) + 'this;
+    dyn for<'arg, 'pnext> FnOnce(CreateInstanceCallbackArgs<'arg, 'pnext>) + 'static;

--- a/wgpu-hal/src/vulkan/pnext_chain.rs
+++ b/wgpu-hal/src/vulkan/pnext_chain.rs
@@ -4,7 +4,8 @@ use ash::vk;
 
 /// A caller-provided `pNext` chain, stashed by one of the `set_next_*_chain`
 /// setters until the Vulkan call that consumes it.
-pub(crate) struct PnextChain(*mut vk::BaseOutStructure<'static>);
+#[derive(Debug)]
+pub struct PnextChain(*mut vk::BaseOutStructure<'static>);
 
 // SAFETY: The pointer is only dereferenced at the Vulkan call that consumes the
 // chain. Each setter's contract keeps the chain valid and unaliased until then.
@@ -13,7 +14,11 @@ unsafe impl Sync for PnextChain {}
 
 impl PnextChain {
     /// Wraps the raw chain pointer that a `set_next_*_chain` setter received.
-    pub(crate) fn new(chain: *mut c_void) -> Self {
+    /// TODO: update docs
+    ///
+    /// This method is safe, but methods that actually operate on a
+    /// [`PnextChain`] are probably not.
+    pub fn new(chain: *mut c_void) -> Self {
         Self(chain.cast())
     }
 

--- a/wgpu-hal/src/vulkan/swapchain/mod.rs
+++ b/wgpu-hal/src/vulkan/swapchain/mod.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use core::{any::Any, fmt::Debug, time::Duration};
 
-use crate::vulkan::{semaphore_list::SemaphoreType, DeviceShared};
+use crate::{RawSurfaceConfiguration, vulkan::{DeviceShared, semaphore_list::SemaphoreType}};
 
 pub(super) use native::*;
 
@@ -37,6 +37,7 @@ pub(super) trait Surface: Send + Sync + 'static {
         &self,
         device: &super::Device,
         config: &crate::SurfaceConfiguration,
+        raw_config: Option<Box<dyn RawSurfaceConfiguration>>,
         provided_old_swapchain: Option<Box<dyn Swapchain>>,
     ) -> Result<Box<dyn Swapchain>, crate::SurfaceError>;
 

--- a/wgpu-hal/src/vulkan/swapchain/native.rs
+++ b/wgpu-hal/src/vulkan/swapchain/native.rs
@@ -6,14 +6,11 @@ use core::any::Any;
 use ash::{khr, vk};
 use wgpu_sync::{Mutex, MutexGuard};
 
-use crate::vulkan::{
-    conv, map_host_device_oom_and_lost_err,
-    semaphore_list::SemaphoreType,
-    swapchain::{
+use crate::{RawSurfaceConfiguration, vulkan::{
+    DeviceShared, InstanceShared, PnextChain, VulkanSurfaceConfiguration, conv, map_host_device_oom_and_lost_err, semaphore_list::SemaphoreType, swapchain::{
         Surface, SurfaceTextureMetadata, Swapchain, SwapchainSubmissionSemaphoreGuard, WindowHandle,
-    },
-    DeviceShared, InstanceShared, PnextChain,
-};
+    }
+}};
 
 pub(crate) struct NativeSurface {
     raw: vk::SurfaceKHR,
@@ -23,12 +20,6 @@ pub(crate) struct NativeSurface {
     /// query; `None` for non-Win32 surfaces.
     #[cfg(windows)]
     hdr_source: Option<crate::auxil::dxgi::hdr::DxgiHdrSource>,
-    /// A caller-provided `pNext` chain to attach to the [`vk::SwapchainCreateInfoKHR`]
-    /// of the next swapchain created for this surface.
-    ///
-    /// Set only through
-    /// [`Surface::set_next_swapchain_create_chain()`](crate::vulkan::Surface::set_next_swapchain_create_chain).
-    next_swapchain_create_chain: Mutex<Option<PnextChain>>,
 }
 
 impl NativeSurface {
@@ -46,19 +37,11 @@ impl NativeSurface {
             instance: Arc::clone(&instance.shared),
             #[cfg(windows)]
             hdr_source: hwnd.map(|wh| crate::auxil::dxgi::hdr::DxgiHdrSource::new(wh.0)),
-            next_swapchain_create_chain: Mutex::new(None),
         }
     }
 
     pub fn as_raw(&self) -> vk::SurfaceKHR {
         self.raw
-    }
-
-    /// # Safety
-    ///
-    /// See [`Surface::set_next_swapchain_create_chain()`](crate::vulkan::Surface::set_next_swapchain_create_chain).
-    pub unsafe fn set_next_swapchain_create_chain(&self, chain: *mut core::ffi::c_void) {
-        *self.next_swapchain_create_chain.lock() = Some(PnextChain::new(chain));
     }
 }
 
@@ -197,9 +180,15 @@ impl Surface for NativeSurface {
         &self,
         device: &crate::vulkan::Device,
         config: &crate::SurfaceConfiguration,
+        raw_config: Option<Box<dyn RawSurfaceConfiguration>>,
         provided_old_swapchain: Option<Box<dyn Swapchain>>,
     ) -> Result<Box<dyn Swapchain>, crate::SurfaceError> {
         profiling::scope!("Device::create_swapchain");
+
+        let mut raw_config = raw_config.map(|value| {
+            Box::<dyn Any>::downcast::<VulkanSurfaceConfiguration>(value).unwrap()
+        });
+
         let functor = khr::swapchain::Device::new(&self.instance.raw, &device.shared.raw);
 
         let old_swapchain = provided_old_swapchain
@@ -247,11 +236,14 @@ impl Surface for NativeSurface {
             info = info.push_next(&mut format_list_info);
         }
 
-        let create_chain = self.next_swapchain_create_chain.lock().take();
-        if let Some(chain) = create_chain {
+        if let Some(create_chain) = raw_config
+            .as_mut()
+            .and_then(|raw| raw.swapchain_create_chain.take())
+        {
+            // TODO: update this safety comment
             // SAFETY: The contract on `Surface::set_next_swapchain_create_chain()` keeps
             // the chain valid and unaliased until this swapchain creation returns.
-            info.p_next = unsafe { chain.splice_into(info.p_next) };
+            info.p_next = unsafe { create_chain.splice_into(info.p_next) };
         }
 
         let result = {

--- a/wgpu-hal/src/vulkan/swapchain/native.rs
+++ b/wgpu-hal/src/vulkan/swapchain/native.rs
@@ -199,7 +199,9 @@ impl Surface for NativeSurface {
         let color_space = conv::map_surface_color_space(config.color_space);
 
         let original_format = device.shared.private_caps.map_texture_format(config.format);
-        let mut raw_flags = vk::SwapchainCreateFlagsKHR::empty();
+        let mut raw_flags = raw_config
+            .as_ref()
+            .map_or(vk::SwapchainCreateFlagsKHR::empty(), |raw| raw.swapchain_create_flags);
         let mut raw_view_formats: Vec<vk::Format> = vec![];
         if !config.view_formats.is_empty() {
             raw_flags |= vk::SwapchainCreateFlagsKHR::MUTABLE_FORMAT;

--- a/wgpu-types/src/adapter.rs
+++ b/wgpu-types/src/adapter.rs
@@ -69,6 +69,16 @@ impl<S> Default for RequestAdapterOptions<S> {
     }
 }
 
+/// Marker trait specializing [`BackendMap`] for [`BackendAdapterOptionsMap`].
+pub trait BackendAdapterOptions: core::any::Any { }
+
+/// A [`BackendMap`] containing backend-defined options for requesting an adapter or
+/// enumerating adapters.
+pub type BackendAdapterOptionsMap = crate::BackendMap<dyn BackendAdapterOptions>;
+
+/// Backend-defined options for requesting (opening) a device.
+pub trait BackendDeviceOptions: core::any::Any {}
+
 /// Power Preference when choosing a physical adapter.
 ///
 /// Corresponds to [WebGPU `GPUPowerPreference`](

--- a/wgpu-types/src/backend.rs
+++ b/wgpu-types/src/backend.rs
@@ -1,6 +1,6 @@
 //! [`Backend`], [`Backends`], and backend-specific options.
 
-use alloc::string::{String, ToString};
+use alloc::{boxed::Box, string::{String, ToString}};
 use core::{hash::Hash, str::FromStr};
 
 use macro_rules_attribute::derive;
@@ -69,8 +69,15 @@ pub enum Backend {
 }
 
 impl Backend {
+    /// The number of defined [`Backend`]s.
+    ///
+    /// Note that although [`Backend`] can represent the full set of backends,
+    /// each actual backend can be excluded at compile time, or lack support on
+    /// the current platform.
+    pub const COUNT: usize = Backends::all().bits().count_ones() as usize;
+
     /// Array of all [`Backend`] values, corresponding to [`Backends::all()`].
-    pub const ALL: [Backend; Backends::all().bits().count_ones() as usize] = [
+    pub const ALL: [Backend; Self::COUNT] = [
         Self::Noop,
         Self::Vulkan,
         Self::Metal,
@@ -218,6 +225,277 @@ impl Backends {
         }
 
         backends
+    }
+}
+
+/// dyn-compatible trait implemented by the value types stored in a [`BackendMap`].
+///
+/// This is the type of the trait objects stored in the map, and is used
+/// as a trait bound in the implementations of `Clone`, `Debug`, and similar
+/// for value types.
+///
+/// This trait should usually be implemented with the assistance of the
+/// [`backend_map_type!`] macro.
+pub trait DynBackendMapValue<M: ?Sized>: core::any::Any { }
+
+/// Non-dyn-compatible trait implemented by the value types stored in a [`BackendMap`].
+///
+/// This trait is required on the type parameter on the methods for getting and setting
+/// values in the map. It defines the `BACKEND` associated constant, which allows
+/// specifying just the backend-specific value type, rather redundantly specifying both
+/// both the type and index, when accessing the map. However, the associated constant is not
+/// dyn-compatible, so a separate trait must be used for trait objects.
+///
+/// This trait should usually be implemented with the assistance of the
+/// [`backend_map_type!`] macro.
+pub trait BackendMapValue<M: ?Sized>: DynBackendMapValue<M> {
+    /// The backend associated with this value type.
+    const BACKEND: Backend;
+}
+
+/// Map of per-backend values.
+///
+/// Backend map types are used to pass per-backend backend-defined data through higher-level
+/// APIs. This is used for contexts like `request_adapter` where a specific backend has
+/// not yet been selected. Dynamic typing is used to avoid conditional compilation or
+/// dependencies on specific hals.
+///
+/// The map is keyed by [`Backend`]s. The value type is determined by `M`, which is
+/// typically `dyn SomeTrait`, where `SomeTrait` is implemented by the value type for each
+/// backend.
+///
+/// The map assumes that each backend has a distinct value type, thus it is possible to
+/// uniquely index the map by specifying only a value type, without also specifying a
+/// [`Backend`].
+pub struct BackendMap<M: ?Sized> {
+    data: [Option<Box<dyn DynBackendMapValue<M>>>; Backend::COUNT],
+}
+
+impl<M: ?Sized> Default for BackendMap<M> {
+    fn default() -> Self {
+        Self {
+            data: core::array::from_fn(|_| None),
+        }
+    }
+}
+
+impl<M: ?Sized> BackendMap<M> {
+    /// Get the map value associated with a particular backend.
+    pub fn get<T: BackendMapValue<M>>(&self) -> Option<&T> {
+        self.data[T::BACKEND as usize]
+            .as_ref()
+            .map(|value| {
+                let value: &dyn core::any::Any = value.as_ref();
+                value.downcast_ref::<T>().unwrap()
+            })
+    }
+
+    /// Remove and return the map value associated with a particular backend.
+    pub fn remove<T: BackendMapValue<M>>(&mut self) -> Option<Box<T>> {
+        self.data[T::BACKEND as usize]
+            .take()
+            .map(|value| {
+                let value: Box<dyn core::any::Any> = value;
+                value.downcast::<T>().unwrap()
+            })
+    }
+
+    /// Set the map value associated with a particular backend, discarding any previous value.
+    pub fn set<T: BackendMapValue<M>>(mut self, value: Box<T>) -> Self {
+        self.data[T::BACKEND as usize] = Some(value);
+        self
+    }
+}
+
+impl<M: ?Sized> core::fmt::Debug for BackendMap<M>
+where
+    dyn DynBackendMapValue<M>: core::fmt::Debug,
+{
+    fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        todo!()
+    }
+}
+
+/// Returns whether `module_path` is the root module of a crate.
+///
+/// Used by the backend type macros, which expand to another macro definition,
+/// and use `crate::` to refer to the definition site of that inner macro.
+/// (`$crate` would refer to the definition site of the backend type macro,
+/// not the inner macro.)
+///
+/// The `crate_in_macro_def` lint flags these uses of `crate`, but as explained
+/// above, this is done intentionally because `$crate` would not work here.
+#[doc(hidden)]
+pub const fn is_crate_root(module_path: &str) -> bool {
+    let bytes = module_path.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b':' {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// Helper for defining value types for [`BackendMap`].
+///
+/// This macro defines some auxiliary items for a [`BackendMap`] value type. Its notable
+/// output is the definition of an inner macro that is invoked for each value type.
+/// The inner macro in turn implements the [`BackendMapValue`] and [`DynBackendMapValue`]
+/// traits for the value types.
+///
+/// Internally, [`backend_map_type!`] also defines a helper trait and struct that are used
+/// to check that at most one value type is defined for each backend. The helper struct is
+/// defined as `CheckStruct<const B: usize>`. Each time the inner macro is invoked, it
+/// generates `impl CheckTrait for CheckStruct<{Backend as usize}>`. Having two such
+/// definitions for a single backend in the same build will cause a conflicting trait
+/// implementation error.
+///
+/// Usage:
+///
+/// ```
+/// // In a crate root (typically `wgpu-hal`):
+/// backend_map_type!(
+///     adapter_options,                    // $macro: name of generated macro
+///                                         //         `value_trait_in_snake_case`
+///     dyn wgt::BackendAdapterOptions,     // $value_ty: trait object type for `M` in `BackendMap<M>`
+///                                         //            `dyn ValueTraitInCamelCase`
+///     AdapterOptionsType,                 // $check_trait: name of generated check trait
+///                                         //               `ValueTraitType`
+///     AdapterOptionsTypeAssignment,       // $check_struct: name of generated check struct
+///                                         //                `ValueTraitTypeAssignment`
+/// );
+///
+/// // Anywhere in the crate
+/// crate::adapter_options! {
+///     /// Options for enumerating Metal adapters.
+///     #[backend(wgt::Backend::Metal)]
+///     #[derive(Clone, Debug)]
+///     pub struct MetalAdapterOptions;
+/// }
+/// ```
+#[macro_export]
+#[rustfmt::skip]
+#[allow(clippy::crate_in_macro_def)] // see comment on `is_crate_root`
+macro_rules! backend_map_type {
+    (
+        $macro:ident,
+        $map_ty:ty,
+        $check_trait:ident,
+        $check_struct:ident,
+    ) => {
+        const _: () = assert!(
+            $crate::is_crate_root(module_path!()),
+            "backend_map_type! must be invoked at the crate root",
+        );
+
+        #[allow(unused)]
+        #[doc(hidden)]
+        pub trait $check_trait { }
+
+        #[allow(unused)]
+        #[doc(hidden)]
+        pub struct $check_struct<const B: usize>;
+
+        macro_rules! $macro {
+            (
+                #[doc = $doc:expr]
+                #[backend($backend:expr)]
+                #[$attr:meta]
+                $vis:vis struct $inner_name:ident $defn:tt
+            ) => {
+                #[doc = $doc]
+                #[$attr]
+                $vis struct $inner_name $defn
+
+                impl wgt::BackendMapValue<$map_ty> for $inner_name {
+                    const BACKEND: wgt::Backend = $backend;
+                }
+
+                impl wgt::DynBackendMapValue<$map_ty> for $inner_name { }
+
+                impl crate::$check_trait for crate::$check_struct<{ $backend as usize }> { }
+            };
+        }
+        pub(crate) use $macro;
+    }
+}
+
+
+/// Helper for defining backend-specific data types.
+///
+/// This is a simpler version of [`backend_map_type!`] used to define backend-specific data
+/// types that are passed through higher-level APIs in a context where the applicable
+/// backend is known.
+///
+/// Like [`backend_map_type!`], it defines and implements helper traits to check for
+/// conflicting per-backend types.
+///
+/// Usage:
+///
+/// ```
+/// // In a crate root (typically `wgpu-hal`):
+/// backend_type!(
+///     device_options,                     // $macro: name of generated macro
+///                                         //         `value_trait_in_snake_case`
+///     wgt::BackendDeviceOptions,          // $trait: trait for this object type (without `dyn`)
+///                                                    `qualified::if:needed::ValueTraitInCamelCase`
+///     DeviceOptionsType                   // $check_trait: name of generated check trait
+///                                         //               `ValueTraitType`
+///     DeviceOptionsTypeAssignment,        // $check_struct: name of generated check struct
+///                                         //                `ValueTraitTypeAssignment`
+/// );
+/// ```
+///
+/// // Anywhere in the crate
+/// crate::device_options! {
+///     /// Options for enumerating Metal devices.
+///     #[backend(wgt::Backend::Metal)]
+///     #[derive(Clone, Debug)]
+///     pub struct MetalDeviceOptions;
+/// }
+/// ```
+#[macro_export]
+#[rustfmt::skip]
+#[allow(clippy::crate_in_macro_def)] // see comment on `is_crate_root`
+macro_rules! backend_type {
+    (
+        $macro:ident,
+        $trait:path,
+        $check_trait:ident,
+        $check_struct:ident,
+    ) => {
+        const _: () = assert!(
+            $crate::is_crate_root(module_path!()),
+            "backend_type! must be invoked at the crate root",
+        );
+
+        #[allow(unused)]
+        #[doc(hidden)]
+        pub trait $check_trait { }
+
+        #[allow(unused)]
+        #[doc(hidden)]
+        pub struct $check_struct<const B: usize>;
+
+        macro_rules! $macro {
+            (
+                #[doc = $doc:expr]
+                #[backend($backend:expr)]
+                #[$attr:meta]
+                $vis:vis struct $inner_name:ident $defn:tt
+            ) => {
+                #[doc = $doc]
+                #[$attr]
+                $vis struct $inner_name $defn
+
+                impl $trait for $inner_name { }
+
+                impl crate::$check_trait for crate::$check_struct<{ $backend as usize }> { }
+            };
+        }
+        pub(crate) use $macro;
     }
 }
 

--- a/wgpu/src/backend/wgpu_core.rs
+++ b/wgpu/src/backend/wgpu_core.rs
@@ -2682,6 +2682,26 @@ impl dispatch::SurfaceInterface for CoreSurface {
         }
     }
 
+    unsafe fn configure_ext(
+        &self,
+        device: &dispatch::DispatchDevice,
+        config: &crate::SurfaceConfiguration,
+        raw_config: Option<Box<dyn wgpu_hal::RawSurfaceConfiguration>>,
+    ) {
+        let device = device.as_core();
+
+        let error = unsafe {
+            self.wgpu_surface.configure_ext(&device.wgpu_device, config, raw_config)
+        };
+        if let Some(e) = error {
+            device
+                .wgpu_device
+                .handle_error_nolabel(e, "Surface::configure");
+        } else {
+            *self.configured_device.lock() = Some(device.wgpu_device.clone());
+        }
+    }
+
     fn get_current_texture(
         &self,
         _desc: Option<crate::TextureDescriptor<'static>>,

--- a/wgpu/src/dispatch.rs
+++ b/wgpu/src/dispatch.rs
@@ -638,6 +638,14 @@ pub trait SurfaceInterface: CommonTraits {
     }
 
     fn configure(&self, device: &DispatchDevice, config: &crate::SurfaceConfiguration);
+
+    unsafe fn configure_ext(
+        &self,
+        device: &DispatchDevice,
+        config: &crate::SurfaceConfiguration,
+        raw_config: Option<Box<dyn wgpu_hal::RawSurfaceConfiguration>>,
+    );
+
     fn get_current_texture(
         &self,
         desc: Option<crate::TextureDescriptor<'static>>,


### PR DESCRIPTION
Proposal for a wgpu extension API. Firefox's most pressing desire for this is to implement an LUID filter when enumerating dx12 adapters. That or similar functionality has also been requested in other contexts (#9932 and #10011). Beyond that, the extension API could apply to various things. Some are discussed below and #4067 has more examples.

This still needs some cleanup, but it should be sufficient to understand and discuss the proposed direction.

The first commit "Support for passing backend data through higher-level APIs" adds the infrastructure, which enables  passing dynamically-typed backend (hal) data through the higher level APIs (`wgpu-core`, and potentially even `wgpu`). The common case is for the backend data to target a specific backend. In that case a backend-specific type like `VulkanDeviceOptions` implements a trait `wgpu_hal::BackendDeviceOptions`. The higher-level APIs carry `Option<Box<dyn BackendDeviceOptions>>`. Passing the wrong type currently panics, which matches the existing raw API behavior. In principle it would be easy to return a "wrong backend" error instead, but we'd need to think about how that maps to the WebGPU error reporting paths.

The less common case is supplying backend data for multiple backends simultaneously. This applies to `request_adapter` and could also apply to the backend options in `InstanceDescriptor`. This is supported with a `BackendMap` type, which is a map keyed by backends. For each backend the map uses a specific value type.

The commits "Add backend-specific extension data when requesting adapters and devices" and "feat(hal/dx12): Extension to restrict enumeration to a specific adapter LUID" implement the dx12 LUID filter using the extension API.

The remaining commits implement various other existing or proposed raw API features using the extension API. The intent is not that we necessarily or immediately take all of these changes, rather to demonstrate that the extension API is capable of supporting various use cases. Included are the `VkSwapchainCreateInfo` hook added in #10095, a hook for `VK_SWAPCHAIN_CREATE_PRESENT_TIMING_BIT_EXT` discussed in https://github.com/gfx-rs/wgpu/issues/2869#issuecomment-5487977763, Vulkan device creation callbacks, and a (only partially completed) `create_texture_from_raw` API intended to replace both the existing `texture_from_raw` hal APIs and the `create_texture_from_hal` wgpu_core API, and include the texture descriptor validation that `create_texture_from_hal` currently omits (see #9980).

Other cases not included here are the backend options in `InstanceDescriptor`, `buffer_from_raw`, command buffer APIs, more presentation APIs.

Some limitations and design questions worth thinking about:

- `Any` requires `'static`, meaning that we can't pass references through the extensions mechanism. This is certainly not ideal, but it's not clear how problematic it is. Some examples of where this appears: (1) the Vulkan creation callbacks currently have a lifetime parameter `'this` reflecting the lifetime of data borrowed by the closure (aside: I'm not sure this actually works right now, which may make breaking it further more palatable, but we could also try to fix it if not adopting `Any`), (2) the `surface_hint` argument to `request_adapter` could be migrated to the extension API (as a GL-backend-specific item), but is currently a reference (to a type that is not `Clone`).
- Directionally, do we want more or less infrastructure (e.g. dynamic typing) around extensions?
  - Less could look like using the `A: hal::Api` and `foo: A::Foo` pattern in more places. Maybe `trait BackendAdapterOptions { type Metal = MetalAdapterOptions; ... }`. Conditional compilation of hals makes this more complicated in practice, and dynamic typing really seems more appropriate on `wgpu_core` APIs than parameterizing them by the concrete hal.
  - More could be having a `BackendItem` that is analogous to `BackendMap` for the single-backend case. Also see next bullet.
- Do we want to support direct use of remote types for `RawFoo` (e.g. bare objc2 `Retained`, etc.)? Not possible with current approach that implements a trait directly for the type (in the non-Map case). More possible with `BackendMap` or a hypothetical `BackendItem` that works like `BackendMap` for the single-backend case (because then the concrete backend-specific type appears as an associated type, rather than needing to implement a trait for it). (Also, as currently written, types/traits divided across hgpu-hal and wgpu-types would be a problem here.)
- Which of the standard `derive` and auto traits should be implemented by the backend types? In earlier versions I had imposed some blanket requirements, but then decided it made more sense to set the requirements on a case-by-case basis.
- Naming. hal, raw, backend, native, ...? My convention was that "hal" means the type on the core/hal interface and "raw" means the type on the hal/platform interface, but I also used "backend" in some places where hal seemed unnatural. `native` might be clearer in place of "raw", but wouldn't match existing APIs.
- #9980 proposed `Vec<Box<dyn Any>>`, inspired by Vulkan's extension structures. Before working on this proposal, Claude implemented a version of that, which is [here](https://github.com/gfx-rs/wgpu/compare/trunk...andyleiserson:wgpu:hal-extensions). Based on requests in the maintainers meeting for "a bit more type safety" (a plain `Any` allows passing all sorts of inapplicable things), and given that our problem is a bit simpler than Vulkan (no independent loader and no runtime ABI compatibility concern), this approach with specific extension structs rather than an arbitrary combination of various extension structs seemed simpler and less unwieldy to work with.