### PR TITLE
[metal] cap the storage binding size at `u32::MAX - 4` again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
 #### Metal
 
+- Cap `max_storage_buffer_binding_size` at `u32::MAX & !3` on Metal again. The bounds checks naga emits read a bound range's byte size from a `u32` (`_mslBufferSizes`), so a storage binding of 2^32 bytes or more silently lost every element past byte 2^32 - 4 once `InstanceFlags::VALIDATION_INDIRECT_CALL` was off; such bindings are refused at bind group creation instead. By @nuri-yoo in [#10306](https://github.com/gfx-rs/wgpu/pull/10306).
 - Fix a crash/hang when configuring a surface with the `Bt2100Pq`, `Bt2100Hlg`, or `ExtendedDisplayP3` color space: the dynamically resolved CoreGraphics color-space constants were read with one level of indirection missing. By @stuartparmenter in [#10175](https://github.com/gfx-rs/wgpu/pull/10175).
 - Fix bind group resources for the task, mesh, fragment, and compute shader stages being bound from the wrong offsets whenever a bind group contained resources visible to the task or mesh stages, which could bind the wrong buffer, texture, or sampler to a shader slot. By @teoxoy in [#10043](https://github.com/gfx-rs/wgpu/issues/10043).
 - Report an error instead of panicking when Metal declines to create a texture view, which can occur for some views of textures with `TRANSIENT_ATTACHMENT` usage. By @matthargett in [#10145](https://github.com/gfx-rs/wgpu/pull/10145).

--- a/wgpu-hal/src/metal/adapter.rs
+++ b/wgpu-hal/src/metal/adapter.rs
@@ -1438,8 +1438,16 @@ impl super::CapabilitiesQuery {
             max_buffer_size: self.max_buffer_size,
             // No limit, use maxBufferSize.
             max_uniform_buffer_binding_size: self.max_buffer_size,
-            // No limit, use maxBufferSize.
-            max_storage_buffer_binding_size: self.max_buffer_size,
+            // Metal has no limit here either, but the shaders do: naga bounds-checks runtime-sized
+            // arrays against `_mslBufferSizes`, whose members are `uint`, and
+            // `make_sizes_buffer_update` saturates a bound range's byte size at `u32::MAX` to fill
+            // them. A storage binding of 2^32 bytes or more therefore looks 2^32 - 1 bytes long to
+            // its own kernel: the last element's index clamps onto its neighbour, and every element
+            // past byte 2^32 - 4 reads as zero and is never written. Cap the binding, not the
+            // buffer (ranges under 4 GiB of a larger buffer are fine), until those sizes are wider.
+            max_storage_buffer_binding_size: self
+                .max_buffer_size
+                .min(u64::from(u32::MAX) & !(wgt::STORAGE_BINDING_SIZE_ALIGNMENT as u64 - 1)),
             min_uniform_buffer_offset_alignment: self.constant_buffer_offset_alignment,
             // No documented limit. Use 32, which is the lowest allowed value.
             min_storage_buffer_offset_alignment: 32,


### PR DESCRIPTION
**Connections**

Fixes #10305.

Merge-After: 2026-09-17[America/New_York]

**Description**

On Metal, the bounds checks naga emits read each bound range's byte size from `_mslBufferSizes`, a struct of `uint`s that `make_sizes_buffer_update` fills with `u32::try_from(size).unwrap_or(u32::MAX)`. A storage binding of 2^32 bytes or more therefore looks 2^32 − 1 bytes long to its own kernel: the last element's index clamps onto its neighbour under `BoundsCheckPolicy::Restrict`, and every element past byte 2^32 − 4 reads as zero and is never written. No error is raised.

v29 hid this because the Metal adapter clamped `max_storage_buffer_binding_size` to `u32::MAX & !3` unconditionally. #9196 replaced that with `maxBufferSize` (the WebGPU correspondence table's value), leaving the cap to wgpu-core's `adjust_limits_for_indirect_validation`, which only applies while `InstanceFlags::VALIDATION_INDIRECT_CALL` is set. With the flag off an M4 Pro reports 14302248960 for the binding limit and accepts bindings that then miscompute.

This restores the cap on the storage *binding* size in the Metal adapter, with a comment saying why it is there, so such bindings are refused at bind group creation again. `max_buffer_size` is left alone: a buffer larger than 4 GiB is fine as long as each bound range stays under the cap. Widening `_mslBufferSizes` to 64 bits would lift the cap properly; this PR does not attempt that.

**Testing**

Ran the reproduction from #10305 against a patched `wgpu-hal` 30.0.1 (via `[patch.crates-io]`) with `WGPU_VALIDATION_INDIRECT_CALL=0`: a 2^32 − 32 MiB storage binding still round-trips (`[1.0, 1.0, 1.0, 1.0]`); 2^32 and 5 GiB bindings are now refused at `create_bind_group` instead of returning `[1.0, 1.0, 1.0, 0.0]` and `[0.0, 0.0, 0.0, 0.0]`. `cargo check`, `cargo clippy -D warnings` and `cargo fmt --check` on `wgpu-hal --features metal`. No new test: exercising the edge needs a 4 GiB allocation on a Metal device, which the CI runners do not have.

**Squash or Rebase?**

Squash

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [x] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works.
