### PR TITLE
[naga hlsl] Initialize compute workgroup arrays with distributed loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,10 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
 - Added explicit `Send` and `Sync` implementations to key `wgpu` types so that the compiler can do less work checking those bounds. If you previously added a `#![recursion_limit = ...]` attribute to your crate due to overflow errors involving `wgpu` types, you may now be able to remove it. By @kpreid in [#10177](https://github.com/gfx-rs/wgpu/pull/10177).
 
+#### naga
+
+- Reduce HLSL compute shader compilation time for large workgroup arrays by initializing their elements with loops distributed across workgroup invocations. By @DonutShinobu. <!-- Add the PR link when opening the PR. -->
+
 ### Documentation
 
 #### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,7 +247,7 @@ By @sagudev in [#10109](https://github.com/gfx-rs/wgpu/pull/10109).
 
 #### naga
 
-- Reduce HLSL compute shader compilation time for large workgroup arrays by initializing their elements with loops distributed across workgroup invocations. By @DonutShinobu. <!-- Add the PR link when opening the PR. -->
+- Reduce HLSL compute shader compilation time for large workgroup arrays by initializing their elements with loops distributed across workgroup invocations. By @DonutShinobu in [#10314](https://github.com/gfx-rs/wgpu/pull/10314).
 
 ### Documentation
 

--- a/naga/src/back/hlsl/writer.rs
+++ b/naga/src/back/hlsl/writer.rs
@@ -1826,21 +1826,27 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
             let back::FunctionType::EntryPoint(index) = func_ctx.ty else {
                 unreachable!();
             };
-            writeln!(
-                self.out,
-                "{}if ({} == 0) {{",
-                back::INDENT,
-                // need_workgroup_variables_initialization forces this to be written
-                // if the user doesn't specify it (so this must be Some())
-                local_invocation_index_name.as_ref().unwrap(),
-            )?;
-            self.write_workgroup_variables_initialization(
-                func_ctx,
-                module,
-                module.entry_points[index as usize].stage,
-            )?;
-
-            writeln!(self.out, "{}}}", back::INDENT)?;
+            let workgroup_size = module.entry_points[index as usize]
+                .workgroup_size
+                .iter()
+                .try_fold(1u32, |total, &size| total.checked_mul(size))
+                .ok_or_else(|| Error::Custom("Workgroup invocation count overflow".into()))?;
+            for (handle, var) in module.global_variables.iter() {
+                if !func_ctx.info[handle].is_empty() && var.space == crate::AddressSpace::WorkGroup
+                {
+                    let name = self.names[&NameKey::GlobalVariable(handle)].clone();
+                    self.write_compute_workgroup_init(
+                        module,
+                        proc::TypeResolution::Handle(var.ty),
+                        (&name, false),
+                        &mut Vec::new(),
+                        (
+                            local_invocation_index_name.as_ref().unwrap(),
+                            workgroup_size,
+                        ),
+                    )?;
+                }
+            }
             self.write_control_barrier(crate::Barrier::WORK_GROUP, back::Level(1))?;
         }
 
@@ -2004,6 +2010,121 @@ impl<'a, W: fmt::Write> super::Writer<'a, W> {
             && module.global_variables.iter().any(|(handle, var)| {
                 !func_ctx.info[handle].is_empty() && var.space.is_workgroup_like()
             })
+    }
+
+    fn write_compute_workgroup_init(
+        &mut self,
+        module: &Module,
+        ty: proc::TypeResolution,
+        (access, in_struct): (&str, bool),
+        dimensions: &mut Vec<(String, u32)>,
+        invocation: (&str, u32),
+    ) -> BackendResult {
+        match *ty.inner_with(&module.types) {
+            TypeInner::Array { base, size, .. } => {
+                let proc::IndexableLength::Known(count) = size.resolve(module.to_ctx())? else {
+                    unreachable!();
+                };
+                let index = self.namer.call("zero_index");
+                let element = format!("{access}[{index}]");
+                dimensions.push((index, count));
+                self.write_compute_workgroup_init(
+                    module,
+                    proc::TypeResolution::Handle(base),
+                    (&element, in_struct),
+                    dimensions,
+                    invocation,
+                )?;
+                dimensions.pop();
+            }
+            TypeInner::Struct { ref members, .. } => {
+                for (index, member) in members.iter().enumerate() {
+                    let name =
+                        &self.names[&NameKey::StructMember(ty.handle().unwrap(), index as u32)];
+                    let field = format!("{access}.{name}");
+                    match module.types[member.ty].inner {
+                        TypeInner::Matrix {
+                            columns,
+                            rows: crate::VectorSize::Bi,
+                            scalar,
+                        } if member.binding.is_none() => {
+                            for column in 0..columns as u8 {
+                                self.write_compute_workgroup_init(
+                                    module,
+                                    proc::TypeResolution::Value(TypeInner::Vector {
+                                        size: crate::VectorSize::Bi,
+                                        scalar,
+                                    }),
+                                    (&format!("{field}_{column}"), true),
+                                    dimensions,
+                                    invocation,
+                                )?;
+                            }
+                        }
+                        _ => {
+                            self.write_compute_workgroup_init(
+                                module,
+                                proc::TypeResolution::Handle(member.ty),
+                                (
+                                    &field,
+                                    member.binding.is_none()
+                                        || matches!(
+                                            module.types[member.ty].inner,
+                                            TypeInner::Array { .. }
+                                        ),
+                                ),
+                                dimensions,
+                                invocation,
+                            )?;
+                        }
+                    }
+                }
+            }
+            ref inner => {
+                let level = back::Level(1);
+                let body = level.next();
+                let (local_index, workgroup_size) = invocation;
+                if dimensions.is_empty() {
+                    writeln!(self.out, "{level}if ({local_index} == 0) {{")?;
+                } else {
+                    let count = dimensions
+                        .iter()
+                        .try_fold(1u32, |total, &(_, size)| total.checked_mul(size))
+                        .ok_or_else(|| {
+                            Error::Custom("Workgroup array element count overflow".into())
+                        })?;
+                    let index = self.namer.call("zero_flat_index");
+                    // Keep DXC from expanding large aggregate initializers during optimization.
+                    writeln!(self.out, "{level}[loop]")?;
+                    writeln!(self.out, "{level}for (uint {index} = {local_index}; {index} < {count}u; {index} += {workgroup_size}u) {{")?;
+                    let mut stride = count;
+                    for &(ref dimension, size) in dimensions.iter() {
+                        stride /= size;
+                        writeln!(
+                            self.out,
+                            "{body}uint {dimension} = ({index} / {stride}u) % {size}u;"
+                        )?;
+                    }
+                }
+                write!(self.out, "{body}{access} = (")?;
+                if in_struct
+                    && matches!(
+                        inner,
+                        TypeInner::Matrix {
+                            rows: crate::VectorSize::Bi,
+                            ..
+                        }
+                    )
+                {
+                    self.write_global_type(module, ty.handle().unwrap())?;
+                } else {
+                    self.write_value_type(module, inner)?;
+                }
+                writeln!(self.out, ")0;")?;
+                writeln!(self.out, "{level}}}")?;
+            }
+        }
+        Ok(())
     }
 
     pub(super) fn write_workgroup_variables_initialization(

--- a/naga/tests/in/wgsl/workgroup-init-compute.toml
+++ b/naga/tests/in/wgsl/workgroup-init-compute.toml
@@ -1,0 +1,2 @@
+targets = "HLSL"
+pipeline_constants = { width = 8.0, height = 2.0, count = 37.0 }

--- a/naga/tests/in/wgsl/workgroup-init-compute.wgsl
+++ b/naga/tests/in/wgsl/workgroup-init-compute.wgsl
@@ -1,0 +1,88 @@
+override width = 8u;
+override height = 2u;
+override count = 37u;
+
+struct Inner {
+    values: array<array<vec4<f32>, 3>, 5>,
+    atoms: array<atomic<u32>, 19>,
+    matrix: mat3x2<f32>,
+    matrices: array<mat2x2<f32>, 3>,
+}
+
+struct Tagged {
+    @location(0) matrix: mat2x2<f32>,
+}
+
+var<workgroup> data: array<Inner, 3>;
+var<workgroup> dynamic: array<u32, count>;
+var<workgroup> floats: array<f32, count>;
+var<workgroup> tagged: Tagged;
+var<workgroup> scalar: u32;
+var<workgroup> vector: vec3<u32>;
+var<workgroup> matrix: mat2x3<f32>;
+var<workgroup> unused: array<u32, 1024>;
+
+@group(0) @binding(0) var<storage, read_write> output: array<u32>;
+
+@compute @workgroup_size(width, height, 1)
+fn main(
+    @builtin(local_invocation_index) zero_flat_index: u32,
+    @builtin(workgroup_id) group: vec3<u32>,
+) {
+    var ok = scalar == 0u && all(vector == vec3(0u));
+    ok &= all(matrix[0] == vec3(0.0)) && all(matrix[1] == vec3(0.0));
+    ok &= all(tagged.matrix[0] == vec2(0.0)) && all(tagged.matrix[1] == vec2(0.0));
+    for (var i = 0u; i < 3u; i++) {
+        for (var j = 0u; j < 5u; j++) {
+            for (var k = 0u; k < 3u; k++) {
+                ok &= all(data[i].values[j][k] == vec4(0.0));
+            }
+        }
+        for (var j = 0u; j < 19u; j++) {
+            ok &= atomicLoad(&data[i].atoms[j]) == 0u;
+        }
+        for (var j = 0u; j < 3u; j++) {
+            ok &= all(data[i].matrix[j] == vec2(0.0));
+            ok &= all(data[i].matrices[j][0] == vec2(0.0));
+            ok &= all(data[i].matrices[j][1] == vec2(0.0));
+        }
+    }
+    for (var i = 0u; i < count; i++) {
+        ok &= dynamic[i] == 0u;
+        ok &= floats[i] == 0.0;
+    }
+    workgroupBarrier();
+    if zero_flat_index == 0u {
+        scalar = 42u;
+        vector = vec3(42u);
+        matrix = mat2x3(vec3(42.0), vec3(42.0));
+        for (var i = 0u; i < 3u; i++) {
+            for (var j = 0u; j < 5u; j++) {
+                for (var k = 0u; k < 3u; k++) {
+                    data[i].values[j][k] = vec4(42.0);
+                }
+            }
+            for (var j = 0u; j < 19u; j++) {
+                atomicStore(&data[i].atoms[j], 42u);
+            }
+        }
+        for (var i = 0u; i < count; i++) {
+            dynamic[i] = 42u;
+            floats[i] = 42.0;
+        }
+    }
+    workgroupBarrier();
+    ok &= scalar == 42u && all(vector == vec3(42u));
+    ok &= all(matrix[0] == vec3(42.0));
+    ok &= all(data[2].values[4][2] == vec4(42.0));
+    ok &= atomicLoad(&data[2].atoms[18]) == 42u;
+    ok &= dynamic[count - 1u] == 42u;
+    ok &= floats[count - 1u] == 42.0;
+    let index = group.x * width * height + zero_flat_index;
+    output[index] |= select(1u, 2u, ok);
+}
+
+@compute @workgroup_size(1)
+fn single() {
+    output[0] = scalar;
+}

--- a/naga/tests/out/hlsl/wgsl-atomicOps-int64.hlsl
+++ b/naga/tests/out/hlsl/wgsl-atomicOps-int64.hlsl
@@ -34,8 +34,19 @@ void cs_main(uint3 id : SV_GroupThreadID, uint local_invocation_index : SV_Group
 {
     if (local_invocation_index == 0) {
         workgroup_atomic_scalar = (uint64_t)0;
-        workgroup_atomic_arr = (int64_t[2])0;
-        workgroup_struct = (Struct)0;
+    }
+    [loop]
+    for (uint zero_flat_index = local_invocation_index; zero_flat_index < 2u; zero_flat_index += 2u) {
+        uint zero_index = (zero_flat_index / 1u) % 2u;
+        workgroup_atomic_arr[zero_index] = (int64_t)0;
+    }
+    if (local_invocation_index == 0) {
+        workgroup_struct.atomic_scalar = (uint64_t)0;
+    }
+    [loop]
+    for (uint zero_flat_index_1 = local_invocation_index; zero_flat_index_1 < 2u; zero_flat_index_1 += 2u) {
+        uint zero_index_1 = (zero_flat_index_1 / 1u) % 2u;
+        workgroup_struct.atomic_arr[zero_index_1] = (int64_t)0;
     }
     GroupMemoryBarrierWithGroupSync();
     { uint64_t dummy = 0; storage_atomic_scalar.InterlockedExchange(0, 1uL, dummy); }

--- a/naga/tests/out/hlsl/wgsl-atomicOps.hlsl
+++ b/naga/tests/out/hlsl/wgsl-atomicOps.hlsl
@@ -25,8 +25,19 @@ void cs_main(uint3 id : SV_GroupThreadID, uint local_invocation_index : SV_Group
 {
     if (local_invocation_index == 0) {
         workgroup_atomic_scalar = (uint)0;
-        workgroup_atomic_arr = (int[2])0;
-        workgroup_struct = (Struct)0;
+    }
+    [loop]
+    for (uint zero_flat_index = local_invocation_index; zero_flat_index < 2u; zero_flat_index += 2u) {
+        uint zero_index = (zero_flat_index / 1u) % 2u;
+        workgroup_atomic_arr[zero_index] = (int)0;
+    }
+    if (local_invocation_index == 0) {
+        workgroup_struct.atomic_scalar = (uint)0;
+    }
+    [loop]
+    for (uint zero_flat_index_1 = local_invocation_index; zero_flat_index_1 < 2u; zero_flat_index_1 += 2u) {
+        uint zero_index_1 = (zero_flat_index_1 / 1u) % 2u;
+        workgroup_struct.atomic_arr[zero_index_1] = (int)0;
     }
     GroupMemoryBarrierWithGroupSync();
     { uint dummy = 0; storage_atomic_scalar.InterlockedExchange(0, 1u, dummy); }

--- a/naga/tests/out/hlsl/wgsl-globals.hlsl
+++ b/naga/tests/out/hlsl/wgsl-globals.hlsl
@@ -112,8 +112,12 @@ uint NagaBufferLength(ByteAddressBuffer buffer)
 [numthreads(1, 1, 1)]
 void main(uint local_invocation_index : SV_GroupIndex)
 {
+    [loop]
+    for (uint zero_flat_index = local_invocation_index; zero_flat_index < 10u; zero_flat_index += 1u) {
+        uint zero_index = (zero_flat_index / 1u) % 10u;
+        wg[zero_index] = (float)0;
+    }
     if (local_invocation_index == 0) {
-        wg = (float[10])0;
         at_1 = (uint)0;
     }
     GroupMemoryBarrierWithGroupSync();

--- a/naga/tests/out/hlsl/wgsl-interface.hlsl
+++ b/naga/tests/out/hlsl/wgsl-interface.hlsl
@@ -77,8 +77,10 @@ FragmentOutput fragment(FragmentInput_fragment fragmentinput_fragment)
 [numthreads(1, 1, 1)]
 void compute(uint3 global_id : SV_DispatchThreadID, uint3 local_id : SV_GroupThreadID, uint local_index : SV_GroupIndex, uint3 wg_id : SV_GroupID, uint3 num_wgs : SV_GroupID)
 {
-    if (local_index == 0) {
-        output = (uint[1])0;
+    [loop]
+    for (uint zero_flat_index = local_index; zero_flat_index < 1u; zero_flat_index += 1u) {
+        uint zero_index = (zero_flat_index / 1u) % 1u;
+        output[zero_index] = (uint)0;
     }
     GroupMemoryBarrierWithGroupSync();
     output[0] = ((((global_id.x + local_id.x) + local_index) + wg_id.x) + uint3(_NagaConstants.first_vertex, _NagaConstants.first_instance, _NagaConstants.other).x);

--- a/naga/tests/out/hlsl/wgsl-workgroup-init-compute.hlsl
+++ b/naga/tests/out/hlsl/wgsl-workgroup-init-compute.hlsl
@@ -1,0 +1,480 @@
+typedef struct { float2 _0; float2 _1; } __mat2x2_f32;
+float2 __get_col_of_mat2x2_f32(__mat2x2_f32 mat, uint idx) {
+    switch(idx) {
+    case 0: { return mat._0; }
+    case 1: { return mat._1; }
+    default: { return (float2)0; }
+    }
+}
+void __set_col_of_mat2x2_f32(__mat2x2_f32 mat, uint idx, float2 value) {
+    switch(idx) {
+    case 0: { mat._0 = value; break; }
+    case 1: { mat._1 = value; break; }
+    }
+}
+void __set_el_of_mat2x2_f32(__mat2x2_f32 mat, uint idx, uint vec_idx, float value) {
+    switch(idx) {
+    case 0: { mat._0[vec_idx] = value; break; }
+    case 1: { mat._1[vec_idx] = value; break; }
+    }
+}
+
+struct Inner {
+    float4 values[5][3];
+    uint atoms[19];
+    int _pad2_0;
+    float2 matrix__0; float2 matrix__1; float2 matrix__2;
+    __mat2x2_f32 matrices[3];
+    int _end_pad_0;
+    int _end_pad_1;
+};
+
+struct Tagged {
+    row_major float2x2 matrix_ : LOC0;
+};
+
+static const uint width = 8u;
+static const uint height = 2u;
+static const uint count = 37u;
+
+groupshared Inner data[3];
+groupshared uint dynamic[37];
+groupshared float floats[37];
+groupshared Tagged tagged;
+groupshared uint scalar;
+groupshared uint3 vector_;
+groupshared float2x3 matrix_;
+RWByteAddressBuffer output : register(u0);
+
+float3x2 GetMatmatrix_OnInner(Inner obj) {
+    return float3x2(obj.matrix__0, obj.matrix__1, obj.matrix__2);
+}
+
+void SetMatmatrix_OnInner(Inner obj, float3x2 mat) {
+    obj.matrix__0 = mat[0];
+    obj.matrix__1 = mat[1];
+    obj.matrix__2 = mat[2];
+}
+
+void SetMatVecmatrix_OnInner(Inner obj, float2 vec, uint mat_idx) {
+    switch(mat_idx) {
+    case 0: { obj.matrix__0 = vec; break; }
+    case 1: { obj.matrix__1 = vec; break; }
+    case 2: { obj.matrix__2 = vec; break; }
+    }
+}
+
+void SetMatScalarmatrix_OnInner(Inner obj, float scalar, uint mat_idx, uint vec_idx) {
+    switch(mat_idx) {
+    case 0: { obj.matrix__0[vec_idx] = scalar; break; }
+    case 1: { obj.matrix__1[vec_idx] = scalar; break; }
+    case 2: { obj.matrix__2[vec_idx] = scalar; break; }
+    }
+}
+
+[numthreads(8, 2, 1)]
+void main(uint zero_flat_index : SV_GroupIndex, uint3 group : SV_GroupID)
+{
+    [loop]
+    for (uint zero_flat_index_1 = zero_flat_index; zero_flat_index_1 < 45u; zero_flat_index_1 += 16u) {
+        uint zero_index = (zero_flat_index_1 / 15u) % 3u;
+        uint zero_index_1 = (zero_flat_index_1 / 3u) % 5u;
+        uint zero_index_2 = (zero_flat_index_1 / 1u) % 3u;
+        data[zero_index].values[zero_index_1][zero_index_2] = (float4)0;
+    }
+    [loop]
+    for (uint zero_flat_index_2 = zero_flat_index; zero_flat_index_2 < 57u; zero_flat_index_2 += 16u) {
+        uint zero_index = (zero_flat_index_2 / 19u) % 3u;
+        uint zero_index_3 = (zero_flat_index_2 / 1u) % 19u;
+        data[zero_index].atoms[zero_index_3] = (uint)0;
+    }
+    [loop]
+    for (uint zero_flat_index_3 = zero_flat_index; zero_flat_index_3 < 3u; zero_flat_index_3 += 16u) {
+        uint zero_index = (zero_flat_index_3 / 1u) % 3u;
+        data[zero_index].matrix__0 = (float2)0;
+    }
+    [loop]
+    for (uint zero_flat_index_4 = zero_flat_index; zero_flat_index_4 < 3u; zero_flat_index_4 += 16u) {
+        uint zero_index = (zero_flat_index_4 / 1u) % 3u;
+        data[zero_index].matrix__1 = (float2)0;
+    }
+    [loop]
+    for (uint zero_flat_index_5 = zero_flat_index; zero_flat_index_5 < 3u; zero_flat_index_5 += 16u) {
+        uint zero_index = (zero_flat_index_5 / 1u) % 3u;
+        data[zero_index].matrix__2 = (float2)0;
+    }
+    [loop]
+    for (uint zero_flat_index_6 = zero_flat_index; zero_flat_index_6 < 9u; zero_flat_index_6 += 16u) {
+        uint zero_index = (zero_flat_index_6 / 3u) % 3u;
+        uint zero_index_4 = (zero_flat_index_6 / 1u) % 3u;
+        data[zero_index].matrices[zero_index_4] = (__mat2x2_f32)0;
+    }
+    [loop]
+    for (uint zero_flat_index_7 = zero_flat_index; zero_flat_index_7 < 37u; zero_flat_index_7 += 16u) {
+        uint zero_index_5 = (zero_flat_index_7 / 1u) % 37u;
+        dynamic[zero_index_5] = (uint)0;
+    }
+    [loop]
+    for (uint zero_flat_index_8 = zero_flat_index; zero_flat_index_8 < 37u; zero_flat_index_8 += 16u) {
+        uint zero_index_6 = (zero_flat_index_8 / 1u) % 37u;
+        floats[zero_index_6] = (float)0;
+    }
+    if (zero_flat_index == 0) {
+        tagged.matrix_ = (float2x2)0;
+    }
+    if (zero_flat_index == 0) {
+        scalar = (uint)0;
+    }
+    if (zero_flat_index == 0) {
+        vector_ = (uint3)0;
+    }
+    if (zero_flat_index == 0) {
+        matrix_ = (float2x3)0;
+    }
+    GroupMemoryBarrierWithGroupSync();
+    bool local = (bool)0;
+    bool ok = (bool)0;
+    bool local_1 = (bool)0;
+    bool local_2 = (bool)0;
+    uint i = 0u;
+    uint j = (uint)0;
+    uint k = (uint)0;
+    uint j_1 = (uint)0;
+    uint j_2 = (uint)0;
+    uint i_1 = 0u;
+    uint i_2 = 0u;
+    uint j_3 = (uint)0;
+    uint k_1 = (uint)0;
+    uint j_4 = (uint)0;
+    uint i_3 = 0u;
+    bool local_3 = (bool)0;
+
+    uint _e3 = scalar;
+    if ((_e3 == 0u)) {
+        uint3 _e9 = vector_;
+        local = all((_e9 == (0u).xxx));
+    } else {
+        local = false;
+    }
+    bool _e15 = local;
+    ok = _e15;
+    bool _e17 = ok;
+    float3 _e20 = matrix_[0];
+    if (all((_e20 == (0.0).xxx))) {
+        float3 _e29 = matrix_[1];
+        local_1 = all((_e29 == (0.0).xxx));
+    } else {
+        local_1 = false;
+    }
+    bool _e35 = local_1;
+    ok = (_e17 & _e35);
+    bool _e37 = ok;
+    float2 _e41 = tagged.matrix_[0];
+    if (all((_e41 == (0.0).xx))) {
+        float2 _e51 = tagged.matrix_[1];
+        local_2 = all((_e51 == (0.0).xx));
+    } else {
+        local_2 = false;
+    }
+    bool _e57 = local_2;
+    ok = (_e37 & _e57);
+    uint2 loop_bound = uint2(4294967295u, 4294967295u);
+    bool loop_init = true;
+    while(true) {
+        if (all(loop_bound == uint2(0u, 0u))) { break; }
+        loop_bound -= uint2(loop_bound.y == 0u, 1u);
+        if (!loop_init) {
+            uint _e164 = i;
+            i = (_e164 + 1u);
+        }
+        loop_init = false;
+        uint _e61 = i;
+        if ((_e61 < 3u)) {
+        } else {
+            break;
+        }
+        {
+            j = 0u;
+            uint2 loop_bound_1 = uint2(4294967295u, 4294967295u);
+            bool loop_init_1 = true;
+            while(true) {
+                if (all(loop_bound_1 == uint2(0u, 0u))) { break; }
+                loop_bound_1 -= uint2(loop_bound_1.y == 0u, 1u);
+                if (!loop_init_1) {
+                    uint _e93 = j;
+                    j = (_e93 + 1u);
+                }
+                loop_init_1 = false;
+                uint _e66 = j;
+                if ((_e66 < 5u)) {
+                } else {
+                    break;
+                }
+                {
+                    k = 0u;
+                    uint2 loop_bound_2 = uint2(4294967295u, 4294967295u);
+                    bool loop_init_2 = true;
+                    while(true) {
+                        if (all(loop_bound_2 == uint2(0u, 0u))) { break; }
+                        loop_bound_2 -= uint2(loop_bound_2.y == 0u, 1u);
+                        if (!loop_init_2) {
+                            uint _e90 = k;
+                            k = (_e90 + 1u);
+                        }
+                        loop_init_2 = false;
+                        uint _e71 = k;
+                        if ((_e71 < 3u)) {
+                        } else {
+                            break;
+                        }
+                        {
+                            bool _e74 = ok;
+                            uint _e76 = i;
+                            uint _e79 = j;
+                            uint _e81 = k;
+                            float4 _e83 = data[min(uint(_e76), 2u)].values[min(uint(_e79), 4u)][min(uint(_e81), 2u)];
+                            ok = (_e74 & all((_e83 == (0.0).xxxx)));
+                        }
+                    }
+                }
+            }
+            j_1 = 0u;
+            uint2 loop_bound_3 = uint2(4294967295u, 4294967295u);
+            bool loop_init_3 = true;
+            while(true) {
+                if (all(loop_bound_3 == uint2(0u, 0u))) { break; }
+                loop_bound_3 -= uint2(loop_bound_3.y == 0u, 1u);
+                if (!loop_init_3) {
+                    uint _e112 = j_1;
+                    j_1 = (_e112 + 1u);
+                }
+                loop_init_3 = false;
+                uint _e97 = j_1;
+                if ((_e97 < 19u)) {
+                } else {
+                    break;
+                }
+                {
+                    bool _e100 = ok;
+                    uint _e102 = i;
+                    uint _e105 = j_1;
+                    uint _e107; InterlockedOr(data[min(uint(_e102), 2u)].atoms[min(uint(_e105), 18u)], 0, _e107);
+                    ok = (_e100 & (_e107 == 0u));
+                }
+            }
+            j_2 = 0u;
+            uint2 loop_bound_4 = uint2(4294967295u, 4294967295u);
+            bool loop_init_4 = true;
+            while(true) {
+                if (all(loop_bound_4 == uint2(0u, 0u))) { break; }
+                loop_bound_4 -= uint2(loop_bound_4.y == 0u, 1u);
+                if (!loop_init_4) {
+                    uint _e161 = j_2;
+                    j_2 = (_e161 + 1u);
+                }
+                loop_init_4 = false;
+                uint _e116 = j_2;
+                if ((_e116 < 3u)) {
+                } else {
+                    break;
+                }
+                {
+                    bool _e119 = ok;
+                    uint _e121 = i;
+                    uint _e124 = j_2;
+                    float2 _e126 = GetMatmatrix_OnInner(data[min(uint(_e121), 2u)])[min(uint(_e124), 2u)];
+                    ok = (_e119 & all((_e126 == (0.0).xx)));
+                    bool _e132 = ok;
+                    uint _e134 = i;
+                    uint _e137 = j_2;
+                    float2 _e140 = data[min(uint(_e134), 2u)].matrices[min(uint(_e137), 2u)]._0;
+                    ok = (_e132 & all((_e140 == (0.0).xx)));
+                    bool _e146 = ok;
+                    uint _e148 = i;
+                    uint _e151 = j_2;
+                    float2 _e154 = data[min(uint(_e148), 2u)].matrices[min(uint(_e151), 2u)]._1;
+                    ok = (_e146 & all((_e154 == (0.0).xx)));
+                }
+            }
+        }
+    }
+    uint2 loop_bound_5 = uint2(4294967295u, 4294967295u);
+    bool loop_init_5 = true;
+    while(true) {
+        if (all(loop_bound_5 == uint2(0u, 0u))) { break; }
+        loop_bound_5 -= uint2(loop_bound_5.y == 0u, 1u);
+        if (!loop_init_5) {
+            uint _e188 = i_1;
+            i_1 = (_e188 + 1u);
+        }
+        loop_init_5 = false;
+        uint _e168 = i_1;
+        if ((_e168 < count)) {
+        } else {
+            break;
+        }
+        {
+            bool _e171 = ok;
+            uint _e173 = i_1;
+            uint _e175 = dynamic[min(uint(_e173), 36u)];
+            ok = (_e171 & (_e175 == 0u));
+            bool _e179 = ok;
+            uint _e181 = i_1;
+            float _e183 = floats[min(uint(_e181), 36u)];
+            ok = (_e179 & (_e183 == 0.0));
+        }
+    }
+    GroupMemoryBarrierWithGroupSync();
+    if ((zero_flat_index == 0u)) {
+        scalar = 42u;
+        vector_ = (42u).xxx;
+        matrix_ = float2x3((42.0).xxx, (42.0).xxx);
+        uint2 loop_bound_6 = uint2(4294967295u, 4294967295u);
+        bool loop_init_6 = true;
+        while(true) {
+            if (all(loop_bound_6 == uint2(0u, 0u))) { break; }
+            loop_bound_6 -= uint2(loop_bound_6.y == 0u, 1u);
+            if (!loop_init_6) {
+                uint _e250 = i_2;
+                i_2 = (_e250 + 1u);
+            }
+            loop_init_6 = false;
+            uint _e205 = i_2;
+            if ((_e205 < 3u)) {
+            } else {
+                break;
+            }
+            {
+                j_3 = 0u;
+                uint2 loop_bound_7 = uint2(4294967295u, 4294967295u);
+                bool loop_init_7 = true;
+                while(true) {
+                    if (all(loop_bound_7 == uint2(0u, 0u))) { break; }
+                    loop_bound_7 -= uint2(loop_bound_7.y == 0u, 1u);
+                    if (!loop_init_7) {
+                        uint _e232 = j_3;
+                        j_3 = (_e232 + 1u);
+                    }
+                    loop_init_7 = false;
+                    uint _e210 = j_3;
+                    if ((_e210 < 5u)) {
+                    } else {
+                        break;
+                    }
+                    {
+                        k_1 = 0u;
+                        uint2 loop_bound_8 = uint2(4294967295u, 4294967295u);
+                        bool loop_init_8 = true;
+                        while(true) {
+                            if (all(loop_bound_8 == uint2(0u, 0u))) { break; }
+                            loop_bound_8 -= uint2(loop_bound_8.y == 0u, 1u);
+                            if (!loop_init_8) {
+                                uint _e229 = k_1;
+                                k_1 = (_e229 + 1u);
+                            }
+                            loop_init_8 = false;
+                            uint _e215 = k_1;
+                            if ((_e215 < 3u)) {
+                            } else {
+                                break;
+                            }
+                            {
+                                uint _e219 = i_2;
+                                uint _e222 = j_3;
+                                uint _e224 = k_1;
+                                data[min(uint(_e219), 2u)].values[min(uint(_e222), 4u)][min(uint(_e224), 2u)] = (42.0).xxxx;
+                            }
+                        }
+                    }
+                }
+                j_4 = 0u;
+                uint2 loop_bound_9 = uint2(4294967295u, 4294967295u);
+                bool loop_init_9 = true;
+                while(true) {
+                    if (all(loop_bound_9 == uint2(0u, 0u))) { break; }
+                    loop_bound_9 -= uint2(loop_bound_9.y == 0u, 1u);
+                    if (!loop_init_9) {
+                        uint _e247 = j_4;
+                        j_4 = (_e247 + 1u);
+                    }
+                    loop_init_9 = false;
+                    uint _e236 = j_4;
+                    if ((_e236 < 19u)) {
+                    } else {
+                        break;
+                    }
+                    {
+                        uint _e240 = i_2;
+                        uint _e243 = j_4;
+                        { uint dummy = 0; InterlockedExchange(data[min(uint(_e240), 2u)].atoms[min(uint(_e243), 18u)], 42u, dummy); }
+                    }
+                }
+            }
+        }
+        uint2 loop_bound_10 = uint2(4294967295u, 4294967295u);
+        bool loop_init_10 = true;
+        while(true) {
+            if (all(loop_bound_10 == uint2(0u, 0u))) { break; }
+            loop_bound_10 -= uint2(loop_bound_10.y == 0u, 1u);
+            if (!loop_init_10) {
+                uint _e266 = i_3;
+                i_3 = (_e266 + 1u);
+            }
+            loop_init_10 = false;
+            uint _e254 = i_3;
+            if ((_e254 < count)) {
+            } else {
+                break;
+            }
+            {
+                uint _e258 = i_3;
+                dynamic[min(uint(_e258), 36u)] = 42u;
+                uint _e262 = i_3;
+                floats[min(uint(_e262), 36u)] = 42.0;
+            }
+        }
+    }
+    GroupMemoryBarrierWithGroupSync();
+    bool _e268 = ok;
+    uint _e270 = scalar;
+    if ((_e270 == 42u)) {
+        uint3 _e276 = vector_;
+        local_3 = all((_e276 == (42u).xxx));
+    } else {
+        local_3 = false;
+    }
+    bool _e282 = local_3;
+    ok = (_e268 & _e282);
+    bool _e284 = ok;
+    float3 _e287 = matrix_[0];
+    ok = (_e284 & all((_e287 == (42.0).xxx)));
+    bool _e293 = ok;
+    float4 _e299 = data[2].values[4][2];
+    ok = (_e293 & all((_e299 == (42.0).xxxx)));
+    bool _e305 = ok;
+    uint _e310; InterlockedOr(data[2].atoms[18], 0, _e310);
+    ok = (_e305 & (_e310 == 42u));
+    bool _e314 = ok;
+    uint _e321 = dynamic[36u];
+    ok = (_e314 & (_e321 == 42u));
+    bool _e325 = ok;
+    float _e332 = floats[36u];
+    ok = (_e325 & (_e332 == 42.0));
+    uint index = (((group.x * width) * height) + zero_flat_index);
+    uint _e344 = asuint(output.Load(index*4));
+    bool _e347 = ok;
+    output.Store(index*4, asuint((_e344 | (_e347 ? 2u : 1u))));
+    return;
+}
+
+[numthreads(1, 1, 1)]
+void single(uint local_invocation_index : SV_GroupIndex)
+{
+    if (local_invocation_index == 0) {
+        scalar = (uint)0;
+    }
+    GroupMemoryBarrierWithGroupSync();
+    uint _e3 = scalar;
+    output.Store(0, asuint(_e3));
+    return;
+}

--- a/naga/tests/out/hlsl/wgsl-workgroup-init-compute.ron
+++ b/naga/tests/out/hlsl/wgsl-workgroup-init-compute.ron
@@ -1,0 +1,20 @@
+(
+    vertex:[
+    ],
+    fragment:[
+    ],
+    compute:[
+        (
+            entry_point:"main",
+            target_profile:"cs_5_1",
+        ),
+        (
+            entry_point:"single",
+            target_profile:"cs_5_1",
+        ),
+    ],
+    task:[
+    ],
+    mesh:[
+    ],
+)

--- a/naga/tests/out/hlsl/wgsl-workgroup-uniform-load-atomic.hlsl
+++ b/naga/tests/out/hlsl/wgsl-workgroup-uniform-load-atomic.hlsl
@@ -12,8 +12,17 @@ void test_atomic_workgroup_uniform_load(uint3 workgroup_id : SV_GroupID, uint3 l
 {
     if (local_invocation_index == 0) {
         wg_scalar = (uint)0;
+    }
+    if (local_invocation_index == 0) {
         wg_signed = (int)0;
-        wg_struct = (AtomicStruct)0;
+    }
+    if (local_invocation_index == 0) {
+        wg_struct.atomic_scalar = (uint)0;
+    }
+    [loop]
+    for (uint zero_flat_index = local_invocation_index; zero_flat_index < 2u; zero_flat_index += 64u) {
+        uint zero_index = (zero_flat_index / 1u) % 2u;
+        wg_struct.atomic_arr[zero_index] = (int)0;
     }
     GroupMemoryBarrierWithGroupSync();
     bool local = (bool)0;

--- a/naga/tests/out/hlsl/wgsl-workgroup-uniform-load.hlsl
+++ b/naga/tests/out/hlsl/wgsl-workgroup-uniform-load.hlsl
@@ -5,8 +5,10 @@ groupshared int arr_i32_[128];
 [numthreads(4, 1, 1)]
 void test_workgroupUniformLoad(uint3 workgroup_id : SV_GroupID, uint local_invocation_index : SV_GroupIndex)
 {
-    if (local_invocation_index == 0) {
-        arr_i32_ = (int[128])0;
+    [loop]
+    for (uint zero_flat_index = local_invocation_index; zero_flat_index < 128u; zero_flat_index += 4u) {
+        uint zero_index = (zero_flat_index / 1u) % 128u;
+        arr_i32_[zero_index] = (int)0;
     }
     GroupMemoryBarrierWithGroupSync();
     GroupMemoryBarrierWithGroupSync();

--- a/naga/tests/out/hlsl/wgsl-workgroup-var-init.hlsl
+++ b/naga/tests/out/hlsl/wgsl-workgroup-var-init.hlsl
@@ -10,8 +10,19 @@ RWByteAddressBuffer output : register(u0);
 [numthreads(1, 1, 1)]
 void main(uint local_invocation_index : SV_GroupIndex)
 {
+    [loop]
+    for (uint zero_flat_index = local_invocation_index; zero_flat_index < 512u; zero_flat_index += 1u) {
+        uint zero_index = (zero_flat_index / 1u) % 512u;
+        w_mem.arr[zero_index] = (uint)0;
+    }
     if (local_invocation_index == 0) {
-        w_mem = (WStruct)0;
+        w_mem.atom = (int)0;
+    }
+    [loop]
+    for (uint zero_flat_index_1 = local_invocation_index; zero_flat_index_1 < 64u; zero_flat_index_1 += 1u) {
+        uint zero_index_1 = (zero_flat_index_1 / 8u) % 8u;
+        uint zero_index_2 = (zero_flat_index_1 / 1u) % 8u;
+        w_mem.atom_arr[zero_index_1][zero_index_2] = (int)0;
     }
     GroupMemoryBarrierWithGroupSync();
     uint _e3[512] = w_mem.arr;

--- a/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
+++ b/tests/tests/wgpu-gpu/shader/zero_init_workgroup_mem.rs
@@ -12,6 +12,103 @@ use wgpu_test::{apply, gpu_test, GpuTestConfiguration, GpuTestInitializer, TestP
 
 pub fn all_tests(vec: &mut Vec<GpuTestInitializer>) {
     vec.push(ZERO_INIT_WORKGROUP_MEMORY);
+    vec.push(ZERO_INIT_WORKGROUP_MEMORY_PARALLEL);
+    vec.push(ZERO_INIT_WORKGROUP_MEMORY_PARALLEL_F16);
+}
+
+#[apply(gpu_test!)]
+static ZERO_INIT_WORKGROUP_MEMORY_PARALLEL: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .limits(Limits::default())
+            .skip(wgpu_test::FailureCase::backend(!wgpu::Backends::DX12)),
+    )
+    .run_async(parallel_zero_init);
+
+#[apply(gpu_test!)]
+static ZERO_INIT_WORKGROUP_MEMORY_PARALLEL_F16: GpuTestConfiguration = GpuTestConfiguration::new()
+    .parameters(
+        TestParameters::default()
+            .limits(Limits::default())
+            .features(wgpu::Features::SHADER_F16)
+            .skip(wgpu_test::FailureCase::backend(!wgpu::Backends::DX12)),
+    )
+    .run_async(parallel_zero_init);
+
+async fn parallel_zero_init(ctx: wgpu_test::TestingContext) {
+    let source = include_str!("../../../../naga/tests/in/wgsl/workgroup-init-compute.wgsl");
+    let source = if ctx.device.features().contains(wgpu::Features::SHADER_F16) {
+        std::borrow::Cow::Owned(format!("enable f16;\n{}", source.replace("f32", "f16")))
+    } else {
+        std::borrow::Cow::Borrowed(source)
+    };
+    let module = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(source),
+        });
+    for (width, height, count) in [(1, 1, 1), (8, 2, 37), (32, 2, 67)] {
+        let pipeline = ctx
+            .device
+            .create_compute_pipeline(&ComputePipelineDescriptor {
+                label: None,
+                layout: None,
+                module: &module,
+                entry_point: Some("main"),
+                compilation_options: wgpu::PipelineCompilationOptions {
+                    constants: &[
+                        ("width", width as f64),
+                        ("height", height as f64),
+                        ("count", count as f64),
+                    ],
+                    ..Default::default()
+                },
+                cache: None,
+            });
+        let size = 32 * width * height * 4;
+        let output = ctx.device.create_buffer(&BufferDescriptor {
+            label: None,
+            size,
+            usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let readback = ctx.device.create_buffer(&BufferDescriptor {
+            label: None,
+            size,
+            usage: BufferUsages::COPY_DST | BufferUsages::MAP_READ,
+            mapped_at_creation: false,
+        });
+        let bind_group = ctx.device.create_bind_group(&BindGroupDescriptor {
+            label: None,
+            layout: &pipeline.get_bind_group_layout(0),
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: output.as_entire_binding(),
+            }],
+        });
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&CommandEncoderDescriptor::default());
+        {
+            let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor::default());
+            pass.set_pipeline(&pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            for _ in 0..32 {
+                pass.dispatch_workgroups(32, 1, 1);
+            }
+        }
+        encoder.copy_buffer_to_buffer(&output, 0, &readback, 0, size);
+        ctx.queue.submit([encoder.finish()]);
+        readback.slice(..).map_async(MapMode::Read, |_| ());
+        ctx.async_poll(PollType::wait_indefinitely()).await.unwrap();
+        let mapped = readback.slice(..).get_mapped_range().unwrap();
+        let values: &[u32] = bytemuck::cast_slice(&mapped);
+        assert!(
+            values.iter().all(|&value| value == 2),
+            "workgroup {width}x{height}, array size {count}: {values:?}"
+        );
+    }
 }
 
 #[apply(gpu_test!)]


### PR DESCRIPTION
**Connections**

Related to https://github.com/gfx-rs/wgpu/issues/7443 and https://github.com/gfx-rs/wgpu/issues/4592.
The broader approach in https://github.com/gfx-rs/wgpu/pull/5521 was closed without merging. This change is limited to the HLSL compute initialization path.

**Description**

While developing my WebGPU-based browser translation extension, ShinobuTranslator, I encountered significantly slower cold starts in Firefox than in Chrome. I traced part of the delay to excessive DXC optimization time for Naga-generated workgroup array initialization, which motivated this upstream fix.

DXC can spend seconds optimizing the aggregate assignments Naga emits to initialize large workgroup arrays. For a `4 × 18 × 18` array of `vec4<f32>`, Naga currently emits an assignment equivalent to `inp = (float4[4][18][18])0` inside the invocation-zero guard.

Emit element assignments in `[loop]` loops instead. Flatten array dimensions, including arrays separated by struct members, and distribute indices over `local_invocation_index` with the workgroup invocation count as the stride. Recurse through struct members without producing a large aggregate assignment. Preserve the HLSL representations of two-row matrices, including members carrying an I/O binding. Non-array leaves remain initialized by invocation zero, followed by the existing unconditional group synchronization barrier.

The existing zero-initialization option and used-global filtering remain in effect. Task/mesh initialization, other shader backends, and function/private initialization are unchanged. There is no public API or dependency change.

The new DX12 GPU regression test checks every field before use, records failures across repeated dispatches, and covers single and multiple invocations, non-divisible array lengths, pipeline overrides, nested arrays and structs, atomics, vectors, matrices, identifier collisions, and f32/f16 variants. It shares its WGSL source with the HLSL snapshot test. Existing cross-backend initialization tests are unchanged.

**Testing**

Windows, NVIDIA GeForce RTX 5070 Ti (driver `32.0.16.1074`) and Microsoft WARP; Rust 1.93.1. Dynamic DXC `v1.9.2602.24` and Windows SDK FXC `10.0.26100.0`; Vulkan SDK `1.4.357.0` supplies snapshot tools. `RUST_MIN_STACK=8388608` avoids a pre-existing stack overflow in Naga's deep-template parser test on this Windows host.

- `cargo build -p naga-cli`: passed.
- `cargo fmt --all -- --check` and `cargo clippy --tests`: passed.
- Tombi 1.1.3 `format --check --diff`: passed (227 files). Prettier 3.9.6 check of `CHANGELOG.md`: passed.
- `cargo nextest run -p naga --all-features`: 369 passed.
- Focused workgroup initialization GPU tests: 15 passed with DXC, including f16; 10 passed with FXC, excluding unsupported f16. Counts include repeated NVIDIA adapter enumerations and WARP, not five different physical GPUs.
- From `naga/`, `cargo xtask validate hlsl dxc` and `cargo xtask validate hlsl fxc`: passed.
- `cargo xtask cts --backend dx12 'webgpu:shader,execution,zero_init:*'`: 348/348 passed with DXC, and separately 348/348 with FXC. These are the zero-initialization CTS cases, not the entire CTS.
- Final `cargo xtask test` result: **2724 passed, 8 failed, 30 skipped (2732 tests run)**. All eight failures are NVIDIA screenshot checks (`ray_cube_fragment` and `ray_scene`, four adapter enumerations). An unmodified checkout of the base commit reproduces all eight with the same image error values; WARP passes both examples when using the matching WARP DLL and Agility SDK.

Optimized compilation, fresh DXC processes, alternating before/after order, seven samples per variant:

| Generated HLSL | Baseline median | Patched median |
| --- | ---: | ---: |
| DXC `-O3`, `cs_6_0`, HLSL 2018 | 1854.99 ms | 22.96 ms |
| DXC `-Od`, `cs_6_0`, HLSL 2018 | 57.81 ms | 22.43 ms |

GPU timestamp measurements use DXIL compiled with `-O3`, observable storage-buffer outputs checked on every run, six warm-up rounds and 21 measured samples per variant, alternating order. Each measurement is a batch of 64 dispatches with 256 workgroups per dispatch, each containing 256 invocations:

| Workgroup data | Baseline median | Patched median |
| --- | ---: | ---: |
| `array<array<array<vec4<f32>,18>,18>,4>` | 0.314688 ms | 0.108160 ms |
| `array<vec4<f32>,37>` | 0.073344 ms | 0.068000 ms |
| Array of structs containing arrays and `mat3x2<f32>` | 0.083808 ms | 0.068992 ms |

These measurements support the compiler improvement and show no runtime regression in these three workloads on this GPU. They do not establish performance on AMD/Intel hardware, or Firefox end-to-end startup. A Firefox build with an updated Naga vendor has not been tested.

Minimal compilation reproducer:

```wgsl
var<workgroup> inp: array<array<array<vec4<f32>, 18>, 18>, 4>;
@group(0) @binding(0) var<storage, read_write> output: array<vec4<f32>>;
@compute @workgroup_size(16, 16, 1)
fn main(@builtin(local_invocation_index) index: u32) {
    output[index] = inp[index / 324u][(index / 18u) % 18u][index % 18u];
}
```

Translate using the base and patched `naga` binaries, then compile each generated file with `dxc -T cs_6_0 -E main -HV 2018 -O3 input.hlsl -Fo output.dxil`. The separate GPU benchmark reads all array elements and gives each workgroup its own output range.

**Squash or Rebase?**

Please squash any follow-up commits into a single commit.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [x] `CHANGELOG.md` entries for the user-facing effects of this change are present.
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [x] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [x] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [x] (If applicable) Tests demonstrate the validation and altered logic works.
