### PR TITLE
Finish NetBSD support

### DIFF
--- a/deno_webgpu/surface.rs
+++ b/deno_webgpu/surface.rs
@@ -3,12 +3,12 @@
 use std::cell::RefCell;
 use std::sync::Arc;
 
-use deno_core::GarbageCollected;
-use deno_core::WebIDL;
 use deno_core::_ops::make_cppgc_object;
 use deno_core::cppgc::Ptr;
 use deno_core::op2;
 use deno_core::v8;
+use deno_core::GarbageCollected;
+use deno_core::WebIDL;
 use deno_error::JsErrorBox;
 use wgpu_types::SurfaceStatus;
 

--- a/wgpu-core/Cargo.toml
+++ b/wgpu-core/Cargo.toml
@@ -175,7 +175,7 @@ wgpu-core-deps-emscripten = { workspace = true, optional = true }
 [target.'cfg(all(target_family = "wasm", not(target_os = "emscripten")))'.dependencies]
 wgpu-core-deps-wasm = { workspace = true, optional = true }
 
-[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 wgpu-core-deps-linux-android-bsd = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/wgpu-core/build.rs
+++ b/wgpu-core/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
-        windows_linux_android: { any(windows, target_os = "linux", target_os = "android", target_os = "freebsd") },
+        windows_linux_android: { any(windows, target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd") },
         send_sync: { all(
             feature = "std",
             any(

--- a/wgpu/build.rs
+++ b/wgpu/build.rs
@@ -28,7 +28,7 @@ fn main() {
         gles: { any(
             // The `gles` feature enables the OpenGL/GLES backend only on "native OpenGL" platforms, i.e. Windows, Linux, Android, and Emscripten.
             // (Note that WebGL is also not included here!)
-            all(any(windows, target_os = "linux", target_os = "android", target_os = "freebsd", Emscripten), feature = "gles"),
+            all(any(windows, target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "netbsd", Emscripten), feature = "gles"),
             // On Apple platforms, however, we require the `angle` feature to explicitly opt-in to OpenGL
             // since it's meant to be used with ANGLE.
             all(target_vendor = "apple", feature = "angle")


### PR DESCRIPTION
Finish what https://github.com/gfx-rs/wgpu/pull/8695 started and actually support gles backend on NetBSD.

Proof of concept, see: https://github.com/Kl4rry/simp/issues/47

Comments to the changes:
 - wgpu/build.rs

 Enable the GLES/OpenGL backend cfg alias on NetBSD. Without this, the `gles` cfg alias in the top-level `wgpu` crate never evaluates true on
 NetBSD, so no backend feature ends up compiled in and wgpu::Instance::new() panics at runtime with "No wgpu backend feature that is implemented for the target platform was enabled."

 - wgpu-core/build.rs

 Add NetBSD to the `windows_linux_android` cfg alias so that `#[cfg(gles)]` code paths inside wgpu-core activate on NetBSD.

 This alias is also used for the `vulkan` cfg alias in this same file, so `vulkan` will now also evaluate true on NetBSD as a side effect.
 This is safe: wgpu-core's src/instance.rs already has an unconditional `#[cfg(all(vulkan, not(target_os = "netbsd")))]` guard around the only place that actually tries to initialize the
 Vulkan backend, so no Vulkan initialization attempt will occur on NetBSD regardless of this alias's value.

 - wgpu-core/Cargo.toml

 This is the change that actually switches GLES on for NetBSD.

**Connections**
[_Link to the issues addressed by this PR, or dependent PRs in other repositories_](https://github.com/Kl4rry/simp/issues/47)

_When one pull request builds on another, please put "Depends on
#NNNN" towards the top of its description. This helps maintainers
notice that they shouldn't merge it until its ancestor has been
approved. Don't use draft PR status to indicate this._

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain what you have done to ensure this change is adequately tested
(e.g. adding test cases, running tests on an unusual platform, or
manually checking visual results)._

**Squash or Rebase?**
_If your pull request contains multiple commits, please indicate whether
they need to be squashed into a single commit before they're merged,
or if they're ready to rebase onto `trunk` as they stand. In the
latter case, please ensure that each commit passes all CI tests, so
that we can continue to bisect along `trunk` to isolate bugs._

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
