### PR TITLE
ci: add Mergify merge queue, drop trunk push runs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,31 @@
+# Mergify merge queue configuration.
+# Reference: https://docs.mergify.com/configuration/file-format/
+#
+# Pull requests enter the queue with the `@mergifyio queue` command.
+# A pull request goes to the first queue rule whose `queue_conditions`
+# match. Required checks and approvals come from branch protection.
+
+merge_queue:
+  queued_label: "queue: queued"
+  dequeued_label: "queue: dequeued"
+
+queue_rules:
+  - name: rebase
+    queue_conditions:
+      - 'label = "merge: rebase"'
+    merge_method: rebase
+    update_method: rebase
+
+  - name: squash
+    queue_conditions:
+      - '-label = "merge: rebase"'
+    merge_method: squash
+    update_method: rebase
+    commit_message_format:
+      title: inherit
+      body: inherit
+
+commands_restrictions:
+  queue:
+    conditions:
+      - sender-permission >= write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches-ignore: [
-        # Branches with the `gh-readonly-queue` prefix are used by the
-        # merge queue, so they are already covered by the `merge_group` event.
-        "gh-readonly-queue/**",
-      ]
   pull_request:
-  merge_group:
+  # Runs on `trunk` to save the build caches that pull requests read
+  # and to upload the coverage baseline.
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
 
 env:
   #
@@ -788,7 +786,9 @@ jobs:
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        if: steps.coverage.outcome == 'success'
+        # Mergify draft pull requests re-run the tests of already-reported
+        # pull requests, so their coverage is not uploaded.
+        if: steps.coverage.outcome == 'success' && !startsWith(github.head_ref, 'mergify/merge-queue/')
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/cts.yml
+++ b/.github/workflows/cts.yml
@@ -1,14 +1,11 @@
 name: CTS
 
 on:
-  push:
-    branches-ignore: [
-        # Branches with the `gh-readonly-queue` prefix are used by the
-        # merge queue, so they are already covered by the `merge_group` event.
-        "gh-readonly-queue/**",
-      ]
   pull_request:
-  merge_group:
+  # Runs on `trunk` to save the build caches that pull requests read.
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
 
 env:
   #

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,13 +2,8 @@ name: Docs
 
 on:
   push:
-    branches-ignore: [
-        # Branches with the `gh-readonly-queue` prefix are used by the
-        # merge queue, so they are already covered by the `merge_group` event.
-        "gh-readonly-queue/**",
-      ]
+    branches: [trunk, "firefox*"]
   pull_request:
-  merge_group:
 
 env:
   # This is the MSRV used by all repository infrastructure.

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,14 +1,11 @@
 name: cargo-generate
 
 on:
-  push:
-    branches-ignore: [
-        # Branches with the `gh-readonly-queue` prefix are used by the
-        # merge queue, so they are already covered by the `merge_group` event.
-        "gh-readonly-queue/**",
-      ]
   pull_request:
-  merge_group:
+  # Runs on `trunk` to save the build caches that pull requests read.
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
 
 env:
   #

--- a/.github/workflows/lazy.yml
+++ b/.github/workflows/lazy.yml
@@ -2,14 +2,7 @@
 name: Lazy
 
 on:
-  push:
-    branches-ignore: [
-        # Branches with the `gh-readonly-queue` prefix are used by the
-        # merge queue, so they are already covered by the `merge_group` event.
-        "gh-readonly-queue/**",
-      ]
   pull_request:
-  merge_group:
 
 env:
   CARGO_INCREMENTAL: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,13 +2,8 @@ name: Publish
 
 on:
   push:
-    branches-ignore: [
-        # Branches with the `gh-readonly-queue` prefix are used by the
-        # merge queue, so they are already covered by the `merge_group` event.
-        "gh-readonly-queue/**",
-      ]
+    branches: [trunk, "firefox*"]
   pull_request:
-  merge_group:
 
 env:
   CARGO_INCREMENTAL: false

--- a/.github/workflows/shaders.yml
+++ b/.github/workflows/shaders.yml
@@ -1,14 +1,11 @@
 name: Shaders
 
 on:
-  push:
-    branches-ignore: [
-        # Branches with the `gh-readonly-queue` prefix are used by the
-        # merge queue, so they are already covered by the `merge_group` event.
-        "gh-readonly-queue/**",
-      ]
   pull_request:
-  merge_group:
+  # Runs on `trunk` to save the build caches that pull requests read.
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
 
 # Every time a PR is pushed to, cancel any previous jobs. This
 # makes us behave nicer to github and get faster turnaround times


### PR DESCRIPTION
**Connections**
None.

**Description**

As discussed in the meeting, we're going to try out Mergify for running merge queues.

**Squash or Rebase?**
Squash.

**Checklist**

- [x] I self-reviewed and fully understand this PR.
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- Not user-facing. -->
- [x] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [x] Commits are logically scoped and individually reviewable.
- [x] The PR description has enough context to understand the motivation and solution implemented.
- [ ] (If applicable) WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] (If applicable) Validation and feature gates are in place to confine behavioral changes.
- [ ] (If applicable) Tests demonstrate the validation and altered logic works.
